### PR TITLE
Update VE Timezone Constant

### DIFF
--- a/database/seeds/ConstantsSeeder.php
+++ b/database/seeds/ConstantsSeeder.php
@@ -69,7 +69,7 @@ class ConstantsSeeder extends Seeder
             'US/East-Indiana' => '(GMT-05:00) Indiana (East)',
             'America/Bogota' => '(GMT-05:00) Bogota',
             'America/Lima' => '(GMT-05:00) Lima',
-            'America/Caracas' => '(GMT-04:30) Caracas',
+            'America/Caracas' => '(GMT-04:00) Caracas',
             'Canada/Atlantic' => '(GMT-04:00) Atlantic Time (Canada)',
             'America/La_Paz' => '(GMT-04:00) La Paz',
             'America/Santiago' => '(GMT-04:00) Santiago',


### PR DESCRIPTION
In Venezuela, the timezone value has been changed months ago, from -4:30 to -4:00  (-0400 UTC) 

https://www.timeanddate.com/news/time/venezuela-change-timezone.html

