### PR TITLE
Remove 'documents' when company is deleted

### DIFF
--- a/app/Events/Company/CompanyWasDeleted.php
+++ b/app/Events/Company/CompanyWasDeleted.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Events\Company;
+
+use App\Models\Company;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class CompanyWasDeleted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var Company
+     */
+    public $company;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param Company $company
+     */
+    public function __construct(Company $company)
+    {
+        $this->company = $company;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Jobs/Util/UploadFile.php
+++ b/app/Jobs/Util/UploadFile.php
@@ -33,10 +33,10 @@ class UploadFile implements ShouldQueue
 
     const PROPERTIES = [
         self::IMAGE => [
-            'path' => 'public/images',
+            'path' => 'images',
         ],
         self::DOCUMENT => [
-            'path' => 'public/documents',
+            'path' => 'documents',
         ]
     ];
 
@@ -66,8 +66,13 @@ class UploadFile implements ShouldQueue
      */
     public function handle() : ?Document
     {
+        $path = self::PROPERTIES[$this->type]['path'];
+
+        if ($this->company)
+            $path = sprintf('%s/%s', $this->company->company_key, self::PROPERTIES[$this->type]['path']);
+
         $instance = Storage::disk($this->disk)->putFileAs(
-            self::PROPERTIES[$this->type]['path'], $this->file, $this->file->hashName() 
+            $path, $this->file, $this->file->hashName()
         );
 
         if (in_array($this->file->extension(), ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'tiff', 'psd'])) {
@@ -110,7 +115,7 @@ class UploadFile implements ShouldQueue
         if (empty(Document::$types[$documentType])) {
             return 'Unsupported file type';
         }
-        
+
         $preview = '';
 
         if (in_array($this->file->getClientOriginalExtension(), ['jpg', 'jpeg', 'png', 'gif', 'bmp', 'tiff', 'psd'])) {

--- a/app/Listeners/Document/DeleteCompanyDocuments.php
+++ b/app/Listeners/Document/DeleteCompanyDocuments.php
@@ -34,8 +34,8 @@ class DeleteCompanyDocuments
         // Remove all files & folders, under company's path.
         // This will delete directory itself, as well.
         // In case we want to remove the content of folder, we should use $fs->cleanDirectory();
-        $fs = new Filesystem();
-        $fs->deleteDirectory($path);
+        $filesystem = new Filesystem();
+        $filesystem->deleteDirectory($path);
 
         Document::whereCompanyId($event->company->id)->delete();
     }

--- a/app/Listeners/Document/DeleteCompanyDocuments.php
+++ b/app/Listeners/Document/DeleteCompanyDocuments.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Listeners\Document;
+
+use App\Events\Company\CompanyWasDeleted;
+use App\Models\Document;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Storage;
+
+class DeleteCompanyDocuments
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param CompanyWasDeleted $event
+     * @return void
+     */
+    public function handle(CompanyWasDeleted $event)
+    {
+        $path = sprintf('%s/%s', storage_path('app/public'), $event->company->company_key);
+
+        // Remove all files & folders, under company's path.
+        // This will delete directory itself, as well.
+        // In case we want to remove the content of folder, we should use $fs->cleanDirectory();
+        $fs = new Filesystem();
+        $fs->deleteDirectory($path);
+
+        Document::whereCompanyId($event->company->id)->delete();
+    }
+}

--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -12,6 +12,7 @@
 namespace App\Models;
 
 use App\DataMapper\CompanySettings;
+use App\Events\Company\CompanyWasDeleted;
 use App\Models\Account;
 use App\Models\Client;
 use App\Models\CompanyGateway;
@@ -65,6 +66,10 @@ class Company extends BaseModel
         const ENTITY_RECURRING_QUOTE = 'recurring_quote';
 
     protected $presenter = 'App\Models\Presenters\CompanyPresenter';
+
+    protected $dispatchesEvents = [
+        'deleted' => CompanyWasDeleted::class,
+    ];
 
     protected $fillable = [
         'fill_products',
@@ -367,6 +372,6 @@ class Company extends BaseModel
         //else the env variable for selfhosted
         //
         return $this->slack_webhook_url;
-        
+
     }
 }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -12,6 +12,7 @@
 namespace App\Providers;
 
 use App\Events\Client\ClientWasCreated;
+use App\Events\Company\CompanyWasDeleted;
 use App\Events\Contact\ContactLoggedIn;
 use App\Events\Credit\CreditWasMarkedSent;
 use App\Events\Invoice\InvoiceWasCreated;
@@ -32,6 +33,7 @@ use App\Listeners\Activity\PaymentDeletedActivity;
 use App\Listeners\Activity\PaymentRefundedActivity;
 use App\Listeners\Activity\PaymentVoidedActivity;
 use App\Listeners\Contact\UpdateContactLastLogin;
+use App\Listeners\Document\DeleteCompanyDocuments;
 use App\Listeners\Invoice\CreateInvoiceActivity;
 use App\Listeners\Invoice\CreateInvoiceHtmlBackup;
 use App\Listeners\Invoice\CreateInvoiceInvitation;
@@ -61,7 +63,7 @@ class EventServiceProvider extends ServiceProvider
             ], // [3]
             \Codedge\Updater\Events\UpdateSucceeded::class => [
                 \Codedge\Updater\Listeners\SendUpdateSucceededNotification::class
-            ], 
+            ],
         UserWasCreated::class => [
             SendVerificationNotification::class,
         ],
@@ -106,7 +108,7 @@ class EventServiceProvider extends ServiceProvider
 
         CreditWasMarkedSent::class => [
         ],
-        
+
         //Invoices
         InvoiceWasMarkedSent::class => [
             CreateInvoiceHtmlBackup::class,
@@ -131,9 +133,12 @@ class EventServiceProvider extends ServiceProvider
         ],
 
         InvitationWasViewed::class => [
-            InvitationViewedListener::class        
+            InvitationViewedListener::class
         ],
-        
+
+        CompanyWasDeleted::class => [
+            DeleteCompanyDocuments::class,
+        ],
     ];
 
     /**

--- a/tests/Unit/CompanyDocumentsTest.php
+++ b/tests/Unit/CompanyDocumentsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Jobs\Util\UploadFile;
+use App\Models\Document;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Support\Facades\Storage;
+use Tests\MockAccountData;
+use Tests\TestCase;
+
+class CompanyDocumentsTest extends TestCase
+{
+    use MockAccountData;
+    use DatabaseTransactions;
+
+    public function setUp() :void
+    {
+        parent::setUp();
+
+        $this->makeTestData();
+
+        $this->withoutMiddleware(
+            ThrottleRequests::class
+        );
+    }
+
+
+    public function testCompanyDocumentExists()
+    {
+        $original_count = Document::whereCompanyId($this->company->id)->count();
+
+        $image = UploadedFile::fake()->image('avatar.jpg');
+
+        $document = UploadFile::dispatchNow(
+            $image, UploadFile::IMAGE, $this->user, $this->company, $this->invoice
+        );
+
+        $this->assertNotNull($document);
+
+        $this->assertGreaterThan($original_count, Document::whereCompanyId($this->company->id)->count());
+
+        $company_key = $this->company->company_key;
+
+        $this->company->delete();
+
+        $this->assertEquals(0, Document::whereCompanyId($this->company->id)->count());
+
+        $path = sprintf('%s/%s', storage_path('app/public'), $company_key);
+
+        $this->assertFalse(file_exists($path));
+    }
+}


### PR DESCRIPTION
Summary:
Company will now raise an event `ComapanyWasDeleted` **after** deletion. `DeleteCompanyDocuments` will listen for it and delete all documents.

![image](https://user-images.githubusercontent.com/13711415/76216092-45e73300-6210-11ea-84ac-42532b04d582.png)
