### PR TITLE
Set default "Valid Until" value for new quotes

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -164,6 +164,7 @@ class Account extends Eloquent
         'custom_value2',
         'custom_messages',
         'custom_fields_options',
+        'valid_until_days',
     ];
 
     /**

--- a/app/Ninja/Repositories/InvoiceRepository.php
+++ b/app/Ninja/Repositories/InvoiceRepository.php
@@ -399,6 +399,8 @@ class InvoiceRepository extends BaseRepository
             if ($entityType == ENTITY_INVOICE && empty($data['partial_due_date'])) {
                 $client = Client::scope()->whereId($data['client_id'])->first();
                 $invoice->due_date = $account->defaultDueDate($client);
+            } elseif($entityType == ENTITY_QUOTE && empty($data['due_date']) && !empty($account->valid_until_days)) {
+                $invoice->due_date = \Carbon::parse($data['invoice_date'])->addDays($account->valid_until_days);
             }
         } else {
             $invoice = Invoice::scope($publicId)->firstOrFail();

--- a/database/migrations/2019_06_20_193559_add_default_valid_until_setting.php
+++ b/database/migrations/2019_06_20_193559_add_default_valid_until_setting.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddDefaultValidUntilSetting extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('accounts', function ($table) {
+            $table->integer('valid_until_days')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('accounts', function ($table) {
+            $table->dropColumn('valid_until_days');
+        });
+    }
+}

--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -3159,7 +3159,8 @@ $LANG = array(
     'design' => 'Design',
     'password_is_too_short' => 'Password is too short',
     'failed_to_find_record' => 'Failed to find record',
-
+    'valid_until_days' => 'Valid Until',
+    'valid_until_days_help' => 'Automatically sets the <b>Valid Until</b> value on quotes to this many days in the future.  Leave blank to disable.',
 );
 
 return $LANG;

--- a/resources/views/accounts/details.blade.php
+++ b/resources/views/accounts/details.blade.php
@@ -20,6 +20,7 @@
 
 	{{ Former::populate($account) }}
 	{{ Former::populateField('task_rate', floatval($account->task_rate) ? Utils::roundSignificant($account->task_rate) : '') }}
+    {{ Former::populateField('valid_until_days', intval($account->valid_until_days) ? $account->valid_until_days : '') }}
 
     @include('accounts.nav', ['selected' => ACCOUNT_COMPANY_DETAILS])
 
@@ -106,6 +107,10 @@
 					{!! Former::text('task_rate')
 					 		->help('task_rate_help')!!}
 				@endif
+
+                {!! Former::text('valid_until_days')
+                                ->label(trans('texts.valid_until_days'))
+                                ->help(trans('texts.valid_until_days_help')) !!}
 
             </div>
         </div>


### PR DESCRIPTION
Adds a setting to automatically set the valid until date of new quotations to the quote date + number of days.  If the settings field is left blank, the setting is ignored.  Auto-calculation is ignored if the user manually assigns a valid until date during quote creation.

Resolves Feature Request #2503