### PR TITLE
Stripe improvements

### DIFF
--- a/app/Ninja/PaymentDrivers/StripePaymentDriver.php
+++ b/app/Ninja/PaymentDrivers/StripePaymentDriver.php
@@ -273,6 +273,11 @@ class StripePaymentDriver extends BasePaymentDriver
             } elseif ($isBitcoin) {
                 $payment->payment_type_id = PAYMENT_TYPE_BITCOIN;
             }
+        } else if (! $paymentMethod && $this->isGatewayType(GATEWAY_TYPE_CREDIT_CARD) && ! strcmp($this->purchaseResponse['payment_method_details']['type'], "card")) {
+            $card = $this->purchaseResponse['payment_method_details']['card'];
+            $payment->last4 = $card['last4'];
+            $payment->expiration = $card['exp_year'] . '-' . $card['exp_month'] . '-01';
+            $payment->payment_type_id = PaymentType::parseCardType($card['brand']);
         }
 
         return $payment;

--- a/resources/views/payments/credit_card.blade.php
+++ b/resources/views/payments/credit_card.blade.php
@@ -154,11 +154,12 @@
 
     @if ($client)
         {{ Former::populate($client) }}
+        {{ Former::populateField('country_id', (string) $client->country_id) }}
         {{ Former::populateField('first_name', $contact->first_name) }}
         {{ Former::populateField('last_name', $contact->last_name) }}
         {{ Former::populateField('email', $contact->email) }}
         @if (!$client->country_id && $client->account->country_id)
-            {{ Former::populateField('country_id', $client->account->country_id) }}
+            {{ Former::populateField('country_id', (string) $client->account->country_id) }}
             {{ Former::populateField('shipping_country_id', $client->account->country_id) }}
         @endif
     @endif
@@ -170,7 +171,7 @@
         {{ Former::populateField('city', 'New York') }}
         {{ Former::populateField('state', 'NY') }}
         {{ Former::populateField('postal_code', '10118') }}
-        {{ Former::populateField('country_id', 840) }}
+        {{ Former::populateField('country_id', (string) 840) }}
 
         <script>
             $(function() {
@@ -253,7 +254,7 @@
                 <div class="col-md-6">
                     {!! Former::select('country_id')
                             ->placeholder(trans('texts.country_id'))
-                            ->fromQuery($countries, 'name', 'id')
+                            ->fromQuery($countries, 'name', ['value' => 'id', 'data-iso_3166_2' => 'iso_3166_2'])
                             ->addGroupClass('country-select')
                             ->label('') !!}
                 </div>
@@ -453,12 +454,16 @@
 
 
             var options = {
-                name: document.getElementById('first_name').value + ' ' + document.getElementById('last_name').value
+                name: document.getElementById('first_name').value + ' ' + document.getElementById('last_name').value,
+@if (!empty($accountGateway->show_address))
+                address_line1: $('#address1').val(),
+                address_line2: $('#address2').val(),
+                address_city: $('#city').val(),
+                address_state: $('#state').val(),
+                address_zip: $('#postal_code').val(),
+                address_country: $("#country_id option:selected").attr('data-iso_3166_2')
+@endif
             };
-
-            if (document.getElementById('postal_code')) {
-                options.address_zip = document.getElementById('postal_code').value;
-            }
 
             stripe.createToken(cardNumber, options).then(function(result) {
                 if (result.error) {


### PR DESCRIPTION
Just as #2862 I'm contributing these improvements from changes I've done to my personal fork.

For the first commit, you'll see some changes to populating `country_id`, that's because of https://github.com/formers/former/issues/583
Also, I've used jQuery to get the values, while the previous code uses standard JS. I might change that on request, although I'm not sure I know how to get the selected country with standard JS.

As for the second, I believe it is quite simple, payment information wouldn't be filled unless a token was being saved too, this fixes it. I've limited to credit card type, although I believe Apple Pay type should work too - I just don't have it to test.