### PR TITLE
Remove blank in email footer html tag

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -983,7 +983,7 @@ class Account extends Eloquent
             // Add line breaks if HTML isn't already being used
             return strip_tags($this->email_footer) == $this->email_footer ? nl2br($this->email_footer) : $this->email_footer;
         } else {
-            return "<p>" . trans('texts.email_signature') . "\n<br>\$account</ p>";
+            return "<p>" . trans('texts.email_signature') . "\n<br>\$account</p>";
         }
     }
 


### PR DESCRIPTION
In the email footer is an presentation error after the account name because of the blank in the ending p-tag.
I have removed the blank.