### PR TITLE
PHP 7.4 fix of Account.php

### DIFF
--- a/app/Models/Account.php
+++ b/app/Models/Account.php
@@ -1123,7 +1123,7 @@ class Account extends Eloquent
         Session::put(SESSION_DATE_FORMAT, $this->date_format ? $this->date_format->format : DEFAULT_DATE_FORMAT);
         Session::put(SESSION_DATE_PICKER_FORMAT, $this->date_format ? $this->date_format->picker_format : DEFAULT_DATE_PICKER_FORMAT);
 
-        $currencyId = ($client && $client->currency_id) ? $client->currency_id : $this->currency_id ?: DEFAULT_CURRENCY;
+        $currencyId = (($client && $client->currency_id) ? $client->currency_id : $this->currency_id) ?: DEFAULT_CURRENCY;
         $locale = ($client && $client->language_id) ? $client->language->locale : ($this->language_id ? $this->Language->locale : DEFAULT_LOCALE);
 
         Session::put(SESSION_CURRENCY, $currencyId);


### PR DESCRIPTION
PHP 7.4 fix - deprecated Unparenthesized options 
"Unparenthesized `a ? b : c ?: d` is deprecated. Use either `(a ? b : c) ?: d` or `a ? b : (c ?: d)`  "