### PR TITLE
FIX - link canonical href

### DIFF
--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -50,7 +50,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="canonical" href="{{ NINJA_APP_URL }}/{{ Request::path() }}"/>
+    <link rel="canonical" href="{{ SITE_URL }}{{ Request::path() }}"/>
 
     @yield('head_css')
 


### PR DESCRIPTION
Hello,

little fix that replaces "app.invoiceninja.com" by the real url of the hosting server.