### PR TITLE
SQLite: fix issues migrating and seeding

### DIFF
--- a/app/database/migrations/2014_07_17_205900_support_hiding_quantity.php
+++ b/app/database/migrations/2014_07_17_205900_support_hiding_quantity.php
@@ -26,11 +26,11 @@ class SupportHidingQuantity extends Migration {
 
 		Schema::table('invoices', function($table)
 		{
-			$table->decimal('custom_value1', 13, 2);
-			$table->decimal('custom_value2', 13, 2);
+			$table->decimal('custom_value1', 13, 2)->default(0);
+			$table->decimal('custom_value2', 13, 2)->default(0);
 
-			$table->boolean('custom_taxes1');
-			$table->boolean('custom_taxes2');			
+			$table->boolean('custom_taxes1')->default(0);
+			$table->boolean('custom_taxes2')->default(0);			
 		});		
 	}
 

--- a/app/database/seeds/PaymentLibrariesSeeder.php
+++ b/app/database/seeds/PaymentLibrariesSeeder.php
@@ -20,14 +20,14 @@ class PaymentLibrariesSeeder extends Seeder
 		// check that moolah exists
 		if (!DB::table('gateways')->where('name', '=', 'moolah')->get())	{
 			DB::table('gateways')->update(['recommended' => 0]);
-			DB::table('gateways')->insert([
+			Gateway::create(array(
 				'name' => 'moolah',
 				'provider' => 'AuthorizeNet_AIM',
 				'sort_order' => 1,
 				'recommended' => 1,
 				'site_url' => 'https://invoiceninja.mymoolah.com/',
 				'payment_library_id' => 1
-			]);
+			));
 		}
 
 		/*

--- a/app/models/Gateway.php
+++ b/app/models/Gateway.php
@@ -2,7 +2,7 @@
 
 class Gateway extends Eloquent
 {
-	public $timestamps = false;
+	public $timestamps = true;
 	protected $softDelete = false;	
 
 	public function paymentlibrary()


### PR DESCRIPTION
Related to issue #49 and issue #122 
- SQLite issues: added missing default values for columns custom_value1, custom_value2 in table invoices
- SQLite issues: corrected NOT NULL constraint violation when seeding gateways

I had these problems migrating and seeding the SQLite database:

```
$php artisan migrate --seed

  [Illuminate\Database\QueryException]                                                                      
  SQLSTATE[HY000]: General error: 1 Cannot add a NOT NULL column with default value NULL (SQL: alter table  
   "invoices" add column "custom_value1" float not null)
```

and seeding the gateways:

```
$ php artisan migrate --seed
Migrated: 2013_11_05_180133_confide_setup_users_table
Migrated: 2013_11_28_195703_setup_countries_table
Migrated: 2014_02_13_151500_add_cascase_drops
Migrated: 2014_02_19_151817_add_support_for_invoice_designs
Migrated: 2014_03_03_155556_add_phone_to_account
Migrated: 2014_03_19_201454_add_language_support
Migrated: 2014_03_20_200300_create_payment_libraries
Migrated: 2014_03_23_051736_enable_forcing_jspdf
Migrated: 2014_03_25_102200_add_sort_and_recommended_to_gateways
Migrated: 2014_04_03_191105_add_pro_plan
Migrated: 2014_04_17_100523_add_remember_token
Migrated: 2014_04_17_145108_add_custom_fields
Migrated: 2014_04_23_170909_add_products_settings
Migrated: 2014_04_29_174315_add_advanced_settings
Migrated: 2014_05_17_175626_add_quotes
Migrated: 2014_06_17_131940_add_accepted_credit_cards_to_account_gateways
Migrated: 2014_07_13_142654_one_click_install
Migrated: 2014_07_17_205900_support_hiding_quantity
Migrated: 2014_07_24_171214_add_zapier_support
Migrated: 2014_10_05_141856_track_last_seen_message
Migrated: 2014_10_06_195330_add_invoice_design_table
Migrated: 2014_10_13_054100_add_invoice_number_settings
Running DatabaseSeeder
Seeded: UserTableSeeder
```
