### PR TITLE
Format amount following precision defined in the clients currency

### DIFF
--- a/resources/views/money_script.blade.php
+++ b/resources/views/money_script.blade.php
@@ -67,7 +67,8 @@
 
         var currency = currencyMap[currencyId];
         var thousand = currency.thousand_separator;
-        var decimal = currency.decimal_separator;
+	var decimal = currency.decimal_separator;
+	var precision = currency.precision;
         var code = currency.code;
         var swapSymbol = false;
 
@@ -82,7 +83,7 @@
             }
         }
 
-        value = accounting.formatMoney(value, '', 2, thousand, decimal);
+        value = accounting.formatMoney(value, '', precision, thousand, decimal);
         var symbol = currency.symbol;
 
         if (hideSymbol) {


### PR DESCRIPTION
In Tunisia we use Tunisian Dinar which is a 3 decimal precision currency. Having the precision hard-coded in formatMoney() function to 2 is not appropriate. I have changed it to fetch the precision from the currency object and use it to format amounts accordingly.