### PR TITLE
Refactor save() method to apply DRY for invoices, Quotes & Credits

### DIFF
--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -11,8 +11,15 @@
 
 namespace App\Repositories;
 
+use App\Factory\InvoiceInvitationFactory;
+use App\Factory\QuoteInvitationFactory;
+use App\Jobs\Product\UpdateOrCreateProduct;
 use App\Models\Client;
+use App\Models\ClientContact;
+use App\Models\Invoice;
+use App\Models\InvoiceInvitation;
 use App\Utils\Traits\MakesHash;
+use ReflectionClass;
 
 /**
  *
@@ -157,5 +164,119 @@ class BaseRepository
     public function findByPublicIdsWithTrashed($ids)
     {
         return $this->getInstance()->scope($ids)->withTrashed()->get();
+    }
+
+    public function getInvitationByKey($key)
+	{
+		return InvoiceInvitation::whereRaw("BINARY `key`= ?", [$key])->first();
+	}
+
+    /**
+     * Alternative save used for Invoices, Quotes & Credits.
+     */
+    protected function alternativeSave($data, $model)
+    {
+        $class = new ReflectionClass($model);        
+        $state = [];
+        $resource = explode('\\', $class->name)[2]; /** This will extract 'Invoice' from App\Models\Invoice */
+
+        if ($class->name == 'App\Models\Invoice') {
+            $state['starting_amount'] = $model->amount;
+
+            if (!$model->id) {
+                $client = Client::find($data['client_id']);
+                $model->uses_inclusive_taxes = $client->getSetting('inclusive_taxes');
+            }
+        }
+
+        if ($class->name == 'App\Models\Quote') {
+            $state['starting_amount'] = $model->amount;
+        }
+
+        $model->fill($data);
+        $model->save();
+
+        $invitation_factory_class = sprintf("App\\Factory\\%sInvitationFactory", $resource);
+
+        if (isset($data['client_contacts'])) {
+            foreach ($data['client_contacts'] as $contact) {
+                if ($contact['send_email'] == 1 && is_string($contact['id'])) {
+                    $client_contact = ClientContact::find($this->decodePrimaryKey($contact['id']));
+                    $client_contact->send_email = true;
+                    $client_contact->save();
+                }
+            }
+        }
+
+        if (isset($data['invitations'])) {
+            $invitations = collect($data['invitations']);
+
+            /* Get array of Keys which have been removed from the invitations array and soft delete each invitation */
+            $model->invitations->pluck('key')->diff($invitations->pluck('key'))->each(function ($invitation) {
+                $this->getInvitationByKey($invitation)->delete();
+            });
+
+            foreach ($data['invitations'] as $invitation) {
+                $inv = false;
+
+                if (array_key_exists('key', $invitation)) {
+                    $inv = $this->getInvitationByKey([$invitation['key']]);
+
+                    if($inv)
+                        $inv->forceDelete();
+
+                }
+
+                if (!$inv) {
+
+                    if (isset($invitation['id'])) {
+                        unset($invitation['id']);
+                    }
+
+                    $new_invitation = $invitation_factory_class::create($model->company_id, $model->user_id);
+                    $new_invitation->quote_id = $model->id;
+                    $new_invitation->client_contact_id = $this->decodePrimaryKey($invitation['client_contact_id']);
+                    $new_invitation->save();
+
+                }
+            }
+        }
+
+        $model->load('invitations');
+
+		/* If no invitations have been created, this is our fail safe to maintain state*/
+		if ($model->invitations->count() == 0) {
+			$model->service()->createInvitations();
+		}
+
+		$state['finished_amount'] = $model->amount;
+
+		$model = $model->service()->applyNumber()->save();
+
+        if ($class->name == 'App\Models\Invoice') {
+            
+            if (($state['finished_amount'] != $state['starting_amount']) && ($model->status_id != Invoice::STATUS_DRAFT)) {
+                $model->ledger()->updateInvoiceBalance(($state['finished_amount'] - $state['starting_amount']));
+            }
+
+            if ($model->company->update_products !== false) {
+                UpdateOrCreateProduct::dispatch($model->line_items, $model, $model->company);
+            }
+
+            $model = $model->calc()->getInvoice();
+
+        }
+
+        if ($class->name == 'App\Models\Credit') {
+            $model = $model->calc()->getCredit();
+        }
+        
+        if ($class->name == 'App\Models\Credit') {
+            $model = $model->calc()->getQuote();
+        }
+
+        $model->save();
+
+		return $model->fresh();
     }
 }

--- a/app/Repositories/BaseRepository.php
+++ b/app/Repositories/BaseRepository.php
@@ -271,7 +271,7 @@ class BaseRepository
             $model = $model->calc()->getCredit();
         }
         
-        if ($class->name == 'App\Models\Credit') {
+        if ($class->name == 'App\Models\Quote') {
             $model = $model->calc()->getQuote();
         }
 

--- a/app/Services/Credit/ApplyNumber.php
+++ b/app/Services/Credit/ApplyNumber.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\Credit;
 
-use App\Credit;
+use App\Models\Credit;
 use App\Events\Payment\PaymentWasCreated;
 use App\Factory\PaymentFactory;
 use App\Jobs\Customer\UpdateCustomerBalance;

--- a/app/Services/Credit/CreditService.php
+++ b/app/Services/Credit/CreditService.php
@@ -1,7 +1,7 @@
 <?php
 namespace App\Services\Credit;
 
-use App\Credit;
+use App\Models\Credit;
 
 class CreditService
 {


### PR DESCRIPTION
Save method inside repositories use this pattern now:
```php
public function save($data, Invoice $invoice):?Invoice
{
	return $this->alternativeSave($data, $invoice);
}
```
Reason, I didn't remove method completely is because `save()` is BaseRepository will mix up with save in other repositories. 

I've was working checking the code, against this tests:
![image](https://user-images.githubusercontent.com/13711415/75363216-16eccb00-58ba-11ea-947b-4c908e2efdd3.png)
