### PR TITLE
on error pages, display 'from' email address instead of 'username'

### DIFF
--- a/resources/views/error.blade.php
+++ b/resources/views/error.blade.php
@@ -9,7 +9,7 @@
   <div class="container" style="min-height:400px">
   <h3>Something went wrong...</h3>
   <h4>{{ $error }}</h4>
-  <h4>If you'd like help please email us at {{ env('MAIL_USERNAME') }}.</h4>
+  <h4>If you'd like help please email us at {{ env('MAIL_FROM_ADDRESS') }}.</h4>
 </div>
 </div>
 


### PR DESCRIPTION
This accounts for configurations where the username is not the from
address, such as Amazon SES.