### PR TITLE
Refactor file uploads to support multiple disks

### DIFF
--- a/tests/Integration/UploadFileTest.php
+++ b/tests/Integration/UploadFileTest.php
@@ -40,13 +40,12 @@ class UploadFileTest extends TestCase
 
     public function testFileUploadWorks()
     {
+        $image = UploadedFile::fake()->image('avatar.jpg');
 
-        $document = UploadFile::dispatchNow(UploadedFile::fake()->image('avatar.jpg'), $this->invoice->user, $this->invoice->company, $this->invoice);
+        $document = UploadFile::dispatchNow(
+            $image, UploadFile::IMAGE, $this->invoice->user, $this->invoice->company, $this->invoice
+        );
 
         $this->assertNotNull($document);
-
     }
-
-
-
 }

--- a/tests/Unit/Migration/ImportTest.php
+++ b/tests/Unit/Migration/ImportTest.php
@@ -43,8 +43,6 @@ class ImportTest extends TestCase
 
     }
 
-    }
-
     public function testExceptionOnUnavailableResource()
     {
         $data['panda_bears'] = [


### PR DESCRIPTION
Uploads could be achieved dynamically now, since there is $disk param.

Changelog:
- Added new $disk param into UploadFile job
- Removed `}` which lead to syntax error in ImportTest