### PR TITLE
Mention reverse proxy in doc

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -130,10 +130,10 @@ Lock Invoices
 
 Adding ``LOCK_SENT_INVOICES=true`` to the .env file will prevent changing an invoice once it has been sent.
 
-Using a Proxy
+Using a (Reverse) Proxy
 """""""""""""
 
-If you need to set a list of trusted proxies you can add a TRUSTED_PROXIES value in the .env file. ie,
+If you need to set a list of trusted (reverse) proxies you can add a TRUSTED_PROXIES value in the .env file. ie,
 
 .. code-block:: shell
 


### PR DESCRIPTION
Mention "Reverse Proxy" as a whole instead of "Using a Proxy" to help people find the reverse proxy solution quicker through a search engine.
Very little small minor change but it could help a lot of people who run self-hosted installations ;)