### PR TITLE
Cannot use $this->account in UserAccount Transformer

### DIFF
--- a/app/Ninja/Transformers/UserAccountTransformer.php
+++ b/app/Ninja/Transformers/UserAccountTransformer.php
@@ -16,6 +16,7 @@ class UserAccountTransformer extends EntityTransformer
         parent::__construct($account, $serializer);
 
         $this->tokenName = $tokenName;
+        $this->account = $account;
     }
 
     public function includeUser(User $user)
@@ -27,7 +28,7 @@ class UserAccountTransformer extends EntityTransformer
     public function transform(User $user)
     {
         return [
-            'account_key' => $this->account->account_key,
+            'account_key' => $user->account->account_key,
             'name' => $user->account->present()->name,
             'token' => $user->account->getToken($user->id, $this->tokenName),
             'default_url' => SITE_URL,

--- a/app/Ninja/Transformers/UserAccountTransformer.php
+++ b/app/Ninja/Transformers/UserAccountTransformer.php
@@ -16,6 +16,7 @@ class UserAccountTransformer extends EntityTransformer
         parent::__construct($account, $serializer);
 
         $this->tokenName = $tokenName;
+        $this->account = $account;
     }
 
     public function includeUser(User $user)

--- a/app/Ninja/Transformers/UserAccountTransformer.php
+++ b/app/Ninja/Transformers/UserAccountTransformer.php
@@ -16,7 +16,6 @@ class UserAccountTransformer extends EntityTransformer
         parent::__construct($account, $serializer);
 
         $this->tokenName = $tokenName;
-        $this->account = $account;
     }
 
     public function includeUser(User $user)
@@ -29,12 +28,12 @@ class UserAccountTransformer extends EntityTransformer
     {
         return [
             'account_key' => $this->account->account_key,
-            'name' => $this->account->present()->name,
-            'token' => $this->account->getToken($user->id, $this->tokenName),
+            'name' => $user->account->present()->name,
+            'token' => $user->account->getToken($user->id, $this->tokenName),
             'default_url' => SITE_URL,
-            'plan' => $this->account->company->plan,
-            'logo' => $this->account->logo,
-            'logo_url' => $this->account->getLogoURL(),
+            'plan' => $user->account->company->plan,
+            'logo' => $user->account->logo,
+            'logo_url' => $user->account->getLogoURL(),
         ];
     }
 }


### PR DESCRIPTION
Changed back to $user object instead of $this->account.

In the case where there are many Companies (user_accounts) the $account object will be different, hence we cannot use $this->account