### PR TITLE
Use translated name for the selected currency on vendor page

### DIFF
--- a/resources/views/vendors/edit.blade.php
+++ b/resources/views/vendors/edit.blade.php
@@ -118,7 +118,7 @@
             <div class="panel-body">
 
             {!! Former::select('currency_id')->addOption('','')
-                ->placeholder($account->currency ? $account->currency->name : '')
+                ->placeholder($account->currency ? $account->currency->getTranslatedName() : '')
                 ->fromQuery($currencies, 'name', 'id') !!}
 			{!! Former::textarea('private_notes')->rows(6) !!}
 


### PR DESCRIPTION
Use the translated name for the selected currency on vendor page. Should fix #2699.