### PR TITLE
Update knockout.blade.php

### DIFF
--- a/resources/views/invoices/knockout.blade.php
+++ b/resources/views/invoices/knockout.blade.php
@@ -1137,7 +1137,7 @@ ko.bindingHandlers.productTypeahead = {
 };
 
 function checkInvoiceNumber() {
-    var url = '{{ url('check_invoice_number') }}/{{ $invoice->id ? $invoice->public_id : '' }}?invoice_number=' + encodeURIComponent($('#invoice_number').val());
+    var url = '{{ url('check_invoice_number') }}{{ $invoice->id ? $invoice->public_id : '' }}?invoice_number=' + encodeURIComponent($('#invoice_number').val());
     $.get(url, function(data) {
         var isValid = data == '{{ RESULT_SUCCESS }}' ? true : false;
         if (isValid) {


### PR DESCRIPTION
Removed a '/' (forward slash) on line 1140 col 49 which was causing the URL to result in a 404 (was pointing to 'https://example.com/public/check_invoice_number/?invoice_number=XXX' rather than 'https://example.com/public/check_invoice_number?invoice_number=XXX') which was resulting in any value being entered in the 'Invoice Number' box while creating a new invoice to respond with 'The Invoice Number has already been taken'.