### PR TITLE
Added mcrypt, gmp and gd extensions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,17 @@
         }
     ],
     "require": {
+        "php": ">=5.5.9",
+        "ext-mcrypt": "*",
+        "ext-gmp": "*",
+        "ext-gd": "*",
         "turbo124/laravel-push-notification": "dev-laravel5",
         "omnipay/mollie": "dev-master#22956c1a62a9662afa5f5d119723b413770ac525",
         "omnipay/2checkout": "dev-master#e9c079c2dde0d7ba461903b3b7bd5caf6dee1248",
         "omnipay/gocardless": "dev-master",
         "omnipay/stripe": "dev-master",
         "doctrine/dbal": "2.5.x",
-        "laravelcollective/bus": "5.2.*",        
+        "laravelcollective/bus": "5.2.*",
         "laravel/framework": "5.2.*",
         "laravelcollective/html": "5.2.*",
         "symfony/css-selector": "~3.0",


### PR DESCRIPTION
This help Heroku like service to understand that this repo will use mcrypt, gmp and gd extensions in PHP. Then Heroku will make it available while deploying.

Also, this is an added advantage for invoiceninja to force the user to install mcrypt, gmp and gd extensions so that invoice ninja can work properly.