### PR TITLE
Allow custom scripts to be injected

### DIFF
--- a/resources/views/portal/ninja2020/layout/app.blade.php
+++ b/resources/views/portal/ninja2020/layout/app.blade.php
@@ -62,11 +62,11 @@
     {{-- Feel free to push anything to header using @push('header') --}}
     @stack('head')
 
-    {!! $client->company->getSetting('portal.custom_head') !!}
+    {!! $client->getSetting('portal.custom_head') !!}
 
     <style>
         /** Any custom defined styles from admin portal go here. */
-        {!! $client->company->getSetting('portal.custom_css') !!}
+        {!! $client->getSetting('portal.custom_css') !!}
     </style>
 </head>
 
@@ -80,12 +80,12 @@
     @yield('footer')
     @stack('footer')
 
-    {!! $client->company->getSetting('portal.custom_footer') !!}
+    {!! $client->getSetting('portal.custom_footer') !!}
 </footer>
 
 <script>
     // .. Any custom definied scripts from admin portal go here.
-    {!! $client->company->getSetting('portal.custom_js') !!}
+    {!! $client->getSetting('portal.custom_js') !!}
 </script>
 
 </html>

--- a/resources/views/portal/ninja2020/layout/app.blade.php
+++ b/resources/views/portal/ninja2020/layout/app.blade.php
@@ -1,76 +1,91 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
-    <head>
+<head>
 
-        <!-- Source: https://github.com/invoiceninja/invoiceninja -->
-        <!-- Error: {{ session('error') }} -->
+    <!-- Source: https://github.com/invoiceninja/invoiceninja -->
+    <!-- Error: {{ session('error') }} -->
 
-        @if (config('services.analytics.tracking_id'))
-            <script async src="https://www.googletagmanager.com/gtag/js?id=UA-122229484-1"></script>
-            <script>
-                window.dataLayer = window.dataLayer || [];
+    @if (config('services.analytics.tracking_id'))
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-122229484-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
 
-                function gtag() {
-                    dataLayer.push(arguments);
-                }
+            function gtag() {
+                dataLayer.push(arguments);
+            }
 
-                gtag('js', new Date());
-                gtag('config', '{{ config('services.analytics.tracking_id') }}', {'anonymize_ip': true});
+            gtag('js', new Date());
+            gtag('config', '{{ config('
+                services.analytics.tracking_id ') }}', {
+                    'anonymize_ip': true
+                });
 
-                function trackEvent(category, action) {
-                    ga('send', 'event', category, action, this.src);
-                }
-            </script>
-            <script>
-                Vue.config.devtools = true;
-            </script>
-        @else
-            <script>
-                function gtag() {
-                }
-            </script>
-        @endif
+            function trackEvent(category, action) {
+                ga('send', 'event', category, action, this.src);
+            }
+        </script>
+        <script>
+            Vue.config.devtools = true;
+        </script>
+    @else
+        <script>
+            function gtag() {}
+        </script>
+    @endif
 
-        <!-- Title -->
-        <title>@yield('meta_title', 'Invoice Ninja') — {{ config('app.name') }}</title>
+    <!-- Title -->
+    <title>@yield('meta_title', 'Invoice Ninja') — {{ config('app.name') }}</title>
 
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="@yield('meta_description')"/>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="@yield('meta_description')" />
 
-        <!-- CSRF Token -->
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+    <!-- CSRF Token -->
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <!-- Scripts -->
-        <script src="{{ mix('js/app.js') }}" defer></script>
-        <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
-        <script src="https://kit.fontawesome.com/8a87eb8352.js" crossorigin="anonymous"></script>
+    <!-- Scripts -->
+    <script src="{{ mix('js/app.js') }}" defer></script>
+    <script src="https://cdn.jsdelivr.net/gh/alpinejs/alpine@v2.x.x/dist/alpine.js" defer></script>
+    <script src="https://kit.fontawesome.com/8a87eb8352.js" crossorigin="anonymous"></script>
 
-        <!-- Fonts -->
-        <link rel="dns-prefetch" href="https://fonts.gstatic.com">
-        <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet" type="text/css">
+    <!-- Fonts -->
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet" type="text/css">
 
-        <!-- Styles -->
-        <link href="{{ mix('css/app.css') }}" rel="stylesheet">
-        {{-- <link href="{{ mix('favicon.png') }}" rel="shortcut icon" type="image/png"> --}}
+    <!-- Styles -->
+    <link href="{{ mix('css/app.css') }}" rel="stylesheet">
+    {{-- <link href="{{ mix('favicon.png') }}" rel="shortcut icon" type="image/png"> --}}
 
-        <link rel="canonical" href="{{ config('ninja.site_url') }}/{{ request()->path() }}"/>
+    <link rel="canonical" href="{{ config('ninja.site_url') }}/{{ request()->path() }}" />
 
-        {{-- Feel free to push anything to header using @push('header') --}}
-        @stack('head')
+    {{-- Feel free to push anything to header using @push('header') --}}
+    @stack('head')
 
-    </head>
+    {!! $client->company->getSetting('portal.custom_head') !!}
 
-    <body class="antialiased">
-        @component('portal.ninja2020.components.general.sidebar.main')
-            @yield('body')
-        @endcomponent
-    </body>
+    <style>
+        /** Any custom defined styles from admin portal go here. */
+        {!! $client->company->getSetting('portal.custom_css') !!}
+    </style>
+</head>
 
-    <footer>
-        @yield('footer')
-        @stack('footer')
-    </footer>
+<body class="antialiased">
+    @component('portal.ninja2020.components.general.sidebar.main')
+        @yield('body')
+    @endcomponent
+</body>
+
+<footer>
+    @yield('footer')
+    @stack('footer')
+
+    {!! $client->company->getSetting('portal.custom_footer') !!}
+</footer>
+
+<script>
+    // .. Any custom definied scripts from admin portal go here.
+    {!! $client->company->getSetting('portal.custom_js') !!}
+</script>
 
 </html>

--- a/resources/views/portal/ninja2020/layout/clean.blade.php
+++ b/resources/views/portal/ninja2020/layout/clean.blade.php
@@ -61,10 +61,10 @@
     {{-- Feel free to push anything to header using @push('header') --}}
     @stack('head')
 
-    {!! $client->company->getSetting('portal.custom_head') !!}
+    {!! $client->getSetting('portal.custom_head') !!}
 
     <style>
-        {!! $client->company->getSetting('portal.custom_css') !!}
+        {!! $client->getSetting('portal.custom_css') !!}
     </style>
 </head>
 
@@ -76,12 +76,12 @@
     @yield('footer')
     @stack('footer')
 
-    {!! $client->company->getSetting('portal.custom_footer') !!}
+    {!! $client->getSetting('portal.custom_footer') !!}
 </footer>
 
 <script>
     // .. Any custom definied scripts from admin portal go here.
-    {!! $client->company->getSetting('portal.custom_js') !!}
+    {!! $client->getSetting('portal.custom_js') !!}
 </script>
 
 </html>

--- a/resources/views/portal/ninja2020/layout/clean.blade.php
+++ b/resources/views/portal/ninja2020/layout/clean.blade.php
@@ -1,73 +1,87 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 
-    <head>
+<head>
 
-        <!-- Source: https://github.com/invoiceninja/invoiceninja -->
-        <!-- Error: {{ session('error') }} -->
+    <!-- Source: https://github.com/invoiceninja/invoiceninja -->
+    <!-- Error: {{ session('error') }} -->
 
-        @if (config('services.analytics.tracking_id'))
-            <script async src="https://www.googletagmanager.com/gtag/js?id=UA-122229484-1"></script>
-            <script>
-                window.dataLayer = window.dataLayer || [];
+    @if (config('services.analytics.tracking_id'))
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-122229484-1"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
 
-                function gtag() {
-                    dataLayer.push(arguments);
-                }
+        function gtag() {
+            dataLayer.push(arguments);
+        }
 
-                gtag('js', new Date());
-                gtag('config', '{{ config('services.analytics.tracking_id') }}', {'anonymize_ip': true});
+        gtag('js', new Date());
+        gtag('config', '{{ config('
+            services.analytics.tracking_id ') }}', {
+                'anonymize_ip': true
+            });
 
-                function trackEvent(category, action) {
-                    ga('send', 'event', category, action, this.src);
-                }
-            </script>
-            <script>
-                Vue.config.devtools = true;
-            </script>
-        @else
-            <script>
-                function gtag() {
-                }
-            </script>
-        @endif
+        function trackEvent(category, action) {
+            ga('send', 'event', category, action, this.src);
+        }
+    </script>
+    <script>
+        Vue.config.devtools = true;
+    </script>
+    @else
+    <script>
+        function gtag() {}
+    </script>
+    @endif
 
-        <!-- Title -->
-        <title>@yield('meta_title', 'Invoice Ninja') | {{ config('app.name') }}</title>
+    <!-- Title -->
+    <title>@yield('meta_title', 'Invoice Ninja') | {{ config('app.name') }}</title>
 
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="@yield('meta_description')"/>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="@yield('meta_description')" />
 
-        <!-- CSRF Token -->
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+    <!-- CSRF Token -->
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        <!-- Scripts -->
-        <script src="{{ mix('js/app.js') }}" defer></script>
-        <script src="https://kit.fontawesome.com/8a87eb8352.js" crossorigin="anonymous"></script>
+    <!-- Scripts -->
+    <script src="{{ mix('js/app.js') }}" defer></script>
+    <script src="https://kit.fontawesome.com/8a87eb8352.js" crossorigin="anonymous"></script>
 
-        <!-- Fonts -->
-        <link rel="dns-prefetch" href="https://fonts.gstatic.com">
-        <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet" type="text/css">
+    <!-- Fonts -->
+    <link rel="dns-prefetch" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans&display=swap" rel="stylesheet" type="text/css">
 
-        <!-- Styles -->
-        <link href="{{ mix('css/app.css') }}" rel="stylesheet">
-        {{-- <link href="{{ mix('favicon.png') }}" rel="shortcut icon" type="image/png"> --}}
+    <!-- Styles -->
+    <link href="{{ mix('css/app.css') }}" rel="stylesheet">
+    {{-- <link href="{{ mix('favicon.png') }}" rel="shortcut icon" type="image/png"> --}}
 
-        <link rel="canonical" href="{{ config('ninja.app_url') }}/{{ request()->path() }}"/>
+    <link rel="canonical" href="{{ config('ninja.app_url') }}/{{ request()->path() }}" />
 
-        {{-- Feel free to push anything to header using @push('header') --}}
-        @stack('head')
+    {{-- Feel free to push anything to header using @push('header') --}}
+    @stack('head')
 
-    </head>
+    {!! $client->company->getSetting('portal.custom_head') !!}
 
-    <body class="antialiased">
-        @yield('body')
-    </body>
+    <style>
+        {!! $client->company->getSetting('portal.custom_css') !!}
+    </style>
+</head>
 
-    <footer>
-        @yield('footer')
-        @stack('footer')
-    </footer>
+<body class="antialiased">
+    @yield('body')
+</body>
+
+<footer>
+    @yield('footer')
+    @stack('footer')
+
+    {!! $client->company->getSetting('portal.custom_footer') !!}
+</footer>
+
+<script>
+    // .. Any custom definied scripts from admin portal go here.
+    {!! $client->company->getSetting('portal.custom_js') !!}
+</script>
 
 </html>


### PR DESCRIPTION
Summary:
Added yields/sections for custom markup.

Available setting keys:
- portal.custom_head
- portal.custom_css
- portal.custom_footer
- portal.custom_js

Note: These are available on both `clean` & `app` layout for client portal.
Note 2: These keys are attached to $client->company->settings.

(Clean is used on pages like password reset, login, etc)