### PR TITLE
Enterprise plan bug fixes

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -1132,7 +1132,7 @@ class AccountController extends BaseController
         $user->registered = true;
         $user->save();
 
-        $user->account->startTrial(PLAN_ENTERPRISE);
+        $user->account->startTrial(PLAN_PRO);
 
         if (Input::get('go_pro') == 'true') {
             Session::set(REQUESTED_PRO_PLAN, true);

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -189,7 +189,7 @@ Route::group([
     Route::post('users/bulk', 'UserController@bulk');
     Route::get('send_confirmation/{user_id}', 'UserController@sendConfirmation');
     Route::get('start_trial/{plan}', 'AccountController@startTrial')
-        ->where(['plan'=>'pro|enterprise']);
+        ->where(['plan'=>'pro']);
     Route::get('restore_user/{user_id}', 'UserController@restoreUser');
     Route::post('users/change_password', 'UserController@changePassword');
     Route::get('/switch_account/{user_id}', 'UserController@switchAccount');

--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -799,6 +799,14 @@ class Account extends Eloquent
         $planDetails = $this->getPlanDetails();
         $selfHost = !Utils::isNinjaProd();
         
+        if (!$selfHost && function_exists('ninja_account_features')) {
+            $result = ninja_account_features($this, $feature);
+            
+            if ($result != null) {
+                return $result;
+            }
+        }
+        
         switch ($feature) {
             // Pro
             case FEATURE_CUSTOMIZE_INVOICE_DESIGN:
@@ -829,10 +837,6 @@ class Account extends Eloquent
             case FEATURE_CLIENT_PORTAL_CSS:
                 return !empty($planDetails);// A plan is required even for self-hosted users
                 
-            // Enterprise
-            case FEATURE_DOCUMENTS:
-                return $selfHost || !empty($planDetails) && $planDetails['plan'] == PLAN_ENTERPRISE;
-                            
             // Enterprise; No Trial allowed; grandfathered for old pro users
             case FEATURE_USERS:// Grandfathered for old Pro users
                 if($planDetails && $planDetails['trial']) {
@@ -843,6 +847,7 @@ class Account extends Eloquent
                 return $selfHost || !empty($planDetails) && ($planDetails['plan'] == PLAN_ENTERPRISE || $planDetails['started'] <= date_create(PRO_USERS_GRANDFATHER_DEADLINE));
                 
             // Enterprise; No Trial allowed
+            case FEATURE_DOCUMENTS:
             case FEATURE_USER_PERMISSIONS:
                 return $selfHost || !empty($planDetails) && $planDetails['plan'] == PLAN_ENTERPRISE && !$planDetails['trial'];
             

--- a/app/Ninja/Repositories/AccountRepository.php
+++ b/app/Ninja/Repositories/AccountRepository.php
@@ -382,7 +382,7 @@ class AccountRepository
             $user->last_name = $lastName;
             $user->registered = true;
 
-            $user->account->startTrial(PLAN_ENTERPRISE);
+            $user->account->startTrial(PLAN_PRO);
         }
 
         $user->oauth_provider_id = $providerId;

--- a/database/migrations/2016_04_16_103943_enterprise_plan.php
+++ b/database/migrations/2016_04_16_103943_enterprise_plan.php
@@ -46,11 +46,11 @@ class EnterprisePlan extends Migration
     
         $single_account_ids = \DB::table('users')
             ->leftJoin('user_accounts', function ($join) {
-                $join->on('user_Accounts.user_id1', '=', 'users.id');
-                $join->orOn('user_Accounts.user_id2', '=', 'users.id');
-                $join->orOn('user_Accounts.user_id3', '=', 'users.id');
-                $join->orOn('user_Accounts.user_id4', '=', 'users.id');
-                $join->orOn('user_Accounts.user_id5', '=', 'users.id');
+                $join->on('user_accounts.user_id1', '=', 'users.id');
+                $join->orOn('user_accounts.user_id2', '=', 'users.id');
+                $join->orOn('user_accounts.user_id3', '=', 'users.id');
+                $join->orOn('user_accounts.user_id4', '=', 'users.id');
+                $join->orOn('user_accounts.user_id5', '=', 'users.id');
             })
             ->whereNull('user_accounts.id')
             ->where(function ($query) {


### PR DESCRIPTION
* Restrict documents support to non-trial plans
* Allow resellers to override feature sets
* Only allow trials of the pro plan (future support for enterprise trials is still there, but the UI doesn't allow it.)
* Fix table name in migration