### PR TITLE
Hide `New Expense Category` if user has no right to create

### DIFF
--- a/resources/views/list.blade.php
+++ b/resources/views/list.blade.php
@@ -90,12 +90,18 @@
 			  ['label' => trans('texts.new_recurring_expense'), 'url' => url('/recurring_expenses/create')],
 			]
 		  )->split() !!}
-	    {!! DropdownButton::normal(trans('texts.categories'))
-			->withAttributes(['class'=>'categoriesDropdown'])
-			->withContents([
-			  ['label' => trans('texts.new_expense_category'), 'url' => url('/expense_categories/create')],
-			]
-		  )->split() !!}
+		@if (Auth::user()->can('create', ENTITY_EXPENSE_CATEGORY))
+			{!! DropdownButton::normal(trans('texts.categories'))
+                ->withAttributes(['class'=>'categoriesDropdown'])
+                ->withContents([
+                  ['label' => trans('texts.new_expense_category'), 'url' => url('/expense_categories/create')],
+                ]
+              )->split() !!}
+		@else
+			{!! DropdownButton::normal(trans('texts.categories'))
+                ->withAttributes(['class'=>'categoriesDropdown'])
+                ->split() !!}
+		@endif
 	  	<script type="text/javascript">
 		  	$(function() {
 				$('.recurringDropdown:not(.dropdown-toggle)').click(function(event) {


### PR DESCRIPTION
A minor fix on #1873, hide Create expense category in Expense -> Categories dropdown if the user has no right to create it.

Remark

Thanks @hillelcoren for the reminding in #1903,  rebased.