### PR TITLE
Reverse exchange rates to comply with payments module

### DIFF
--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -218,7 +218,7 @@ class SendReminders extends Command
 
                 foreach ($data->rates as $code => $rate) {
                     if($recalculate) {
-                        $rate = 1 / $data->rates->{$base} * $rate;
+                        $rate = $data->rates->{$base} * 1 / $rate;
                     }
 
                     Currency::whereCode($code)->update(['exchange_rate' => $rate]);

--- a/resources/views/invoices/knockout.blade.php
+++ b/resources/views/invoices/knockout.blade.php
@@ -1067,21 +1067,20 @@ ko.bindingHandlers.productTypeahead = {
                                 rate = window.model.invoice().custom_text_value2();
                             }
                             if (rate) {
-                                cost = cost * rate;
+                                cost = cost / rate;
                             } else {
                                 var client = window.model.invoice().client();
                                 if (client) {
                                     var clientCurrencyId = client.currency_id();
                                     var accountCurrencyId = {{ $account->getCurrencyId() }};
                                     if (clientCurrencyId && clientCurrencyId != accountCurrencyId) {
-                                        cost = fx.convert(cost, {
-                                            from: currencyMap[accountCurrencyId].code,
-                                            to: currencyMap[clientCurrencyId].code,
-                                        });
                                         var rate = fx.convert(1, {
                                             from: currencyMap[accountCurrencyId].code,
                                             to: currencyMap[clientCurrencyId].code,
                                         });
+                                        
+                                        cost = cost / rate;
+
                                         if ((account.custom_fields.invoice_text1 || '').toLowerCase() == "{{ strtolower(trans('texts.exchange_rate')) }}") {
                                             window.model.invoice().custom_text_value1(roundToFour(rate, true));
                                         } else if ((account.custom_fields.invoice_text2 || '').toLowerCase() == "{{ strtolower(trans('texts.exchange_rate')) }}") {


### PR DESCRIPTION
Reverse how much cost base curency in foreing currency to how much cost foreing currency in base currency. Ex. base currecny = CZK, foreing currency = EUR. Exchange rate was 0,04 (1CZK = 0,04EUR), now is 25 (1EUR = 25CZK).

This way are also converted amounts in payment module, where 'amount' in DB table is in client currency (foreing currency) and we are converting to base currency.

If this proposal of changes will not be accepted, them we have to change calculation in payments module.

Personally, I think my proposal is more standard way, at least in our region.

Signed-off-by: Kristián Feldsam <feldsam@gmail.com>