### PR TITLE
Table locking for public_id integrity

### DIFF
--- a/app/Models/EntityModel.php
+++ b/app/Models/EntityModel.php
@@ -27,6 +27,7 @@ class EntityModel extends Eloquent
         $lastEntity = $className::withTrashed()
                         ->scope(false, $entity->account_id)
                         ->orderBy('public_id', 'DESC')
+                        ->lockForUpdate()
                         ->first();
 
         if ($lastEntity) {

--- a/app/Ninja/Repositories/ClientRepository.php
+++ b/app/Ninja/Repositories/ClientRepository.php
@@ -66,6 +66,8 @@ class ClientRepository extends BaseRepository
     {
         $publicId = isset($data['public_id']) ? $data['public_id'] : false;
 
+        DB::beginTransaction();
+
         if (!$publicId || $publicId == '-1') {
             $client = Client::createNew();
         } else {
@@ -74,6 +76,9 @@ class ClientRepository extends BaseRepository
 
         $client->fill($data);
         $client->save();
+
+        DB::commit();
+
 
         /*
         if ( ! isset($data['contact']) && ! isset($data['contacts'])) {


### PR DESCRIPTION
The following commit attempts to prevent public_id duplicates when multiple requests are executed simultaneously. Selective row locking is implemented with lockForUpdate(), and the lock is released when the transaction is completed.