### PR TITLE
Added ability to disable module sidebar entry

### DIFF
--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -405,7 +405,7 @@
             @endforeach
             @if ( ! Utils::isNinjaProd())
                 @foreach (Module::collections() as $module)
-                    @include('partials.navigation_option', [
+                    @includeWhen(empty($module->get('no-sidebar')) || $module->get('no-sidebar') != '1', [
                         'option' => $module->getAlias(),
                         'icon' => $module->get('icon', 'th-large'),
                     ])


### PR DESCRIPTION
Added a module.json attribute to allow disabling inclusion of the sidebar partial view. Intended for modules that add background-type functionality and do not necessarily require a UI (at least as prominent as in the sidebar, that is).