### PR TITLE
Fix 1 cent tax rounding issue

### DIFF
--- a/app/Ninja/Repositories/InvoiceRepository.php
+++ b/app/Ninja/Repositories/InvoiceRepository.php
@@ -388,34 +388,34 @@ class InvoiceRepository extends BaseRepository
                 continue;
             }
 
-            $invoiceItemCost = round(Utils::parseFloat($item['cost']), 2);
-            $invoiceItemQty = round(Utils::parseFloat($item['qty']), 2);
+            $invoiceItemCost = round(Utils::parseFloat($item['cost']), 3);
+            $invoiceItemQty = round(Utils::parseFloat($item['qty']), 3);
 
             $lineTotal = $invoiceItemCost * $invoiceItemQty;
-            $total += round($lineTotal, 2);
+            $total += round($lineTotal, 3);
         }
 
         foreach ($data['invoice_items'] as $item) {
             $item = (array) $item;
-            $invoiceItemCost = round(Utils::parseFloat($item['cost']), 2);
-            $invoiceItemQty = round(Utils::parseFloat($item['qty']), 2);
+            $invoiceItemCost = round(Utils::parseFloat($item['cost']), 3);
+            $invoiceItemQty = round(Utils::parseFloat($item['qty']), 3);
             $lineTotal = $invoiceItemCost * $invoiceItemQty;
 
             if ($invoice->discount > 0) {
                 if ($invoice->is_amount_discount) {
-                    $lineTotal -= round(($lineTotal/$total) * $invoice->discount, 2);
+                    $lineTotal -= round(($lineTotal/$total) * $invoice->discount, 3);
                 } else {
-                    $lineTotal -= round($lineTotal * ($invoice->discount/100), 2);
+                    $lineTotal -= round($lineTotal * ($invoice->discount/100), 3);
                 }
             }
 
             if (isset($item['tax_rate1']) && Utils::parseFloat($item['tax_rate1']) > 0) {
                 $invoiceItemTaxRate = Utils::parseFloat($item['tax_rate1']);
-                $itemTax += round($lineTotal * $invoiceItemTaxRate / 100, 2);
+                $itemTax += round($lineTotal * $invoiceItemTaxRate / 100, 3);
             }
             if (isset($item['tax_rate2']) && Utils::parseFloat($item['tax_rate2']) > 0) {
                 $invoiceItemTaxRate = Utils::parseFloat($item['tax_rate2']);
-                $itemTax += round($lineTotal * $invoiceItemTaxRate / 100, 2);
+                $itemTax += round($lineTotal * $invoiceItemTaxRate / 100, 3);
             }
         }
 
@@ -424,18 +424,18 @@ class InvoiceRepository extends BaseRepository
                 $total -= $invoice->discount;
             } else {
                 $total *= (100 - $invoice->discount) / 100;
-                $total = round($total, 2);
+                $total = round($total, 3);
             }
         }
 
         if (isset($data['custom_value1'])) {
-            $invoice->custom_value1 = round($data['custom_value1'], 2);
+            $invoice->custom_value1 = round($data['custom_value1'], 3);
             if ($isNew) {
                 $invoice->custom_taxes1 = $account->custom_invoice_taxes1 ?: false;
             }
         }
         if (isset($data['custom_value2'])) {
-            $invoice->custom_value2 = round($data['custom_value2'], 2);
+            $invoice->custom_value2 = round($data['custom_value2'], 3);
             if ($isNew) {
                 $invoice->custom_taxes2 = $account->custom_invoice_taxes2 ?: false;
             }
@@ -456,9 +456,9 @@ class InvoiceRepository extends BaseRepository
             $total += $invoice->custom_value2;
         }
 
-        $taxAmount1 = round($total * $invoice->tax_rate1 / 100, 2);
-        $taxAmount2 = round($total * $invoice->tax_rate2 / 100, 2);
-        $total = round($total + $taxAmount1 + $taxAmount2, 2);
+        $taxAmount1 = round($total * $invoice->tax_rate1 / 100, 3);
+        $taxAmount2 = round($total * $invoice->tax_rate2 / 100, 3);
+        $total = round($total + $taxAmount1 + $taxAmount2, 3);
         $total += $itemTax;
 
         // custom fields not charged taxes

--- a/public/built.js
+++ b/public/built.js
@@ -30887,8 +30887,8 @@ function toggleDatePicker(field) {
 }
 
 function roundToTwo(num, toString) {
-  var val = +(Math.round(num + "e+2")  + "e-2");
-  return toString ? val.toFixed(2) : (val || 0);
+  var val = +(Math.round(num + "e+4")  + "e-4");
+  return toString ? val.toFixed(4) : (val || 0);
 }
 
 function roundToFour(num, toString) {

--- a/public/js/script.js
+++ b/public/js/script.js
@@ -993,8 +993,8 @@ function toggleDatePicker(field) {
 }
 
 function roundToTwo(num, toString) {
-  var val = +(Math.round(num + "e+2")  + "e-2");
-  return toString ? val.toFixed(2) : (val || 0);
+  var val = +(Math.round(num + "e+4")  + "e-4");
+  return toString ? val.toFixed(4) : (val || 0);
 }
 
 function roundToFour(num, toString) {

--- a/resources/views/invoices/knockout.blade.php
+++ b/resources/views/invoices/knockout.blade.php
@@ -462,7 +462,7 @@ function InvoiceModel(data) {
     });
 
     self.totals.rawPaidToDate = ko.computed(function() {
-        return roundToTwo(accounting.toFixed(self.amount(),2) - accounting.toFixed(self.balance(),2));
+        return roundToTwo(accounting.toFixed(self.amount(),4) - accounting.toFixed(self.balance(),4));
     });
 
     self.totals.paidToDate = ko.computed(function() {
@@ -471,7 +471,7 @@ function InvoiceModel(data) {
     });
 
     self.totals.rawTotal = ko.computed(function() {
-        var total = accounting.toFixed(self.totals.rawSubtotal(),2);
+        var total = accounting.toFixed(self.totals.rawSubtotal(),4);
         var discount = self.totals.rawDiscounted();
         total -= discount;
 


### PR DESCRIPTION
For certain tax rates, eg: 21%, the pricing is wrong and illegal.
Eg: user paid 7€
If I fill in unit cost 5.78, then the invoice is 6,99€.
If I enter unit cost 5.79, then the invoice is 7,01€
No way to get to 7€.
This fixes it for me.