### PR TITLE
Client_ID in credit api

### DIFF
--- a/app/Ninja/Transformers/CreditTransformer.php
+++ b/app/Ninja/Transformers/CreditTransformer.php
@@ -27,6 +27,7 @@ class CreditTransformer extends EntityTransformer
             'credit_number' => $credit->credit_number,
             'private_notes' => $credit->private_notes,
             'public_notes' => $credit->public_notes,
+            'client_id' => $credit->client_id,
         ]);
     }
 }


### PR DESCRIPTION
This change now includes the client_id within the return of the credit api. This solves my issue #1512 .