### PR TITLE
Add user id and displayname in task status (API)

### DIFF
--- a/app/Ninja/Transformers/TaskTransformer.php
+++ b/app/Ninja/Transformers/TaskTransformer.php
@@ -52,6 +52,8 @@ class TaskTransformer extends EntityTransformer
     {
         return array_merge($this->getDefaults($task), [
             'id' => (int) $task->public_id,
+            'user_id' => (int) $task->user_id,
+            'username' => $task->user->getDisplayName(),
             'description' => $task->description ?: '',
             'duration' => $task->getDuration() ?: 0,
             'updated_at' => (int) $this->getTimestamp($task->updated_at),


### PR DESCRIPTION
As a workaround for #2743 I tried to use the API. This way, I can get the status of the task, but I'm unable to show the user who created the task.

This PR adds the user id and the user's displayname in the API for retrieving a specific task.