### PR TITLE
Ensure getEventClass type is capitalized

### DIFF
--- a/app/Ninja/Repositories/BaseRepository.php
+++ b/app/Ninja/Repositories/BaseRepository.php
@@ -36,7 +36,7 @@ class BaseRepository
      */
     private function getEventClass($entity, $type)
     {
-        return 'App\Events\\' . ucfirst($entity->getEntityType()) . 'Was' . $type;
+        return 'App\Events\\' . ucfirst($entity->getEntityType()) . 'Was' . ucfirst($type);
     }
 
     /**


### PR DESCRIPTION
Allows passing in 'created' or 'Created' for example