### PR TITLE
Fix missing word in Digital Ocean documentation

### DIFF
--- a/docs/digital_ocean.rst
+++ b/docs/digital_ocean.rst
@@ -30,7 +30,7 @@ FAQ:
 
 Q: My emails are not being delivered.
 
-A: Most likely you have not configured a mail service and have set up the built in Postfix server. We creating a Mailgun account and entering your credentials under Settings -> System Settings -> Email Settings.
+A: Most likely you have not configured a mail service and have set up the built in Postfix server. We suggest creating a Mailgun account and entering your credentials under Settings -> System Settings -> Email Settings.
 
 Q: Do I need to create a database on the server?
 


### PR DESCRIPTION
Simple one. 
I was looking through documentation and noticed that Question 1 of the FAQ reads "We creating a Mailgun account and entering your credentials under Settings -> System Settings -> Email Settings. I added the word "suggest" to complete the sentence in a way that I thought made sense (and was probably intended).