### PR TITLE
Let's comment one line

### DIFF
--- a/app/Ninja/PaymentDrivers/PayPalExpressPaymentDriver.php
+++ b/app/Ninja/PaymentDrivers/PayPalExpressPaymentDriver.php
@@ -58,7 +58,7 @@ class PayPalExpressPaymentDriver extends BasePaymentDriver
         $client->shipping_address2 = '';
         $client->shipping_city = trim($data['SHIPTOCITY']);
         $client->shipping_state = isset($data['SHIPTOSTATE']) ? trim($data['SHIPTOSTATE']) : '';
-        $client->shipping_postal_code = trim($data['SHIPTOZIP']);
+     //   $client->shipping_postal_code = trim($data['SHIPTOZIP']);
 
         if ($country = cache('countries')->filter(function ($item) use ($data) {
             return strtolower($item->iso_3166_2) == strtolower(trim($data['SHIPTOCOUNTRYCODE']));


### PR DESCRIPTION
$client->shipping_postal_code = trim($data['SHIPTOZIP']);
causes error

Post Link: https://www.invoiceninja.com/forums/topic/paypal-payment-successful-but-the-invoice-is-still-considered-unpaid/#post-15792