### PR TITLE
Fixed ping route & added a way to find client by email address or if …

### DIFF
--- a/app/Http/Controllers/ClientApiController.php
+++ b/app/Http/Controllers/ClientApiController.php
@@ -93,20 +93,7 @@ class ClientApiController extends BaseAPIController
      */
     public function store(CreateClientRequest $request)
     {
-        if ($request->has('filter_by_email')) {
-
-            $email = $request->get('filter_by_email');
-            $client = Client::whereHas('contacts', function ($query) use ($email) {
-                $query->where('email', $email);
-            })->with('contacts')->first();
-
-            if (is_null($client)) {
-                $client = $this->clientRepo->save($request->input());
-            }
-
-        } else {
-            $client = $this->clientRepo->save($request->input());
-        }
+        $client = $this->clientRepo->save($request->input());
 
         $client = Client::scope($client->public_id)
                     ->with('country', 'contacts', 'industry', 'size', 'currency')

--- a/app/Http/Controllers/ClientApiController.php
+++ b/app/Http/Controllers/ClientApiController.php
@@ -82,8 +82,21 @@ class ClientApiController extends BaseAPIController
      */
     public function store(CreateClientRequest $request)
     {
-        $client = $this->clientRepo->save($request->input());
-        
+        if ($request->has('filter_by_email')) {
+
+            $email = $request->get('filter_by_email');
+            $client = Client::whereHas('contacts', function ($query) use ($email) {
+                $query->where('email', $email);
+            })->with('contacts')->first();
+
+            if (is_null($client)) {
+                $client = $this->clientRepo->save($request->input());
+            }
+
+        } else {
+            $client = $this->clientRepo->save($request->input());
+        }
+
         $client = Client::scope($client->public_id)
                     ->with('country', 'contacts', 'industry', 'size', 'currency')
                     ->first();

--- a/app/Http/Controllers/ClientApiController.php
+++ b/app/Http/Controllers/ClientApiController.php
@@ -48,8 +48,19 @@ class ClientApiController extends BaseAPIController
     {
         $clients = Client::scope()
                     ->with($this->getIncluded())
-                    ->orderBy('created_at', 'desc')
-                    ->paginate();
+                    ->orderBy('created_at', 'desc');
+
+        // Filter by email
+        if (Input::has('email')) {
+
+            $email = Input::get('email');
+            $clients = $clients->whereHas('contacts', function ($query) use ($email) {
+                $query->where('email', $email);
+            });
+
+        }
+
+        $clients = $clients->paginate();
 
         $transformer = new ClientTransformer(Auth::user()->account, Input::get('serializer'));
         $paginator = Client::scope()->paginate();

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -209,7 +209,7 @@ Route::group(['middleware' => 'auth'], function() {
 // Route groups for API
 Route::group(['middleware' => 'api', 'prefix' => 'api/v1'], function()
 {
-    Route::resource('ping', 'ClientApiController@ping');
+    Route::get('ping', 'ClientApiController@ping');
     Route::post('login', 'AccountApiController@login');
     Route::get('static', 'AccountApiController@getStaticData');
     Route::get('accounts', 'AccountApiController@show');


### PR DESCRIPTION
…not exist - create a new

Seems that ping route was not working as I was not able to POST or GET to it.

In addition, I needed a way to somehow find a client if it already exists, if not - create a new one as looping through index over x pages and searching was not good idea if there are many clients.

Basically, if you pass filter_by_email=email@email.com parameter it will try to find a client and if such client does not exist - it just creates a new one.

Not sure if I should have created another route or it is okay to add to the same route.