### PR TITLE
fixed a small typo

### DIFF
--- a/app/lang/de/texts.php
+++ b/app/lang/de/texts.php
@@ -36,7 +36,7 @@ return array(
   'po_number' => 'Bestellnummer',
   'po_number_short' => 'BN #',
   'frequency_id' => 'Wie oft',
-  'dicount' => 'Rabatt',
+  'discount' => 'Rabatt',
   'taxes' => 'Steuern',
   'tax' => 'Steuer',
   'item' => 'Artikel',


### PR DESCRIPTION
This small Typo causes "texts.discount" to show up in frontend and PDF preview
