### PR TITLE
Fix ninja:reset-data command

### DIFF
--- a/app/Console/Commands/ResetData.php
+++ b/app/Console/Commands/ResetData.php
@@ -1,5 +1,7 @@
 <?php namespace App\Console\Commands;
 
+
+use Utils;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;


### PR DESCRIPTION
PHP Fatal error:  Class 'App\Console\Commands\Utils' not found in ... app/Console/Commands/ResetData.php on line 16

```
  [Symfony\Component\Debug\Exception\FatalErrorException]
  Class 'App\Console\Commands\Utils' not found
```