### PR TITLE
Add trait to allow mergine multi-dimensional configurations

### DIFF
--- a/app/Providers/Traits/HasDynamicConfigs.php
+++ b/app/Providers/Traits/HasDynamicConfigs.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Providers\Traits;
+
+
+trait HasDynamicConfigs
+{
+    public function mergeDynamicConfig($path, $key) {
+        $key = "modules.{$key}";
+        $config = $this->app['config']->get($key, []);
+
+        $this->app['config']->set($key, array_merge_recursive(require $path, $config));
+    }
+}


### PR DESCRIPTION
Adds a new method to allow merging configuration values beyond 1 level, i.e. multi-dimensional arrays.

Important for the dynamic entity relationship configuration, otherwise only the first registered relation will exist.

Also important to allow similar functionality to be developed in the future where a hierarchy may need to be defined via arrays in configuration file(s).