### PR TITLE
Fixes #3196 (exchange rate and converted currency not working)

### DIFF
--- a/app/Ninja/Repositories/ExpenseRepository.php
+++ b/app/Ninja/Repositories/ExpenseRepository.php
@@ -195,7 +195,7 @@ class ExpenseRepository extends BaseRepository
         }
 
         $rate = isset($input['exchange_rate']) ? Utils::parseFloat($input['exchange_rate']) : 1;
-        $expense->exchange_rate = round($rate, 4);
+        $expense->exchange_rate = round($rate, 14);
         if (isset($input['amount'])) {
             $expense->amount = round(Utils::parseFloat($input['amount']), 2);
         }

--- a/app/Ninja/Repositories/RecurringExpenseRepository.php
+++ b/app/Ninja/Repositories/RecurringExpenseRepository.php
@@ -133,7 +133,7 @@ class RecurringExpenseRepository extends BaseRepository
             $expense->invoice_currency_id = \Auth::user()->account->getCurrencyId();
         }
         $rate = isset($input['exchange_rate']) ? Utils::parseFloat($input['exchange_rate']) : 1;
-        $expense->exchange_rate = round($rate, 4);
+        $expense->exchange_rate = round($rate, 14);
         if (isset($input['amount'])) {
             $expense->amount = round(Utils::parseFloat($input['amount']), 2);
         }

--- a/database/migrations/2020_01_06_132500_increase_exchange_rate_precision.php
+++ b/database/migrations/2020_01_06_132500_increase_exchange_rate_precision.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class IncreaseExchangeRatePrecision extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('payments', function ($table) {
+            $table->decimal('exchange_rate', 23, 14)->change();
+        });
+		Schema::table('expenses', function ($table) {
+            $table->decimal('exchange_rate', 23, 14)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('payments', function ($table) {
+            $table->decimal('exchange_rate', 13, 4)->change();
+        });
+		Schema::table('expenses', function ($table) {
+            $table->decimal('exchange_rate', 13, 4)->change();
+        });
+    }
+}

--- a/resources/assets/js/script.js
+++ b/resources/assets/js/script.js
@@ -1008,13 +1008,12 @@ function toggleDatePicker(field) {
 }
 
 function getPrecision(number) {
-  if (roundToPrecision(number, 3) != number) {
-    return 4;
-  } else if (roundToPrecision(number, 2) != number) {
-    return 3;
-  } else {
-    return 2;
+  if (typeof(number) == 'string'){ number = parseFloat(number); }
+  for (let i = 2; i <= 20; i++)
+  {
+    if (roundToPrecision(number, i) === number) { return i; }
   }
+  return 20;
 }
 
 function roundSignificant(number, toString) {
@@ -1031,6 +1030,25 @@ function roundToTwo(number, toString) {
 function roundToFour(number, toString) {
   var val = roundToPrecision(number, 4) || 0;
   return toString ? val.toFixed(4) : val;
+}
+
+function roundExchangeRate(number, toString, amount, convertedAmount) {
+  var val = roundToPrecision(number, 14) || 0;
+  var tmp;
+  var d = 14;
+
+  for (let i = 2; i < 13; i++)
+  {
+    tmp = roundToPrecision(number, i) || 0;
+    if (roundToTwo(amount * tmp) === convertedAmount)
+    {
+        val = tmp;
+        d = i;
+        break;
+    }
+  }
+
+  return toString ? val.toFixed(d) : val;
 }
 
 // https://stackoverflow.com/a/18358056/497368

--- a/resources/views/expenses/edit.blade.php
+++ b/resources/views/expenses/edit.blade.php
@@ -485,7 +485,7 @@
                 write: function(value) {
                     // When changing the converted amount we're updating
                     // the exchange rate rather than change the amount
-                    self.exchange_rate(roundSignificant(NINJA.parseFloat(value) / self.amount()));
+                    self.exchange_rate(roundExchangeRate(NINJA.parseFloat(value) / self.amount(), false, self.amount(), roundToTwo(value)));
                     //self.amount(roundToTwo(value / self.exchange_rate()));
                 }
             }, self);
@@ -498,7 +498,7 @@
                         from: fromCode,
                         to: toCode,
                     });
-                    self.exchange_rate(roundToFour(rate, true));
+                    self.exchange_rate(roundSignificant(rate, true));
                 } else {
                     self.exchange_rate(1);
                 }

--- a/resources/views/payments/edit.blade.php
+++ b/resources/views/payments/edit.blade.php
@@ -316,7 +316,7 @@
             },
             write: function(value) {
                 var amount = NINJA.parseFloat(value) / self.amount();
-                self.exchange_rate(roundSignificant(amount));
+                self.exchange_rate(roundExchangeRate(amount, false, self.amount(), roundToTwo(value)));
             }
         }, self);
 
@@ -329,7 +329,7 @@
                     from: fromCode,
                     to: toCode,
                 });
-                self.exchange_rate(roundToFour(rate, true));
+                self.exchange_rate(roundSignificant(rate, true));
             } else {
                 self.exchange_rate(1);
             }


### PR DESCRIPTION
## Increase exchange rate precision to 14 decimals

I have increased the precision of exchange rates to allow 14 decimal positions. I have chosen 14 decimal positions because it's recommended [here](https://stackoverflow.com/questions/10505312/in-a-currency-exchange-rate-what-is-the-maximum-number-of-decimal-places-used) as a way to catch all possible currency exchanges.

This fixes the aforementioned issue #3196 which occurs when you try to input a converted amount yourself. In my case, I was trying to input the amount on my bank account which was being changed before my eyes because the exchange rate was only 4 decimals long.

## Improve reverse calculation (converted value to exchange rate)

After implementing the fix, I encountered an issue where the full 14 decimals would be used in all cases, even when the same converted amount could be reached with less precision.

This change modifies the calculation of exchange rate to try to do it with as few decimal positions as possible. While 14 decimal positions is the maximum it should not be necessary to store that much except in rare cases.

## Notes

I was able to generate a new "built.js" file but it was not minified. I have not generated any new files from the changes that I made to `resources/assets/js/script.js`, someone else will need to do this.