### PR TITLE
Fix broken 'force' migration:

### DIFF
--- a/app/Console/Commands/ImportMigrations.php
+++ b/app/Console/Commands/ImportMigrations.php
@@ -65,7 +65,7 @@ class ImportMigrations extends Command
         }
     }
 
-    private function getUser(): User
+    public function getUser(): User
     {
         $user = factory(\App\Models\User::class)->create([
             'email' => $this->faker->email,
@@ -96,12 +96,12 @@ class ImportMigrations extends Command
         return $user;
     }
 
-    private function getAccount(): Account
+    public function getAccount(): Account
     {
         return factory(\App\Models\Account::class)->create();
     }
 
-    private function getCompany(Account $account): Company
+    public function getCompany(Account $account): Company
     {
         $company = factory(Company::class)->create([
             'account_id' => $account->id,

--- a/app/Http/Controllers/MigrationController.php
+++ b/app/Http/Controllers/MigrationController.php
@@ -226,8 +226,6 @@ class MigrationController extends BaseController
         $migration_file = $request->file('migration')
             ->storeAs('migrations', $request->file('migration')->getClientOriginalName());
 
-        // return response(200);
-
         if (app()->environment() == 'testing') return;
 
         StartMigration::dispatch(base_path("storage/app/public/$migration_file"), $user, $company);

--- a/app/Jobs/Util/StartMigration.php
+++ b/app/Jobs/Util/StartMigration.php
@@ -44,7 +44,7 @@ class StartMigration implements ShouldQueue
      */
     public function __construct($filepath, User $user, Company $company)
     {
-        $this->filepath = base_path("storage/$filepath");
+        $this->filepath = $filepath;
         $this->user = $user;
         $this->company = $company;
     }


### PR DESCRIPTION
Summary:
If user selects 'force' when migrating, it will wipe the company with all its relations, generate a brand new and attach the account property.

Changes:
-  Uploaded migration file now has to be passed with abs path