### PR TITLE
Check invoice type at link generation

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -848,7 +848,8 @@ class Invoice extends EntityModel implements BalanceAffecting
      */
     public static function calcLink($invoice)
     {
-        return link_to('invoices/' . $invoice->public_id, $invoice->invoice_number);
+        $linkPrefix = ($invoice->invoice_type_id == INVOICE_TYPE_QUOTE) ? 'quotes/' : 'invoices/';
+        return link_to($linkPrefix . $invoice->public_id, $invoice->invoice_number);
     }
 
     /**


### PR DESCRIPTION
fixes #2396

Upcoming and expired quotes links from the dashboard are generated from the following view `resources/views/dashboard.blade.php` via the `\App\Models\Invoice::calcLink($invoice)` method.

By checking the invoice type id, the right link is returned.
