### PR TITLE
Bug Fix in TaxRate Transformer

### DIFF
--- a/app/Ninja/Transformers/TaxRateTransformer.php
+++ b/app/Ninja/Transformers/TaxRateTransformer.php
@@ -13,7 +13,7 @@ class TaxRateTransformer extends EntityTransformer
         /**
          * @SWG\Property(property="id", type="integer", example=1, readOnly=true)
          * @SWG\Property(property="name", type="string", example="GST")
-         * @SWG\Property(property="account_key", type="string", example="34erfdf33fdff" readOnly=true)
+         * @SWG\Property(property="account_key", type="string", example="asimplestring", readOnly=true)
          * @SWG\Property(property="rate", type="float", example=17.5)
          * @SWG\Property(property="updated_at", type="date-time", example="2016-01-01 12:10:00")
          * @SWG\Property(property="archived_at", type="date-time", example="2016-01-01 12:10:00")


### PR DESCRIPTION
Missing comma was causing /api-docs route to crash with a 500 error