### PR TITLE
Fixes for "Pay now" with invoices

### DIFF
--- a/app/Http/Controllers/ClientPortal/PaymentController.php
+++ b/app/Http/Controllers/ClientPortal/PaymentController.php
@@ -90,7 +90,9 @@ class PaymentController extends Controller
         });
 
         if ($invoices->count() == 0) {
-            return back()->with(['warning' => 'No payable invoices selected']);
+            return redirect()
+                ->route('client.invoices.index')
+                ->with(['warning' => 'No payable invoices selected.']);
         }
 
         $invoices->map(function ($invoice) {

--- a/app/Http/Controllers/ClientPortal/PaymentController.php
+++ b/app/Http/Controllers/ClientPortal/PaymentController.php
@@ -75,11 +75,11 @@ class PaymentController extends Controller
      * The request will also contain the amount
      * and invoice ids for reference.
      *
-     * @return void
+     * @return \Illuminate\Http\RedirectResponse|mixed
      */
     public function process()
     {
-        $invoices = Invoice::whereIn('id', $this->transformKeys(explode(",", request()->input('hashed_ids'))))
+        $invoices = Invoice::whereIn('id', $this->transformKeys(request()->invoices))
                                 ->whereClientId(auth()->user()->client->id)
                                 ->get();
 
@@ -98,6 +98,7 @@ class PaymentController extends Controller
             $invoice->due_date = $this->formatDate($invoice->due_date, $invoice->client->date_format());
             return $invoice;
         });
+
 
         $payment_methods = auth()->user()->client->getPaymentMethods($amount);
 

--- a/resources/js/clients/invoices/payment.js
+++ b/resources/js/clients/invoices/payment.js
@@ -16,6 +16,8 @@ class Payment {
     }
 
     handleMethodSelect(element) {
+        document.getElementById('company_gateway_id').value = element.dataset.companyGatewayId;
+        document.getElementById('payment_method_id').value = element.dataset.gatewayTypeId;
 
         if (this.shouldDisplaySignature && !this.shouldDisplayTerms) {
             this.displayTerms();

--- a/resources/views/portal/ninja2020/invoices/payment.blade.php
+++ b/resources/views/portal/ninja2020/invoices/payment.blade.php
@@ -10,7 +10,9 @@
 @section('body')
     <form action="{{ route('client.payments.process') }}" method="post" id="payment-form">
         @csrf
-        <input type="hidden" name="hashed_ids" value="{!! $hashed_ids !!}" id="hashed_ids">
+        @foreach($invoices as $invoice)
+            <input type="hidden" name="invoices[]" value="{{ $invoice->hashed_id }}">
+        @endforeach
         <input type="hidden" name="company_gateway_id" id="company_gateway_id">
         <input type="hidden" name="payment_method_id" id="payment_method_id">
     </form>
@@ -51,7 +53,7 @@
                         </div>
                     </div>
                 </div>
-    
+
                 @foreach($invoices as $invoice)
                     <div class="bg-white shadow overflow-hidden sm:rounded-lg mb-4">
                         <div class="px-4 py-5 border-b border-gray-200 sm:px-6">


### PR DESCRIPTION
- Changed the input from $hashed_ids to invoices[] as an array
- Fixes for payment.js

Summary:
Previously we were sending an array of invoice hash_ids as big object, now we do that with array support. Code is cleaner and more maintainable. 