### PR TITLE
Add Polish currency into a CurrenciesSeeder

### DIFF
--- a/database/seeds/CurrenciesSeeder.php
+++ b/database/seeds/CurrenciesSeeder.php
@@ -58,6 +58,7 @@ class CurrenciesSeeder extends Seeder
             ['name' => 'Maldivian Rufiyaa', 'code' => 'MVR', 'symbol' => '', 'precision' => '2', 'thousand_separator' => ',', 'decimal_separator' => '.'],
             ['name' => 'Costa Rican Colón', 'code' => 'CRC', 'symbol' => '', 'precision' => '2', 'thousand_separator' => ',', 'decimal_separator' => '.'],
             ['name' => 'Pakistani Rupee', 'code' => 'PKR', 'symbol' => 'Rs ', 'precision' => '0', 'thousand_separator' => ',', 'decimal_separator' => '.'],
+            ['name' => 'Polish Zloty', 'code' => 'PLN', 'symbol' => 'zł', 'precision' => '2', 'thousand_separator' => ' ', 'decimal_separator' => ','],
         ];
 
         foreach ($currencies as $currency) {


### PR DESCRIPTION
Added missing Polish currency. 

Can You tell me how to adjust currency symbol position? Symbol for Polish zloty should be always after a price.

I have noticed that in countries table You have a field "swap_currency_symbol", even though is set to true still the same effect.

