### PR TITLE
[V1] Update 'migrations:export' message

### DIFF
--- a/app/Console/Commands/ExportMigrations.php
+++ b/app/Console/Commands/ExportMigrations.php
@@ -17,14 +17,14 @@ class ExportMigrations extends Command
      *
      * @var string
      */
-    protected $signature = 'migrations:export';
+    protected $signature = 'migrations:export {--user=}';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Export account migrations to folder';
+    protected $description = 'Export account migrations to folder.';
 
     /**
      * Create a new command instance.
@@ -45,39 +45,51 @@ class ExportMigrations extends Command
     {
         $this->info('Note: Migrations will be stored inside of (storage/migrations) folder.');
 
-        foreach (User::all() as $user) {
-            $this->account = $user->account;
-
-            $date = date('Y-m-d');
-            $accountKey = $this->account->account_key;
-
-            $output = fopen('php://output', 'w') or Utils::fatalError();
-
-            $fileName = "{$accountKey}-{$date}-invoiceninja";
-
-            $data = [
-                'company' => $this->getCompany(),
-                'users' => $this->getUsers(),
-                'tax_rates' => $this->getTaxRates(),
-                'clients' => $this->getClients(),
-                'products' => $this->getProducts(),
-                'invoices' => $this->getInvoices(),
-                'quotes' => $this->getQuotes(),
-                'payments' => array_merge($this->getPayments(), $this->getCredits()),
-                'credits' => $this->getCreditsNotes(),
-                'documents' => $this->getDocuments(),
-                'company_gateways' => $this->getCompanyGateways(),
-                'client_gateway_tokens' => $this->getClientGatewayTokens(),
-            ];
-
-            $file = storage_path("migrations/{$fileName}.zip");
-
-            $zip = new \ZipArchive();
-            $zip->open($file, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-            $zip->addFromString('migration.json', json_encode($data, JSON_PRETTY_PRINT));
-            $zip->close();
-
-            $this->info('User with id #'. $user->id . ' exported.');
+        if($this->option('user')) {
+            $record = User::findOrFail($this->option('user'));
+            return $this->export($record);
         }
+
+        $users = User::all();
+
+        foreach($users as $user) {
+            $this->export($user);
+        }
+    }
+
+    private function export($user)
+    {
+        $this->account = $user->account;
+
+        $date = date('Y-m-d');
+        $accountKey = $this->account->account_key;
+
+        $output = fopen('php://output', 'w') or Utils::fatalError();
+
+        $fileName = "{$accountKey}-{$date}-invoiceninja";
+
+        $data = [
+            'company' => $this->getCompany(),
+            'users' => $this->getUsers(),
+            'tax_rates' => $this->getTaxRates(),
+            'clients' => $this->getClients(),
+            'products' => $this->getProducts(),
+            'invoices' => $this->getInvoices(),
+            'quotes' => $this->getQuotes(),
+            'payments' => array_merge($this->getPayments(), $this->getCredits()),
+            'credits' => $this->getCreditsNotes(),
+            'documents' => $this->getDocuments(),
+            'company_gateways' => $this->getCompanyGateways(),
+            'client_gateway_tokens' => $this->getClientGatewayTokens(),
+        ];
+
+        $file = storage_path("migrations/{$fileName}.zip");
+
+        $zip = new \ZipArchive();
+        $zip->open($file, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
+        $zip->addFromString('migration.json', json_encode($data, JSON_PRETTY_PRINT));
+        $zip->close();
+
+        $this->info('User with id #' . $user->id . ' exported.');
     }
 }

--- a/app/Console/Commands/ExportMigrations.php
+++ b/app/Console/Commands/ExportMigrations.php
@@ -43,6 +43,8 @@ class ExportMigrations extends Command
      */
     public function handle()
     {
+        $this->info('Note: Migrations will be stored inside of (storage/migrations) folder.');
+
         foreach (User::all() as $user) {
             $this->account = $user->account;
 


### PR DESCRIPTION
Changes: 
- Added message for the migrations export location
- Added user option.

In case you run: `php artisan migrations:export', it will export all of accounts.
However, you can specify the user with ID using:

`php artisan migrations:export --user=1`. 
