### PR TITLE
remove unsecure key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_ENV=production
 APP_DEBUG=false
 APP_URL=http://www.ninja.test
-APP_KEY=SomeRandomStringSomeRandomString
+APP_KEY=
 APP_CIPHER=AES-256-CBC
 APP_LOCALE=en
 

--- a/config/app.php
+++ b/config/app.php
@@ -84,7 +84,7 @@ return [
     |
     */
 
-    'key' => env('APP_KEY', 'SomeRandomStringSomeRandomString'),
+    'key' => env('APP_KEY'),
 
     'cipher' => env('APP_CIPHER', 'AES-256-CBC'),
 


### PR DESCRIPTION
This PR removes `SomeRandomStringSomeRandomString` from:

1. `app.php`
2. `example.env`

I'm aware that the software checks against unsecure keys [here](https://github.com/invoiceninja/invoiceninja/blob/730b378b5bcc41a508fc09f954eeb223045e5bba/app/Listeners/HandleUserLoggedIn.php#L102). 
However, I feel like this PR still improves overall security.

Maybe there should also be an explicit mention of `php artisan key:generate` in the docs:[http://docs.invoiceninja.com/en/latest/install.html](http://docs.invoiceninja.com/en/latest/install.html) 