### PR TITLE
[BUGFIX] Wrong usage of use statement

### DIFF
--- a/app/controllers/ClientApiController.php
+++ b/app/controllers/ClientApiController.php
@@ -1,7 +1,6 @@
 <?php
 
 use ninja\repositories\ClientRepository;
-use Client;
 
 class ClientApiController extends Controller {
 

--- a/app/controllers/InvoiceApiController.php
+++ b/app/controllers/InvoiceApiController.php
@@ -1,7 +1,6 @@
 <?php
 
 use ninja\repositories\InvoiceRepository;
-use Invoice;
 
 class InvoiceApiController extends Controller {
 

--- a/app/controllers/PaymentApiController.php
+++ b/app/controllers/PaymentApiController.php
@@ -1,7 +1,6 @@
 <?php
 
 use ninja\repositories\PaymentRepository;
-use Payment;
 
 class PaymentApiController extends Controller {
 

--- a/app/controllers/QuoteApiController.php
+++ b/app/controllers/QuoteApiController.php
@@ -1,7 +1,6 @@
 <?php
 
 use ninja\repositories\InvoiceRepository;
-use Invoice;
 
 class QuoteApiController extends Controller {
 


### PR DESCRIPTION
Resolves errors like "The use statement
with non-compound name 'Client' has no effect"
