### PR TITLE
Fixes recurring invoices end date parsing

### DIFF
--- a/app/Ninja/Datatables/RecurringInvoiceDatatable.php
+++ b/app/Ninja/Datatables/RecurringInvoiceDatatable.php
@@ -3,6 +3,7 @@
 namespace App\Ninja\Datatables;
 
 use Auth;
+use Carbon;
 use URL;
 use Utils;
 use App\Models\Invoice;
@@ -85,6 +86,8 @@ class RecurringInvoiceDatatable extends EntityDatatable
         if ($model->invoice_status_id == INVOICE_STATUS_SENT) {
             if (! $model->last_sent_date_sql || $model->last_sent_date_sql == '0000-00-00') {
                 $label = trans('texts.pending');
+            } elseif ($model->end_date_sql && Carbon::parse($model->end_date_sql)->isPast()) {
+                $label = trans('texts.status_completed');
             } else {
                 $label = trans('texts.active');
             }

--- a/resources/views/invoices/edit.blade.php
+++ b/resources/views/invoices/edit.blade.php
@@ -81,7 +81,7 @@
 		@if ($invoice->is_recurring && $invoice->isSent())
 			@if (! $invoice->last_sent_date || $invoice->last_sent_date == '0000-00-00')
 				{!! $invoice->present()->statusLabel(trans('texts.pending')) !!}
-			@elseif ($invoice->end_date && Carbon::parse($invoice->end_date)->isPast())
+			@elseif ($invoice->end_date && Carbon::parse(Utils::toSqlDate($invoice->end_date))->isPast())
 				{!! $invoice->present()->statusLabel(trans('texts.status_completed')) !!}
 			@else
 				{!! $invoice->present()->statusLabel(trans('texts.active')) !!}


### PR DESCRIPTION
As first commit sub-message says:

> View gets the date already formatted and Carbon isn't always able to parse that format automatically, so convert it back to SQL format

I'm using a format with slashes (16/Jul/2019) and Carbon/DateTime isn't able to parse that without giving it the format. There are a few options here but I chose to just converted it back to SQL format.

The second commit basically reproduces the same code into the datatable, otherwise a completed recurring invoice shows as active.