### PR TITLE
Importing migration data via HTTP

### DIFF
--- a/app/Http/Controllers/MigrationController.php
+++ b/app/Http/Controllers/MigrationController.php
@@ -184,20 +184,13 @@ class MigrationController extends BaseController
      *       ),
      *     )
      */
-    public function startMigration(UploadMigrationFileRequest $request)
+    public function startMigration(Request $request, Company $company)
     {
-        $file = $request->file('migration')->storeAs(
-            'migrations', $request->file('migration')->getClientOriginalName()
-        );
-
-        if(!auth()->user()->company) 
-            return response()->json(['message' => 'Company doesn\'t exists.'], 402);
-
         if($request->has('force'))
-            $this->purgeCompany(auth()->user()->company);
+            $this->purgeCompany($company);
 
         if(app()->environment() !== 'testing') {
-            StartMigration::dispatchNow($file, auth()->user(), auth()->user()->company);
+            StartMigration::dispatchNow($request->file('migration'), auth()->user(), $company);
         }
 
         return response()->json([], 200);

--- a/app/Http/Requests/Migration/UploadMigrationFileRequest.php
+++ b/app/Http/Requests/Migration/UploadMigrationFileRequest.php
@@ -29,7 +29,7 @@ class UploadMigrationFileRequest extends FormRequest
 
         /** We'll skip mime validation while running tests. */
         if(app()->environment() !== 'testing') {
-            $rules['migration'] = ['required', 'mimes:zip'];
+            $rules['migration'] = ['required', 'file', 'mimes:zip'];
         }
 
         return $rules;

--- a/routes/api.php
+++ b/routes/api.php
@@ -99,7 +99,7 @@ Route::group(['middleware' => ['api_db', 'token_auth', 'locale'], 'prefix' => 'a
 
 		Route::post('migration/purge/{company}', 'MigrationController@purgeCompany')->middleware('password_protected');
 		Route::post('migration/purge_save_settings/{company}', 'MigrationController@purgeCompanySaveSettings')->middleware('password_protected');
-		Route::post('migration/start', 'MigrationController@startMigration')->middleware('password_protected');
+		Route::post('migration/start/{company}', 'MigrationController@startMigration');
 
 		Route::resource('companies', 'CompanyController');// name = (companies. index / create / show / update / destroy / edit
 

--- a/tests/Feature/MigrationTest.php
+++ b/tests/Feature/MigrationTest.php
@@ -116,5 +116,6 @@ class MigrationTest extends TestCase
     //     $response->assertStatus(200);
     //     $this->assertTrue(file_exists(base_path('storage/migrations/migration/migration.json')));
     // }
+    
 
 }


### PR DESCRIPTION
This PR is connected with https://github.com/invoiceninja/invoiceninja/pull/3364 and it is required to make migration possible.

Changes:
- Don't use default company anymore, but the one from the request
- Migration .zip isn't stored anymore, but dispatched to service