### PR TITLE
Fix inconsistency at ProductRepository

### DIFF
--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -178,7 +178,7 @@ class ProductController extends BaseController
      */
     public function store(StoreProductRequest $request)
     {
-        $product = $this->product_repo->save($request, ProductFactory::create(auth()->user()->company()->id, auth()->user()->id));
+        $product = $this->product_repo->save($request->all(), ProductFactory::create(auth()->user()->company()->id, auth()->user()->id));
 
         return $this->itemResponse($product);
     }

--- a/app/Repositories/ProductRepository.php
+++ b/app/Repositories/ProductRepository.php
@@ -23,10 +23,15 @@ class ProductRepository extends BaseRepository
     {
         return Product::class;
     }
-    
-    public function save(Request $request, Product $product) : ?Product
+
+    /**
+     * @param array $data
+     * @param Product $product
+     * @return Product|null
+     */
+    public function save(array $data, Product $product) : ?Product
     {
-        $product->fill($request->input());
+        $product->fill($data);
         $product->save();
 
         return $product;


### PR DESCRIPTION
Why: 
- Most of the repositories (if not all), use array of data as first object when creating.
- During the process of the migration, we will need to create fake request object to  use this repository.

Changes:
- Remove required Request object to be passed
- Use array of data instead