### PR TITLE
Use aboslute path for the migration archive

### DIFF
--- a/app/Console/Commands/ImportMigrations.php
+++ b/app/Console/Commands/ImportMigrations.php
@@ -60,7 +60,7 @@ class ImportMigrations extends Command
         foreach ($directory as $file) {
             if ($file->getExtension() === 'zip') {
                 $this->info('Started processing: ' . $file->getBasename() . ' at ' . now());
-                StartMigration::dispatch('migrations/import/' . $file->getFilename(), $this->getUser(), $this->getUser()->companies()->first());
+                StartMigration::dispatch($file->getRealPath(), $this->getUser(), $this->getUser()->companies()->first());
             }
         }
     }

--- a/app/Jobs/Util/StartMigration.php
+++ b/app/Jobs/Util/StartMigration.php
@@ -44,7 +44,7 @@ class StartMigration implements ShouldQueue
      */
     public function __construct($filepath, User $user, Company $company)
     {
-        $this->filepath = base_path("storage/$filepath");
+        $this->filepath = $filepath;
         $this->user = $user;
         $this->company = $company;
     }


### PR DESCRIPTION
Since we removed the relative path attributes, this had to be fixed as well, plus it looks cleaner with method.

Summary:
StartMigration used to accept relative paths, but since some of migrations are uploaded via HTTP and stored under public/ folder and we have this part of application that uses something else, best scenario is to change the method to accept absolute path.