### PR TITLE
using a localized date format [server-side]

### DIFF
--- a/app/Libraries/Utils.php
+++ b/app/Libraries/Utils.php
@@ -12,7 +12,7 @@ use Input;
 use Log;
 use DateTime;
 use stdClass;
-use Carbon;
+use Jenssegers\Date\Date;
 
 use App\Models\Currency;
 
@@ -304,7 +304,10 @@ class Utils
         if (!$timestamp) {
             return '';
         }
-        $date = Carbon::createFromTimeStamp($timestamp);
+
+        Date::setLocale(\App::getLocale());
+
+        $date = Date::createFromTimeStamp($timestamp);
         if ($timezone) {
             $date->tz = $timezone;
         }
@@ -324,7 +327,9 @@ class Utils
         $timezone = Session::get(SESSION_TIMEZONE, DEFAULT_TIMEZONE);
         $format = Session::get(SESSION_DATE_FORMAT, DEFAULT_DATE_FORMAT);
 
-        $dateTime = DateTime::createFromFormat($format, $date, new DateTimeZone($timezone));
+        Date::setLocale(\App::getLocale());
+
+        $dateTime = Date::createFromFormat($format, $date, new DateTimeZone($timezone));
 
         return $formatResult ? $dateTime->format('Y-m-d') : $dateTime;
     }
@@ -338,9 +343,10 @@ class Utils
         $timezone = Session::get(SESSION_TIMEZONE, DEFAULT_TIMEZONE);
         $format = Session::get(SESSION_DATE_FORMAT, DEFAULT_DATE_FORMAT);
 
-        $dateTime = DateTime::createFromFormat('Y-m-d', $date);
-        $dateTime->setTimeZone(new DateTimeZone($timezone));
+        Date::setLocale(\App::getLocale());
 
+        $dateTime = Date::createFromFormat('Y-m-d', $date);
+        $dateTime->setTimeZone(new DateTimeZone($timezone));
         return $formatResult ? $dateTime->format($format) : $dateTime;
     }
 
@@ -352,8 +358,10 @@ class Utils
 
         $timezone = Session::get(SESSION_TIMEZONE, DEFAULT_TIMEZONE);
         $format = Session::get(SESSION_DATETIME_FORMAT, DEFAULT_DATETIME_FORMAT);
-        
-        $dateTime = DateTime::createFromFormat('Y-m-d H:i:s', $date);
+
+        Date::setLocale(\App::getLocale());
+
+        $dateTime = Date::createFromFormat('Y-m-d H:i:s', $date);
         $dateTime->setTimeZone(new DateTimeZone($timezone));
 
         return $formatResult ? $dateTime->format($format) : $dateTime;
@@ -665,3 +673,4 @@ class Utils
         fwrite($output, "\n");
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
 		"guzzlehttp/guzzle": "~5.0",
         "laravelcollective/html": "~5.0",
         "wildbit/laravel-postmark-provider": "dev-master",
-        "Dwolla/omnipay-dwolla": "dev-master"
+        "Dwolla/omnipay-dwolla": "dev-master",
+        "jenssegers/date": "~3.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~4.0",


### PR DESCRIPTION
I'm using InvoiceNinja in German (invoices have to in German... even though I prefer English) and that's why I'm trying to find some "locale inconsistencies". If you'd rather not merge/want me to send PRs, let me know, I won't be offended!

This PR makes the date format adapt to the current locale on *the server side*, which means only the lists are changed (instead of "Dec 10, 2015" it's now "Dez 10, 2015"). I used the [laravel-date](https://github.com/jenssegers/laravel-date) class which builds on Carbon (thus the interface stays the same) and works pretty great.

I'm trying to get [bootstrap-datepicker](https://github.com/eternicode/bootstrap-datepicker) working as well (I'm using it localized in another project), but that's gonna be a separate PR.

Since the client-side is still missing, this probably breaks a few things when editing/saving, so I'd suggest not to merge this PR yet.

What do you think?