### PR TITLE
Hide 'Create expense category' for non admin

### DIFF
--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -67,12 +67,18 @@
 			  ['label' => trans('texts.new_recurring_expense'), 'url' => url('/recurring_expenses/create')],
 			]
 		  )->split() !!}
-	    {!! DropdownButton::normal(trans('texts.categories'))
-			->withAttributes(['class'=>'categoriesDropdown'])
-			->withContents([
-			  ['label' => trans('texts.new_expense_category'), 'url' => url('/expense_categories/create')],
-			]
-		  )->split() !!}
+		@if (Utils::isAdmin())
+			{!! DropdownButton::normal(trans('texts.categories'))
+				->withAttributes(['class'=>'categoriesDropdown'])
+				->withContents([
+				  ['label' => trans('texts.new_expense_category'), 'url' => url('/expense_categories/create')],
+				]
+			  )->split() !!}
+		@else
+			{!! DropdownButton::normal(trans('texts.categories'))
+				->withAttributes(['class'=>'categoriesDropdown'])
+				->split() !!}
+		@endif
 	  	<script type="text/javascript">
 		  	$(function() {
 				$('.recurringDropdown:not(.dropdown-toggle)').click(function(event) {


### PR DESCRIPTION
A minor fix on #1873, hide `Create expense category` in Expense -> Categories dropdown if the user has no admin right.

#### Remark

My first PR in InvoiceNinja, I would like to contribute more if time permits. By the way I checked the [Contribution guildline](https://github.com/invoiceninja/invoiceninja/blob/master/CONTRIBUTING.md) and noticed that there is no `WIP (Wor in progress)` rule for issues, so I have no idea which one is taken and which is free.





