### PR TITLE
Add DATE_MONTH and DATE_YEAR variables for recurring invoices. DATE_M…

### DIFF
--- a/app/Libraries/Utils.php
+++ b/app/Libraries/Utils.php
@@ -864,7 +864,7 @@ class Utils
             return '';
         }
 
-        $variables = ['MONTH', 'QUARTER', 'YEAR'];
+        $variables = ['MONTH', 'QUARTER', 'YEAR', 'DATE_MONTH', 'DATE_YEAR'];
         for ($i = 0; $i < count($variables); $i++) {
             $variable = $variables[$i];
             $regExp = '/:'.$variable.'[+-]?[\d]*/';
@@ -904,7 +904,38 @@ class Utils
             return self::getQuarter($offset);
         } elseif ($part == 'YEAR') {
             return self::getYear($offset);
+        } elseif ($part == 'DATE_MONTH') {
+            return self::getDateMonth($offset, $locale);
+        } elseif ($part == 'DATE_YEAR') {
+            return self::getDateYear($offset);
         }
+    }
+
+    public static function getDateMonth($offset, $locale) 
+    {
+        $timestamp = time();
+        $res = $timestamp + ($offset * 24 * 60 * 60);
+
+        $months = static::$months;
+        $month = intval(date('n', $res)) - 1;
+
+        $month = $month % 12;
+
+        if ($month < 0) {
+            $month += 12;
+        }
+
+        return trans('texts.' . $months[$month], [], $locale);
+    }
+
+    public static function getDateYear($offset) 
+    {
+        $timestamp = time();
+        $res = $timestamp + ($offset * 24 * 60 * 60);
+
+        $year = intval(date('Y', $res));
+
+        return $year;
     }
 
     public static function getMonthOptions()


### PR DESCRIPTION
After requesting this feature on the support forums I was encouraged to create a pull request, so here it is. Please don't be mad if I violate your guidelines in any way, I have tried to follow everything closely but I am not accustomed to GitHub and also not experienced in PHP.

My contribution would add two new variables to be used in recurring invoices:
`:DATE_YEAR` and `:DATE_MONTH`

Both would accept offsets in full days, so `:DATE_YEAR+1` would give you tomorrow's calendar year (always the current one except on December 31) and `:DATE_MONTH+7` would give you the calendar month one week from now.

I had no way of testing this thoroughly on a live system because I couldn't get invoiceninja installed locally. If this completely disqualifies my contribution I guess I'll have to accept that.
