### PR TITLE
Use object_get to retrieve a config field

### DIFF
--- a/app/Models/AccountGateway.php
+++ b/app/Models/AccountGateway.php
@@ -60,13 +60,7 @@ class AccountGateway extends EntityModel
 
     public function getConfigField($field)
     {
-        $config = $this->getConfig();
-
-        if (!$field || !property_exists($config, $field)) {
-            return false;
-        }
-
-        return $config->$field;
+        return object_get($this->getConfig(), $field, false);
     }
 
     public function getPublishableStripeKey()


### PR DESCRIPTION
This PR makes the `getConfigField` method a bit cleaner by using Laravels `object_get` helper method.

https://github.com/illuminate/support/blob/master/helpers.php#L551-L576