### PR TITLE
Fix #1033

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -119,7 +119,7 @@
             @endif
 
             @if (Session::has('warning'))
-            <div class="alert alert-warning">{{ Session::get('warning') }}</div>
+            <div class="alert alert-warning">{!! Session::get('warning') !!}</div>
             @endif
 
             @if (Session::has('message'))


### PR DESCRIPTION
- Do not escape Session warning in login template as it contains the
Trello board link.