### PR TITLE
Doc: Mention attachments (documents) in update documentation

### DIFF
--- a/docs/update.rst
+++ b/docs/update.rst
@@ -11,7 +11,7 @@ If you have trouble updating you can manually load /update to check for errors.
 
 .. TIP:: We recommend using this `shell script <https://pastebin.com/j657uv9A>`_ to automate the update process, run it as a daily cron to automatically keep your app up to date.
 
-If you're moving servers make sure to copy over the .env file and the custom company logo(s) located in the public/logo directory.
+If you're moving servers make sure to copy over the .env file and the custom company logo(s) located in the public/logo directory. For attachments make sure you do not forget to copy the storage/documents directory.
 
 You can manually run the update with the following commands. Once completed add ``?clear_cache=true`` to the end of the URL to clear the application cache.
 


### PR DESCRIPTION
After my last invoiceninja upgrade, a customer complained that he is not able to see attached documents to an invoice anymore in the web-ui. I realized that the "storage/documents" content must be synced with the new version path. Hence this should be mentioned in the documentation, too. :-)