### PR TITLE
Allow tasks to be associated with products

### DIFF
--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -84,6 +84,14 @@ class Task extends EntityModel
     /**
      * @return mixed
      */
+    public function product()
+    {
+        return $this->belongsTo('App\Models\Product')->withTrashed();
+    }
+
+    /**
+     * @return mixed
+     */
     public function task_status()
     {
         return $this->belongsTo('App\Models\TaskStatus')->withTrashed();
@@ -180,7 +188,9 @@ class Task extends EntityModel
     {
         $value = 0;
 
-        if ($this->project && floatval($this->project->task_rate)) {
+        if ($this->product && $this->product->cost) {
+            $value = $this->product->cost;
+        } elseif ($this->project && floatval($this->project->task_rate)) {
             $value = $this->project->task_rate;
         } elseif ($this->client && floatval($this->client->task_rate)) {
             $value = $this->client->task_rate;

--- a/app/Ninja/Repositories/TaskRepository.php
+++ b/app/Ninja/Repositories/TaskRepository.php
@@ -4,6 +4,7 @@ namespace App\Ninja\Repositories;
 
 use App\Models\Client;
 use App\Models\Project;
+use App\Models\Product;
 use App\Models\Task;
 use App\Models\TaskStatus;
 use Auth;
@@ -25,6 +26,7 @@ class TaskRepository extends BaseRepository
                     ->leftJoin('contacts', 'contacts.client_id', '=', 'clients.id')
                     ->leftJoin('invoices', 'invoices.id', '=', 'tasks.invoice_id')
                     ->leftJoin('projects', 'projects.id', '=', 'tasks.project_id')
+                    ->leftJoin('products', 'products.id', '=', 'tasks.product_id')
                     ->leftJoin('task_statuses', 'task_statuses.id', '=', 'tasks.task_status_id')
                     ->where('tasks.account_id', '=', Auth::user()->account_id)
                     ->where(function ($query) { // handle when client isn't set
@@ -171,6 +173,11 @@ class TaskRepository extends BaseRepository
             } elseif (isset($data['client_id'])) {
                 $task->client_id = $data['client_id'] ? Client::getPrivateId($data['client_id']) : null;
             }
+        }
+
+        if (!empty($data['product_id'])) {
+            $product = Product::scope($data['product_id'])->firstOrFail();
+            $task->product_id = $product->id;
         }
 
         if (isset($data['description'])) {

--- a/database/migrations/2020_01_11_215020_add_task_products.php
+++ b/database/migrations/2020_01_11_215020_add_task_products.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddTaskProducts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tasks', function ($table) {
+            $table->integer('product_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tasks', function ($table) {
+            $table->dropColumn('product_id');
+        });
+    }
+}

--- a/resources/views/invoices/edit.blade.php
+++ b/resources/views/invoices/edit.blade.php
@@ -936,7 +936,8 @@
                     item.notes(task.description);
                     item.qty(task.duration);
 					item.cost(task.cost);
-                    item.task_public_id(task.publicId);
+					item.task_public_id(task.publicId);
+					item.product_key(task.productKey);
                 }
                 model.invoice().has_tasks(true);
 				NINJA.formIsChanged = true;


### PR DESCRIPTION
Hello!

This PR allows tasks to optionally be linked to products, and passes that information along to the invoice when invoices are created from tasks. It:

1. Adds a new `product_id` field the tasks table.
1. Adds an auto-filling Product field to the task entry screen.
1. When an invoice is created from tasks, sets the correct values for service and rate based on the Product.

I did not open an issue, but I believe this fixes already-existing #2721.