### PR TITLE
Use "from" address on error pages.

### DIFF
--- a/resources/views/error.blade.php
+++ b/resources/views/error.blade.php
@@ -9,7 +9,7 @@
   <div class="container" style="min-height:400px">
   <h3>{{ trans('texts.error_title') }}...</h3>
   <h4>{{ $error }}</h4>
-  <h4>{{ trans('texts.error_contact_text', ['mailaddress' => env('CONTACT_EMAIL', env('MAIL_USERNAME'))]) }}</h4>
+  <h4>{{ trans('texts.error_contact_text', ['mailaddress' => env('CONTACT_EMAIL', env('MAIL_FROM_ADDRESS'))]) }}</h4>
 </div>
 </div>
 


### PR DESCRIPTION
Use "from" address instead of SMTP username on error pages.