### PR TITLE
Reset the invoice schema counter

### DIFF
--- a/app/Console/Commands/ResetInvoiceSchemaCounter.php
+++ b/app/Console/Commands/ResetInvoiceSchemaCounter.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Account;
+use App\Models\Invoice;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class ResetInvoiceSchemaCounter extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ninja:reset-invoice-schema-counter
+                            {--force : Force setting the counter back to "1", regardless if the year changed}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Reset the invoice schema counter at the turn of the year.';
+
+    /**
+     * @var Account
+     */
+    protected $account;
+
+    /**
+     * @var Invoice
+     */
+    protected $invoice;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param Account $account
+     * @param Invoice $invoice
+     */
+    public function __construct(Account $account, Invoice $invoice)
+    {
+        parent::__construct();
+        $this->account = $account;
+        $this->invoice = $invoice;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $latestInvoice = $this->invoice->latest()->first();
+        $invoiceYear = Carbon::parse($latestInvoice->created_at)->year;
+
+        if(Carbon::now()->year > $invoiceYear || $this->option('force')) {
+            $this->account->invoice_number_counter = 1;
+            $this->account->update();
+        }
+    }
+}

--- a/app/Console/Commands/ResetInvoiceSchemaCounter.php
+++ b/app/Console/Commands/ResetInvoiceSchemaCounter.php
@@ -15,6 +15,7 @@ class ResetInvoiceSchemaCounter extends Command
      * @var string
      */
     protected $signature = 'ninja:reset-invoice-schema-counter
+                            {account : The ID of the account}
                             {--force : Force setting the counter back to "1", regardless if the year changed}';
 
     /**
@@ -25,11 +26,6 @@ class ResetInvoiceSchemaCounter extends Command
     protected $description = 'Reset the invoice schema counter at the turn of the year.';
 
     /**
-     * @var Account
-     */
-    protected $account;
-
-    /**
      * @var Invoice
      */
     protected $invoice;
@@ -37,13 +33,11 @@ class ResetInvoiceSchemaCounter extends Command
     /**
      * Create a new command instance.
      *
-     * @param Account $account
      * @param Invoice $invoice
      */
-    public function __construct(Account $account, Invoice $invoice)
+    public function __construct(Invoice $invoice)
     {
         parent::__construct();
-        $this->account = $account;
         $this->invoice = $invoice;
     }
 
@@ -58,8 +52,10 @@ class ResetInvoiceSchemaCounter extends Command
         $invoiceYear = Carbon::parse($latestInvoice->created_at)->year;
 
         if(Carbon::now()->year > $invoiceYear || $this->option('force')) {
-            $this->account->invoice_number_counter = 1;
-            $this->account->update();
+            $account = Account::find($this->argument('account'))->first();
+            $account->invoice_number_counter = 1;
+            $account->update();
+            $this->info('The counter has been resetted successfully.');
         }
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -54,6 +54,7 @@ class Kernel extends ConsoleKernel
                 ->daily();
         }
 
+        // Reset the invoice schema counter at the turn of the year
         $schedule
             ->command('ninja:reset-invoice-schema-counter')
             ->daily();

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends ConsoleKernel
         'App\Console\Commands\SendRecurringInvoices',
         'App\Console\Commands\RemoveOrphanedDocuments',
         'App\Console\Commands\ResetData',
+        'App\Console\Commands\ResetInvoiceSchemaCounter',
         'App\Console\Commands\CheckData',
         'App\Console\Commands\PruneData',
         'App\Console\Commands\CreateTestData',
@@ -52,5 +53,9 @@ class Kernel extends ConsoleKernel
                 ->sendOutputTo($logFile)
                 ->daily();
         }
+
+        $schedule
+            ->command('ninja:reset-invoice-schema-counter')
+            ->daily();
     }
 }


### PR DESCRIPTION
- Fix #585 and resolve #585
- Reset the invoice schema counter back to „1“ at the turn of the year
- Implemented as command the also call it manually