### PR TITLE
Use initialize method to set configuration

### DIFF
--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -39,18 +39,7 @@ class PaymentService extends BaseService
     public function createGateway($accountGateway)
     {
         $gateway = Omnipay::create($accountGateway->gateway->provider);
-        $config = $accountGateway->getConfig();
-
-        foreach ($config as $key => $val) {
-            if (!$val) {
-                continue;
-            }
-
-            $function = "set".ucfirst($key);
-            if (method_exists($gateway, $function)) {
-                $gateway->$function($val);
-            }
-        }
+        $gateway->initialize($accountGateway->getConfig());
 
         if ($accountGateway->isGateway(GATEWAY_DWOLLA)) {
             if ($gateway->getSandbox() && isset($_ENV['DWOLLA_SANDBOX_KEY']) && isset($_ENV['DWOLLA_SANSBOX_SECRET'])) {

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -39,7 +39,7 @@ class PaymentService extends BaseService
     public function createGateway($accountGateway)
     {
         $gateway = Omnipay::create($accountGateway->gateway->provider);
-        $gateway->initialize($accountGateway->getConfig());
+        $gateway->initialize((array) $accountGateway->getConfig());
 
         if ($accountGateway->isGateway(GATEWAY_DWOLLA)) {
             if ($gateway->getSandbox() && isset($_ENV['DWOLLA_SANDBOX_KEY']) && isset($_ENV['DWOLLA_SANSBOX_SECRET'])) {


### PR DESCRIPTION
Using the `initialize` method seems cleaner since it does the same what you are doing with your foreach and is provided by the `league/omnipay-common` package which means it is available for every gateway.

https://github.com/thephpleague/omnipay-common/blob/master/src/Omnipay/Common/AbstractGateway.php#L85-L107