### PR TITLE
Import migrations from the folder massively

### DIFF
--- a/app/Console/Commands/ImportMigrations.php
+++ b/app/Console/Commands/ImportMigrations.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\DataMapper\CompanySettings;
+use App\Jobs\Util\StartMigration;
+use App\Models\Account;
+use App\Models\Company;
+use App\Models\CompanyToken;
+use App\Models\User;
+use App\Utils\Traits\MakesHash;
+use Faker\Factory;
+use Illuminate\Console\Command;
+
+class ImportMigrations extends Command
+{
+    use MakesHash;
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'migrations:import {--path=}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Massively import the migrations.';
+
+    /**
+     * @var \Faker\Generator
+     */
+    private $faker;
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->faker = Factory::create();
+
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $path = $this->option('path') ?? storage_path('migrations/import');
+
+        $directory = new \DirectoryIterator($path);
+
+        foreach ($directory as $file) {
+            if ($file->getExtension() === 'zip') {
+                $this->info('Started processing: ' . $file->getBasename() . ' at ' . now());
+                StartMigration::dispatch('migrations/import/' . $file->getFilename(), $this->getUser(), $this->getUser()->companies()->first());
+            }
+        }
+    }
+
+    private function getUser(): User
+    {
+        $user = factory(\App\Models\User::class)->create([
+            'email' => $this->faker->email,
+            'confirmation_code' => $this->createDbHash(config('database.default'))
+        ]);
+
+        $account = $this->getAccount();
+        $company = $this->getCompany($account);
+
+        $company_token = CompanyToken::create([
+            'user_id' => $user->id,
+            'company_id' => $company->id,
+            'account_id' => $account->id,
+            'name' => 'test token',
+            'token' => \Illuminate\Support\Str::random(64),
+        ]);
+
+        $user->companies()->attach($company->id, [
+            'account_id' => $account->id,
+            'is_owner' => 1,
+            'is_admin' => 1,
+            'is_locked' => 0,
+            'notifications' => CompanySettings::notificationDefaults(),
+            'permissions' => '',
+            'settings' => null,
+        ]);
+
+        return $user;
+    }
+
+    private function getAccount(): Account
+    {
+        return factory(\App\Models\Account::class)->create();
+    }
+
+    private function getCompany(Account $account): Company
+    {
+        $company = factory(Company::class)->create([
+            'account_id' => $account->id,
+        ]);
+
+        $account->default_company_id = $company->id;
+        $account->save();
+
+        return $company;
+    }
+}

--- a/app/Jobs/Util/StartMigration.php
+++ b/app/Jobs/Util/StartMigration.php
@@ -44,7 +44,7 @@ class StartMigration implements ShouldQueue
      */
     public function __construct($filepath, User $user, Company $company)
     {
-        $this->filepath = base_path("public/storage/$filepath");
+        $this->filepath = base_path("storage/$filepath");
         $this->user = $user;
         $this->company = $company;
     }


### PR DESCRIPTION
Summary:
We can use `php artisan migrations:import` to massively import migration archives.