### PR TITLE
Import correct Document class into HasLogo trait.

### DIFF
--- a/app/Models/Traits/HasLogo.php
+++ b/app/Models/Traits/HasLogo.php
@@ -4,6 +4,7 @@ namespace App\Models\Traits;
 
 use Utils;
 use Illuminate\Support\Facades\Storage;
+use App\Models\Document;
 
 /**
  * Class HasLogo.


### PR DESCRIPTION
Dupe of #3711 as requested.
---
If you aren't using the local driver for logo storage, the attempts to use Document::getDirectFileUrl in this file will fail as it tries to autoload from Traits, Document needs to be explicitly imported.

The function calls in question:

https://github.com/invoiceninja/invoiceninja/blob/509ba80c5c06d6d3b8a63c6698df3133f7d6756b/app/Models/Traits/HasLogo.php#L94

https://github.com/invoiceninja/invoiceninja/blob/509ba80c5c06d6d3b8a63c6698df3133f7d6756b/app/Models/Traits/HasLogo.php#L109