### PR TITLE
Allow vertical scrolling in time tracker

### DIFF
--- a/resources/views/tasks/time_tracker.blade.php
+++ b/resources/views/tasks/time_tracker.blade.php
@@ -123,6 +123,10 @@
 			position: fixed;
 		}
 
+    div#taskForm {
+      overflow-y: auto;
+    }
+
 		.ui-timepicker-wrapper.start-time  {
 			width: 140px !important;
 		}


### PR DESCRIPTION
This PR fixes a simple problem. Some of us start & stop a timer several times per day. Before you know it the entire list of time entries overflows outside of the container and you cannot scroll down to edit entries, save the task or do something else.

![Screenshot from 2020-01-14 17-02-30](https://user-images.githubusercontent.com/28788713/72396311-22f94080-36f1-11ea-95c2-366073c41988.png)

By adding overflow to the task form's container, I am able to scroll and use the interface again.

![Screenshot from 2020-01-14 17-02-55](https://user-images.githubusercontent.com/28788713/72396175-ab2b1600-36f0-11ea-9393-c83bd61e55b8.png)

![Screenshot from 2020-01-14 17-03-05](https://user-images.githubusercontent.com/28788713/72396179-b1b98d80-36f0-11ea-8176-9bae0635c041.png)

This pull request adds a simple CSS rule to time_tracker.blade.php to allow scrolling in the `#taskForm` container.