### PR TITLE
Make sure to fetch latest prerelease of 6.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "grunt-contrib-uglify": "~0.2.2",
     "grunt-dump-dir": "^0.1.2",
     "gulp": "^3.8.8",
-    "laravel-elixir": "^6.0.0"
+    "laravel-elixir": "^6.0.0-10"
   },
   "dependencies": {
     "grunt-dump-dir": "^0.1.2"


### PR DESCRIPTION
- Prereleases can only be specified with exact versions
- Currently there is no full version 6.0.0.