### PR TITLE
[PHP 7.4] implode parameter order

### DIFF
--- a/app/Models/Traits/Inviteable.php
+++ b/app/Models/Traits/Inviteable.php
@@ -74,7 +74,7 @@ trait Inviteable
             }
         }
 
-        return $hasValue ? implode($parts, '<br/>') : false;
+        return $hasValue ? implode('<br/>', $part) : false;
     }
 
     /**


### PR DESCRIPTION
In PHP 7.4 `implode` function no longer allows incorrectly placed $glue.

The glue should be the first parameter:
https://wiki.php.net/rfc/deprecations_php_7_4#implode_parameter_order_mix