### PR TITLE
Fix status filters

### DIFF
--- a/app/Http/Livewire/InvoicesTable.php
+++ b/app/Http/Livewire/InvoicesTable.php
@@ -31,7 +31,6 @@ class InvoicesTable extends Component
     public function render()
     {
         $query = Invoice::query()
-            ->where('company_id', auth('contact')->user()->company->id)
             ->orderBy($this->sort_field, $this->sort_asc ? 'asc' : 'desc');
 
         if (in_array('paid', $this->status)) {
@@ -48,7 +47,9 @@ class InvoicesTable extends Component
                 ->orWhere('partial_due_date', '<', Carbon::now());
         }
 
-        $query = $query->paginate($this->per_page);
+        $query = $query
+            ->where('company_id', auth('contact')->user()->company->id)
+            ->paginate($this->per_page);
 
         return render('components.livewire.invoices-table', [
             'invoices' => $query,

--- a/app/Http/Livewire/QuotesTable.php
+++ b/app/Http/Livewire/QuotesTable.php
@@ -27,9 +27,8 @@ class QuotesTable extends Component
     public function render()
     {
         $query = Quote::query()
-            ->orderBy($this->sort_field, $this->sort_asc ? 'asc' : 'desc')
-            ->where('company_id', auth('contact')->user()->company->id);
-        
+            ->orderBy($this->sort_field, $this->sort_asc ? 'asc' : 'desc');
+
         if (in_array('draft', $this->status)) {
             $query = $query->orWhere('status_id', Quote::STATUS_DRAFT);
         }
@@ -46,7 +45,9 @@ class QuotesTable extends Component
             $query = $query->orWhere('status_id', Quote::STATUS_EXPIRED);
         }
 
-        $query = $query->paginate($this->per_page);
+        $query = $query
+            ->where('company_id', auth('contact')->user()->company->id)
+            ->paginate($this->per_page);
 
         return render('components.livewire.quotes-table', [
             'quotes' => $query


### PR DESCRIPTION
For whatever reason, it works when we put where at the end of the query instead of the top. I love PHP.

(Livewire sorting wasn't working on invoices/quotes table)