### PR TITLE
Minor fix to invoice item transformer

### DIFF
--- a/app/Ninja/Transformers/InvoiceItemTransformer.php
+++ b/app/Ninja/Transformers/InvoiceItemTransformer.php
@@ -19,9 +19,9 @@ class InvoiceItemTransformer extends EntityTransformer
             'notes' => $item->notes,
             'cost' => (float) $item->cost,
             'qty' => (float) $item->qty,
-            'tax_name1' => $item->tax_name1,
+            'tax_name1' => $item->tax_name1 ? $item->tax_name1 : '',
             'tax_rate1' => (float) $item->tax_rate1,
-            'tax_name2' => $item->tax_name2,
+            'tax_name2' => $item->tax_name2 ? $item->tax_name1 : '',
             'tax_rate2' => (float) $item->tax_rate2,
         ];
     }


### PR DESCRIPTION
Ensures tax_names are returned as empty strings rather than NULL.