### PR TITLE
return archived invoice as success

### DIFF
--- a/app/Http/Controllers/InvoiceApiController.php
+++ b/app/Http/Controllers/InvoiceApiController.php
@@ -276,10 +276,15 @@ class InvoiceApiController extends BaseAPIController
         if ($request->action == ACTION_ARCHIVE) {
             $invoice = Invoice::scope($publicId)->firstOrFail();
             $this->invoiceRepo->archive($invoice);
-            
+            /*
             $response = json_encode(RESULT_SUCCESS, JSON_PRETTY_PRINT);
             $headers = Utils::getApiHeaders();
             return Response::make($response, 200, $headers);
+            */
+            $transformer = new InvoiceTransformer(\Auth::user()->account, Input::get('serializer'));
+            $data = $this->createItem($invoice, $transformer, 'invoice');
+
+            return $this->response($data);
         }
 
         $data = $request->input();


### PR DESCRIPTION
In addition to a HTTP 200 response, we should also return the invoice so downstream can process the correct archived_at timestamp.