### PR TITLE
Added missing function to ScheduledReport

### DIFF
--- a/app/Models/ScheduledReport.php
+++ b/app/Models/ScheduledReport.php
@@ -56,4 +56,8 @@ class ScheduledReport extends EntityModel
 
         $this->save();
     }
+
+    public function getEntityType() {
+        return '';
+    }
 }


### PR DESCRIPTION
Adds a missing getEntityType() function to ScheduledReport.

Without the function, EntityModel will try to call getEntityType(), not find it, and then pass the call down to the __call method... and repeat, causing an infinite recursion.