### PR TITLE
(1/2) Fix PaymentWasCreated event second parameter

### DIFF
--- a/app/Console/Commands/CreateTestData.php
+++ b/app/Console/Commands/CreateTestData.php
@@ -92,14 +92,14 @@ class CreateTestData extends Command
         $user = User::whereEmail('small@example.com')->first();
 
         if(!$user)
-        {    
+        {
             $user = factory(\App\Models\User::class)->create([
             //    'account_id' => $account->id,
                 'email' => 'small@example.com',
                 'confirmation_code' => $this->createDbHash(config('database.default'))
             ]);
         }
-        
+
         $token = \Illuminate\Support\Str::random(64);
 
         $company_token = CompanyToken::create([
@@ -147,14 +147,14 @@ class CreateTestData extends Command
         $user = User::whereEmail('medium@example.com')->first();
 
         if(!$user)
-        {    
+        {
             $user = factory(\App\Models\User::class)->create([
             //    'account_id' => $account->id,
                 'email' => 'medium@example.com',
                 'confirmation_code' => $this->createDbHash(config('database.default'))
             ]);
         }
-        
+
         $token = \Illuminate\Support\Str::random(64);
 
         $company_token = CompanyToken::create([
@@ -203,14 +203,14 @@ class CreateTestData extends Command
         $user = User::whereEmail('large@example.com')->first();
 
         if(!$user)
-        {    
+        {
             $user = factory(\App\Models\User::class)->create([
             //    'account_id' => $account->id,
                 'email' => 'large@example.com',
                 'confirmation_code' => $this->createDbHash(config('database.default'))
             ]);
         }
-        
+
         $token = \Illuminate\Support\Str::random(64);
 
         $company_token = CompanyToken::create([
@@ -283,7 +283,7 @@ class CreateTestData extends Command
         $invoice = InvoiceFactory::create($client->company->id,$client->user->id);//stub the company and user_id
         $invoice->client_id = $client->id;
         $invoice->date = $faker->date();
-        
+
         $invoice->line_items = $this->buildLineItems();
         $invoice->uses_inclusive_taxes = false;
 
@@ -315,7 +315,7 @@ class CreateTestData extends Command
         $invoice->save();
 
             event(new CreateInvoiceInvitation($invoice));
-            
+
             UpdateCompanyLedgerWithInvoice::dispatchNow($invoice, $invoice->balance);
 
             $this->invoice_repo->markSent($invoice);
@@ -335,7 +335,7 @@ class CreateTestData extends Command
 
                 $payment->invoices()->save($invoice);
 
-                event(new PaymentWasCreated($payment));
+                event(new PaymentWasCreated($payment, $payment->company));
 
                 UpdateInvoicePayment::dispatchNow($payment, $payment->company);
             }
@@ -349,7 +349,7 @@ class CreateTestData extends Command
         $quote = QuoteFactory::create($client->company->id,$client->user->id);//stub the company and user_id
         $quote->client_id = $client->id;
         $quote->date = $faker->date();
-        
+
         $quote->line_items = $this->buildLineItems();
         $quote->uses_inclusive_taxes = false;
 
@@ -379,7 +379,7 @@ class CreateTestData extends Command
         $quote = $quote_calc->getInvoice();
 
         $quote->save();
-            
+
             CreateQuoteInvitations::dispatch($quote, $quote->company);
 
 
@@ -393,19 +393,19 @@ class CreateTestData extends Command
         $item->quantity = 1;
         $item->cost =10;
 
-        if(rand(0, 1)) 
+        if(rand(0, 1))
         {
             $item->tax_name1 = 'GST';
             $item->tax_rate1 = 10.00;
         }
 
-        if(rand(0, 1)) 
+        if(rand(0, 1))
         {
             $item->tax_name1 = 'VAT';
             $item->tax_rate1 = 17.50;
         }
 
-        if(rand(0, 1)) 
+        if(rand(0, 1))
         {
             $item->tax_name1 = 'Sales Tax';
             $item->tax_rate1 = 5;
@@ -421,7 +421,7 @@ class CreateTestData extends Command
     {
                 /* Warm up the cache !*/
         $cached_tables = config('ninja.cached_tables');
-        
+
         foreach ($cached_tables as $name => $class) {
             if (! Cache::has($name)) {
                 // check that the table exists in case the migration is pending

--- a/database/seeds/RandomDataSeeder.php
+++ b/database/seeds/RandomDataSeeder.php
@@ -41,7 +41,7 @@ class RandomDataSeeder extends Seeder
 
         /* Warm up the cache !*/
         $cached_tables = config('ninja.cached_tables');
-        
+
         foreach ($cached_tables as $name => $class) {
             if (! Cache::has($name)) {
                 // check that the table exists in case the migration is pending
@@ -63,7 +63,7 @@ class RandomDataSeeder extends Seeder
                 }
             }
         }
-        
+
 
         $this->command->info('Running RandomDataSeeder');
 
@@ -141,7 +141,7 @@ class RandomDataSeeder extends Seeder
 
         /** Invoice Factory */
         factory(\App\Models\Invoice::class,20)->create(['user_id' => $user->id, 'company_id' => $company->id, 'client_id' => $client->id]);
-      
+
         $invoices = Invoice::cursor();
         $invoice_repo = new InvoiceRepository();
 
@@ -151,15 +151,15 @@ class RandomDataSeeder extends Seeder
 
             if($invoice->uses_inclusive_taxes)
                 $invoice_calc = new InvoiceSumInclusive($invoice);
-            else 
+            else
                 $invoice_calc = new InvoiceSum($invoice);
 
             $invoice = $invoice_calc->build()->getInvoice();
-            
+
             $invoice->save();
 
             event(new CreateInvoiceInvitation($invoice));
-            
+
             UpdateCompanyLedgerWithInvoice::dispatchNow($invoice, $invoice->balance);
 
             $invoice_repo->markSent($invoice);
@@ -169,8 +169,8 @@ class RandomDataSeeder extends Seeder
             if(rand(0, 1)) {
                 $payment = App\Models\Payment::create([
                     'date' => now(),
-                    'user_id' => $user->id, 
-                    'company_id' => $company->id, 
+                    'user_id' => $user->id,
+                    'company_id' => $company->id,
                     'client_id' => $client->id,
                     'amount' => $invoice->balance,
                     'transaction_reference' => rand(0,500),
@@ -180,13 +180,13 @@ class RandomDataSeeder extends Seeder
 
                 $payment->invoices()->save($invoice);
 
-                event(new PaymentWasCreated($payment));
+                event(new PaymentWasCreated($payment, $payment->company));
 
                 UpdateInvoicePayment::dispatchNow($payment, $payment->company);
             }
-            
+
         });
-        
+
         /** Recurring Invoice Factory */
         factory(\App\Models\RecurringInvoice::class,10)->create(['user_id' => $user->id, 'company_id' => $company->id, 'client_id' => $client->id]);
 
@@ -210,7 +210,7 @@ class RandomDataSeeder extends Seeder
             'settings' =>  ClientSettings::buildClientSettings(CompanySettings::defaults(), ClientSettings::defaults()),
             'name' => 'Default Client Settings',
         ]);
-        
+
 
         if(config('ninja.testvars.stripe'))
         {


### PR DESCRIPTION
Unfortunately fresh seeding didn't worked, because of second parameter. 

![Screenshot_20191227_125551](https://user-images.githubusercontent.com/13711415/71516338-b71d7800-28a8-11ea-95b4-56ac2e4baeb6.png)

Changes:
- [ x ] Second parameter passed on the event instances
- [ x ] Reindentation format fix 

If its hard to follow the code changes because of formatting, here are where instances got updated:

![Screenshot_20191227_125858](https://user-images.githubusercontent.com/13711415/71516371-e9c77080-28a8-11ea-876f-dbcd259d1465.png)


