### PR TITLE
1854 - Add overlay Translation

### DIFF
--- a/app/Ninja/Translation/FileLoader.php
+++ b/app/Ninja/Translation/FileLoader.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Ninja\Translation;
+
+use Illuminate\Filesystem\Filesystem;
+
+class FileLoader extends \Illuminate\Translation\FileLoader
+{
+
+    /**
+     * The overlay path for the loader.
+     *
+     * @var string
+     */
+    protected $overlayPath;
+
+    /**
+     * Create a new file loader instance.
+     *
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @param  string  $path
+     * @param  string  $overlayPath
+     * @return void
+     */
+    public function __construct(Filesystem $files, $path, $overlayPath)
+    {
+        parent::__construct($files, $path);
+        $this->overlayPath = $overlayPath;
+    }
+
+    /**
+     * Load the messages for the given locale.
+     *
+     * @param  string  $locale
+     * @param  string  $group
+     * @param  string  $namespace
+     * @return array
+     */
+    public function load($locale, $group, $namespace = null)
+    {
+        $parent = parent::load($locale, $group, $namespace);
+
+        if ($group == '*' && $namespace == '*') {
+            return array_merge($parent, $this->loadJsonPath($this->overlayPath, $locale));
+        }
+
+        if (is_null($namespace) || $namespace == '*') {
+            return array_merge($parent, $this->loadPath($this->overlayPath, $locale, $group));
+        }
+
+        return array_merge($parent, $this->loadNamespaced($locale, $group, $namespace));
+    }
+}

--- a/app/Ninja/Translation/TranslationServiceProvider.php
+++ b/app/Ninja/Translation/TranslationServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Ninja\Translation;
+
+class TranslationServiceProvider extends \Illuminate\Translation\TranslationServiceProvider
+{
+
+    /**
+     * Register the translation line loader.
+     *
+     * @return void
+     */
+    protected function registerLoader()
+    {
+        $this->app->singleton('translation.loader', function ($app) {
+            return new FileLoader($app['files'], $app['path.lang'], storage_path("lang"));
+        });
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -137,11 +137,11 @@ return [
         'Illuminate\Redis\RedisServiceProvider',
         'Illuminate\Auth\Passwords\PasswordResetServiceProvider',
         'Illuminate\Session\SessionServiceProvider',
-        'Illuminate\Translation\TranslationServiceProvider',
         'Illuminate\Validation\ValidationServiceProvider',
         'Illuminate\View\ViewServiceProvider',
         'Illuminate\Broadcasting\BroadcastServiceProvider',
         'Illuminate\Notifications\NotificationServiceProvider',
+        'App\Ninja\Translation\TranslationServiceProvider',
 
         /*
          * Additional Providers

--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -18,6 +18,27 @@ We use Gulp to concatenate the JavasScript and CSS files. You can download the s
 
 Most of the system tables are cached (ie, currencies, languages, etc). If you make any changes you need to run ``php artisan db:seed --class=UpdateSeeder`` and then load any page with ?clear_cache=true added at the end of the URL.
 
+Custom Localization
+"""""""""""""""""""
+
+Invoice Ninja has many translations build-in. Many of them are contributed by users via `Transifex <https://www.transifex.com/invoice-ninja/invoice-ninja/>`_. But not every translation can be sent upstream.
+It is possible to selectively override text strings as required. Any text that is not overridden is taken from the default locale file.
+
+By default the locale override folder ``storage/lang`` does not exist. You have to create it when you want to use this feature. The layout of this folder is the same as the main translation folder, which is located at ``resources/lang``.
+
+**Example**
+
+To override the string *Organization* from the English translation you need to override the locale file ``texts.php``.
+
+Create both ``lang`` and ``lang/en`` folders inside of your installations storage folder, then create the file ``texts.php`` in that last folder with the following contents;
+
+.. code-block:: php
+
+   <?php
+   return $LANG = [
+      'organization' => 'Company',
+   ];
+
 Database
 """"""""
 


### PR DESCRIPTION
This adds an overlay system which allows locale files to be patched without modifying core files.

Most of the code is lifted from the Laravel base with small modifications. Tried to change as little as possible to ease future maintenance.
I've added a bit to the developer documentation mentioning this feature.

## Issue
This fixes issue #1854.

## Motivation
I have have no direct need for this feature, but saw it was requested and seemed like a simple enough starting point for getting involved in this project.