### PR TITLE
Fixing cancel button.

### DIFF
--- a/resources/views/payments/credit_card.blade.php
+++ b/resources/views/payments/credit_card.blade.php
@@ -632,7 +632,7 @@
     <p>&nbsp;</p>
     <center>
         @if (isset($invitation))
-            {!! Button::normal(strtoupper(trans('texts.cancel')))->large()->asLinkTo($invitation->getLink()) !!}
+            {!! Button::normal(strtoupper(trans('texts.cancel')))->large()->asLinkTo(HTMLUtils::previousUrl('/')) !!}
             &nbsp;&nbsp;
         @endif
 


### PR DESCRIPTION
This fix addresses a bug where if you create a quote and then go into the client portal to add a credit card, the cancel button will take you back to the first quote of the client regardless if it is a draft or not. This will now take you back to the previous page.