### PR TITLE
Bug Fixes

### DIFF
--- a/app/Libraries/Utils.php
+++ b/app/Libraries/Utils.php
@@ -377,7 +377,10 @@ class Utils
         $format = Session::get(SESSION_DATE_FORMAT, DEFAULT_DATE_FORMAT);
         $dateTime = DateTime::createFromFormat($format, $date);
 
-        return $formatResult ? $dateTime->format('Y-m-d') : $dateTime;
+        if(!$dateTime)
+            return $date;
+        else
+            return $formatResult ? $dateTime->format('Y-m-d') : $dateTime;
     }
 
     public static function fromSqlDate($date, $formatResult = true)


### PR DESCRIPTION
**Temp fix for API:

If the $date format does not match DEFAULT_DATE_FORMAT a fatal error is thrown . (Default date format from API should match (YYYY-mm-dd).

Temporarily returning $date to prevent fatal exception when called from API.

