### PR TITLE
Update texts.php

### DIFF
--- a/resources/lang/es_ES/texts.php
+++ b/resources/lang/es_ES/texts.php
@@ -38,7 +38,7 @@ return array(
   'frequency_id' => 'Frecuencia',
   'discount' => 'Descuento',
   'taxes' => 'Impuestos',
-  'tax' => 'IVA',
+  'tax' => 'Impuesto',
   'item' => 'Concepto',
   'description' => 'Descripción',
   'unit_cost' => 'Coste unitario',


### PR DESCRIPTION
Se cambia "'tax' => 'IVA'," por "'tax' => 'Impuesto'," ya que este literal se usa para mas impuestos aparte del IVA