### PR TITLE
fixed bug with contact key and authed user clash

### DIFF
--- a/app/Http/Requests/EntityRequest.php
+++ b/app/Http/Requests/EntityRequest.php
@@ -49,8 +49,10 @@ class EntityRequest extends Request
 
         //Support Client Portal Scopes
         $accountId = false;
-
-        if(Input::get('account_id'))
+  
+        if($this->user()->account_id)
+            $accountId = $this->user()->account_id;
+        elseif(Input::get('account_id'))
             $accountId = Input::get('account_id');
         elseif($contact = Contact::getContactIfLoggedIn())
             $accountId = $contact->account->id;


### PR DESCRIPTION
If a contact key is set and a user is also logged in. this was causing the account id to be set to that of the contact, not the authed user. broke multi-account setups.