### PR TITLE
fix-module-naming-and-routing

### DIFF
--- a/app/Http/Requests/EntityRequest.php
+++ b/app/Http/Requests/EntityRequest.php
@@ -33,6 +33,12 @@ class EntityRequest extends Request
             }
         }
         if (! $publicId) {
+            $field = $this->entityType;
+            if (! empty($this->$field)) {
+                $publicId = $this->$field;
+            }
+        }
+        if (! $publicId) {
             $publicId = Input::get('public_id') ?: Input::get('id');
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -125,8 +125,22 @@ class AppServiceProvider extends ServiceProvider
                     return '';
                 }
 
+
+                if(! Utils::isNinjaProd() && \App::isLocale('en') == false) {
+                    $modules = \Module::enabled();
+
+                    foreach($modules as $module) {
+                        if($crumb == $module->get('plural', '')) {
+                            $crumb = $module->getLowerName();
+                            break;
+                        }
+                    }
+                }
+
                 if (! Utils::isNinjaProd() && $module = \Module::find($crumb)) {
                     $name = mtrans($crumb);
+                } elseif(! Utils::isNinjaProd() && \App::isLocale('en') && $module = \Module::find(str_singular($crumb))) {
+                    $name = mtrans(str_singular($crumb));
                 } else {
                     $name = trans("texts.$crumb");
                 }

--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -408,6 +408,7 @@
                     @includeWhen(empty($module->get('no-sidebar')) || $module->get('no-sidebar') != '1', 'partials.navigation_option', [
                         'option' => $module->get('plural', $module->getAlias()),
                         'icon' => $module->get('icon', 'th-large'),
+                        'moduleName' => $module->getLowerName(),
                     ])
                 @endforeach
             @endif

--- a/resources/views/header.blade.php
+++ b/resources/views/header.blade.php
@@ -406,7 +406,7 @@
             @if ( ! Utils::isNinjaProd())
                 @foreach (Module::collections() as $module)
                     @includeWhen(empty($module->get('no-sidebar')) || $module->get('no-sidebar') != '1', 'partials.navigation_option', [
-                        'option' => $module->getAlias(),
+                        'option' => $module->get('plural', $module->getAlias()),
                         'icon' => $module->get('icon', 'th-large'),
                     ])
                 @endforeach

--- a/resources/views/partials/navigation_option.blade.php
+++ b/resources/views/partials/navigation_option.blade.php
@@ -21,7 +21,7 @@
         style="padding-top:6px; padding-bottom:6px"
         class="nav-link {{ Request::is("{$option}*") ? 'active' : '' }}">
         <i class="fa fa-{{ empty($icon) ? \App\Models\EntityModel::getIcon($option) : $icon }}" style="width:46px; padding-right:10px"></i>
-        {{ ($option == 'recurring_invoices') ? trans('texts.recurring') : mtrans($option) }}
+        {{ ($option == 'recurring_invoices') ? trans('texts.recurring') : (!empty($moduleName) ? mtrans($moduleName) : mtrans($option)) }}
         {!! Utils::isTrial() && in_array($option, ['reports']) ? '&nbsp;<sup>' . trans('texts.pro') . '</sup>' : '' !!}
     </a>
 


### PR DESCRIPTION
Fixes for scenario where module name does not match the URL format in the sidebar navigation and page breadcrumbs.