### PR TITLE
Added better debug messages to importer

### DIFF
--- a/app/Services/ImportService.php
+++ b/app/Services/ImportService.php
@@ -183,45 +183,58 @@ class ImportService
                 if ($transformer->hasProduct($jsonProduct['product_key'])) {
                     continue;
                 }
-                if (EntityModel::validate($jsonProduct, ENTITY_PRODUCT) === true) {
+                
+                $productValidate = EntityModel::validate($jsonProduct, ENTITY_PRODUCT);
+                if ($productValidate === true) {
                     $product = $this->productRepo->save($jsonProduct);
                     $this->addProductToMaps($product);
                     $this->addSuccess($product);
                 } else {
+                    $jsonProduct['type'] = ENTITY_PRODUCT;
+                    $jsonProduct['error'] = $productValidate;
                     $this->addFailure(ENTITY_PRODUCT, $jsonProduct);
                     continue;
                 }
             }
 
             foreach ($json['clients'] as $jsonClient) {
-                if (EntityModel::validate($jsonClient, ENTITY_CLIENT) === true) {
+                $clientValidate = EntityModel::validate($jsonClient, ENTITY_CLIENT);
+                if ($clientValidate === true) {
                     $client = $this->clientRepo->save($jsonClient);
                     $this->addClientToMaps($client);
                     $this->addSuccess($client);
                 } else {
+                    $jsonClient['type'] = ENTITY_CLIENT;
+                    $jsonClient['error'] = $clientValidate;
                     $this->addFailure(ENTITY_CLIENT, $jsonClient);
                     continue;
                 }
 
                 foreach ($jsonClient['invoices'] as $jsonInvoice) {
                     $jsonInvoice['client_id'] = $client->id;
-                    if (EntityModel::validate($jsonInvoice, ENTITY_INVOICE) === true) {
+                    $invoiceValidate = EntityModel::validate($jsonInvoice, ENTITY_INVOICE);
+                    if ($invoiceValidate === true) {
                         $invoice = $this->invoiceRepo->save($jsonInvoice);
                         $this->addInvoiceToMaps($invoice);
                         $this->addSuccess($invoice);
                     } else {
+                        $jsonInvoice['type'] = ENTITY_INVOICE;
+                        $jsonInvoice['error'] = $invoiceValidate;
                         $this->addFailure(ENTITY_INVOICE, $jsonInvoice);
                         continue;
                     }
 
                     foreach ($jsonInvoice['payments'] as $jsonPayment) {
                         $jsonPayment['invoice_id'] = $invoice->public_id;
-                        if (EntityModel::validate($jsonPayment, ENTITY_PAYMENT) === true) {
+                        $paymentValidate = EntityModel::validate($jsonPayment, ENTITY_PAYMENT);
+                        if ($paymentValidate === true) {
                             $jsonPayment['client_id'] = $client->id;
                             $jsonPayment['invoice_id'] = $invoice->id;
                             $payment = $this->paymentRepo->save($jsonPayment);
                             $this->addSuccess($payment);
                         } else {
+                            $jsonPayment['type'] = ENTITY_PAYMENT;
+                            $jsonPayment['error'] = $paymentValidate;
                             $this->addFailure(ENTITY_PAYMENT, $jsonPayment);
                             continue;
                         }


### PR DESCRIPTION
I had a few issues while importing data from InvoicePlane to InvoiceNinja after using the `turbo124/Plane2Ninja` importer.

I'd get these errors which didn't help me as to why they were being thrown. Turns out they were false positives, mainly because the invoices were marked as paid but had no payment on it (this was intentional in the previous invoice system and is not caused by the migration tool from @turbo124)

```
Successfully created 33 client(s)
Successfully created 81 invoice(s)
Successfully created 64 payment(s)
Successfully created 4 quotes(s)
Successfully created 7 product(s)
The following records failed to import, they either already exist or are missing required fields.
{"invoice_id":30}
{"invoice_id":42}
{"invoice_id":43}
{"invoice_id":44}
{"invoice_id":45}
{"invoice_id":46}
{"invoice_id":47}
{"invoice_id":49}
{"invoice_id":50}
{"invoice_id":51}
{"invoice_id":52}
{"invoice_id":53}
{"invoice_id":54}
{"invoice_id":55}
{"invoice_id":56}
{"invoice_id":61}
{"invoice_id":63}
{"invoice_id":85}
```

Now when importing data if there's an error it'll tell you what product/customer/invoice/payment ID but also the type so above it says invoice_id but it was being thrown from the payment loop, now it'll show a `type` of either `product` `invoice`, etc.. as well as the validator error in `error`.

Hopefully for anyone importing data this will give them a bit more detail on why it didn't import so that they can then move to fix that issue withing having to edit core code or scanning through a ton of data 👍 