### PR TITLE
show pointer on search dropdown

### DIFF
--- a/resources/assets/css/typeahead.js-bootstrap.css
+++ b/resources/assets/css/typeahead.js-bootstrap.css
@@ -44,6 +44,7 @@
 .twitter-typeahead .tt-suggestion {
   padding: 3px 20px;
   white-space: nowrap;
+  cursor: pointer;
 }
 
 /*Added to menu element when it contains no content*/


### PR DESCRIPTION
This *should* fix #1076 - it does it in my browser, but on disk is not reflected - maybe I don't know how to clear the CSS cache - ?clear_cache=true does not help here.