### PR TITLE
[V1] Update payment fields for export

### DIFF
--- a/app/Traits/GenerateMigrationResources.php
+++ b/app/Traits/GenerateMigrationResources.php
@@ -506,6 +506,8 @@ trait GenerateMigrationResources
                 'transaction_reference' => $payment->transaction_reference,
                 'payer_id' => $payment->payer_id,
                 'is_deleted' => $payment->is_deleted,
+                'exchange_rate' => $payment->exchange_rate ? number_format((float)$payment->exchange_rate, 6) : null,
+                'exchange_currency_id' => $payment->exchange_currency_id,
                 'updated_at' => $payment->updated_at ? $payment->updated_at->toDateString() : null,
                 'created_at' => $payment->created_at ? $payment->created_at->toDateString() : null,
                 'deleted_at' => $payment->deleted_at ? $payment->deleted_at->toDateString() : null,

--- a/app/Traits/GenerateMigrationResources.php
+++ b/app/Traits/GenerateMigrationResources.php
@@ -508,6 +508,7 @@ trait GenerateMigrationResources
                 'is_deleted' => $payment->is_deleted,
                 'exchange_rate' => $payment->exchange_rate ? number_format((float)$payment->exchange_rate, 6) : null,
                 'exchange_currency_id' => $payment->exchange_currency_id,
+                'currency_id' => $payment->client->currency->id,
                 'updated_at' => $payment->updated_at ? $payment->updated_at->toDateString() : null,
                 'created_at' => $payment->created_at ? $payment->created_at->toDateString() : null,
                 'deleted_at' => $payment->deleted_at ? $payment->deleted_at->toDateString() : null,


### PR DESCRIPTION
So we needed to export:
- exchange_rate
- currency_id
- exchange_currency_id

from version 1 to 2. However, I was unable to find `currency_id` inside of payments table (version 1).

> Edit: I used `$payment->client->currency->id` as `currency_id` for v2.

Note: Please check the formatting of `exchange_rate` before merging.