### PR TITLE
Add StackOverflow, fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,10 @@
 
 ## [Hosted](https://www.invoiceninja.com) | [Self-Hosted](https://www.invoiceninja.org)
 
-### We're on Slack, join us at [slack.invoiceninja.com](http://slack.invoiceninja.com)
+### We're on Slack, join us at [slack.invoiceninja.com](http://slack.invoiceninja.com) or if you like [StackOverflow](https://stackoverflow.com/tags/invoice-ninja/
+) better you can find us there as well.  
+Just make sure to add the `invoice-ninja` tag to your question.
+
 
 #### We are currently looking for co-mainteners for the [dockerfiles repository](https://github.com/invoiceninja/dockerfiles), if you're interested please let us know
 
@@ -19,8 +22,9 @@ The self-host zip includes all third party libraries whereas downloading the cod
 
 * [Features](https://www.invoiceninja.com/invoicing-features/)
 * [Videos](https://www.youtube.com/channel/UCXAHcBvhW05PDtWYIq7WDFA/videos)
-* [User Guide](https://invoice-ninja.readthedocs.io/en/latest/)
+* [User Guide](https://docs.invoiceninja.com/)
 * [Support Forum](https://www.invoiceninja.com/forums/forum/support/)
+* [StackOverflow](https://stackoverflow.com/tags/invoice-ninja/)
 
 ## Referral Program
 * Earn 50% of Pro & Enterprise Plans up to 4 years - [Learn more](https://www.invoiceninja.com/referral-program/)
@@ -32,7 +36,7 @@ The self-host zip includes all third party libraries whereas downloading the cod
 
 ## Installation Options
 * [Ansible](https://github.com/invoiceninja/ansible-installer)
-* [Self-Host Zip](https://invoice-ninja.readthedocs.io/en/latest/install.html)
+* [Self-Host Zip](https://docs.invoiceninja.com/install.html)
 * [Docker File](https://hub.docker.com/r/invoiceninja/invoiceninja/)
 * [Cloudron](https://cloudron.io/store/com.invoiceninja.cloudronapp.html)
 * [Softaculous](https://www.softaculous.com/apps/ecommerce/Invoice_Ninja)


### PR DESCRIPTION
User can ask questions on SO - just make sure to include the `invoice-ninja` tag.
Some links to the documentation were broken and let to a 404 page. 