### PR TITLE
Sort by date for expenses, payments, quotes and invoices

### DIFF
--- a/app/Http/Controllers/ExpenseController.php
+++ b/app/Http/Controllers/ExpenseController.php
@@ -45,7 +45,7 @@ class ExpenseController extends BaseController
         return View::make('list', array(
             'entityType' => ENTITY_EXPENSE,
             'title' => trans('texts.expenses'),
-            'sortCol' => '1',
+            'sortCol' => '3',
             'columns' => Utils::trans([
               'checkbox',
               'vendor',

--- a/app/Http/Controllers/InvoiceController.php
+++ b/app/Http/Controllers/InvoiceController.php
@@ -52,6 +52,7 @@ class InvoiceController extends BaseController
         $data = [
             'title' => trans('texts.invoices'),
             'entityType' => ENTITY_INVOICE,
+            'sortCol' => '3',
             'columns' => Utils::trans([
                 'checkbox',
                 'invoice_number',

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -48,6 +48,7 @@ class PaymentController extends BaseController
         return View::make('list', array(
             'entityType' => ENTITY_PAYMENT,
             'title' => trans('texts.payments'),
+            'sortCol' => '6',
             'columns' => Utils::trans([
               'checkbox',
               'invoice',

--- a/app/Http/Controllers/QuoteController.php
+++ b/app/Http/Controllers/QuoteController.php
@@ -54,6 +54,7 @@ class QuoteController extends BaseController
         $data = [
           'title' => trans('texts.quotes'),
           'entityType' => ENTITY_QUOTE,
+          'sortCol' => '3',
           'columns' => Utils::trans([
             'checkbox',
             'quote_number',


### PR DESCRIPTION
When looking at these items, a user is almost certainly wanting to see the most recent ones.

Invoices are especially odd right now, since they're sorted by number, which means they're in order except that recurring invoices are listed at the top.