### PR TITLE
Require password update if not set when confirming email

### DIFF
--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -3224,5 +3224,5 @@ return [
     'year_invalid' => 'Provided year is not valid.',
 
     'if_you_need_help' => 'If you need help you can either post to our',
-    'update_password_on_confirm' => 'After updating your password, your account will be confirmed.',
+    'update_password_on_confirm' => 'After updating password, your account will be confirmed.',
 ];

--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -3224,4 +3224,5 @@ return [
     'year_invalid' => 'Provided year is not valid.',
 
     'if_you_need_help' => 'If you need help you can either post to our',
+    'update_password_on_confirm' => 'After updating your password, your account will be confirmed.',
 ];

--- a/resources/views/themes/ninja2020/auth/confirmation_with_password.blade.php
+++ b/resources/views/themes/ninja2020/auth/confirmation_with_password.blade.php
@@ -1,0 +1,43 @@
+@extends('portal.ninja2020.layout.clean')
+@section('meta_title', ctrans('texts.set_password'))
+
+@section('body')
+    <div class="flex h-screen">
+        <div class="m-auto md:w-1/3 lg:w-1/5">
+            <div class="flex flex-col">
+                <img src="{{ asset('images/invoiceninja-black-logo-2.png') }}" class="border-b border-gray-100 h-18 pb-4" alt="Invoice Ninja logo">
+                <h1 class="text-center text-3xl mt-10">{{ ctrans('texts.set_password') }}</h1>
+                <span class="text-gray-900 text-sm text-center">{{ ctrans('texts.update_password_on_confirm') }}</span>
+
+                <form action="{{ url()->current() }}" method="post" class="mt-6">
+                    @csrf
+                    <div class="flex flex-col mt-4">
+                        <label for="password" class="input-label">{{ ctrans('texts.password') }}</label>
+                        <input type="password" name="password" id="password"
+                               class="input"
+                               autofocus>
+                        @error('password')
+                        <div class="validation validation-fail">
+                            {{ $message }}
+                        </div>
+                        @enderror
+                    </div>
+                    <div class="flex flex-col mt-4">
+                        <label for="password" class="input-label">{{ ctrans('texts.password') }}</label>
+                        <input type="password" name="password_confirmation" id="password_confirmation"
+                               class="input"
+                               autofocus>
+                        @error('password_confirmation')
+                        <div class="validation validation-fail">
+                            {{ $message }}
+                        </div>
+                        @enderror
+                    </div>
+                    <div class="mt-5">
+                        <button class="button button-primary button-block">{{ ctrans('texts.update') }}</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/themes/ninja2020/auth/confirmation_with_password.blade.php
+++ b/resources/views/themes/ninja2020/auth/confirmation_with_password.blade.php
@@ -23,7 +23,7 @@
                         @enderror
                     </div>
                     <div class="flex flex-col mt-4">
-                        <label for="password" class="input-label">{{ ctrans('texts.password') }}</label>
+                        <label for="password" class="input-label">{{ ctrans('texts.password_confirmation') }}</label>
                         <input type="password" name="password_confirmation" id="password_confirmation"
                                class="input"
                                autofocus>

--- a/resources/views/themes/ninja2020/auth/passwords/reset.blade.php
+++ b/resources/views/themes/ninja2020/auth/passwords/reset.blade.php
@@ -38,7 +38,7 @@
                         @enderror
                     </div>
                     <div class="flex flex-col mt-4">
-                        <label for="password" class="input-label">{{ ctrans('texts.password') }}</label>
+                        <label for="password" class="input-label">{{ ctrans('texts.password_confirmation') }}</label>
                         <input type="password" name="password_confirmation" id="password_confirmation"
                                class="input"
                                autofocus>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,4 +30,5 @@ Route::post('password/reset', 'Auth\ResetPasswordController@reset')->name('passw
  */
 Route::group(['middleware' => ['url_db']], function () {
     Route::get('/user/confirm/{confirmation_code}', 'UserController@confirm');
+    Route::post('/user/confirm/{confirmation_code}', 'UserController@confirmWithPassword');
 });


### PR DESCRIPTION
Summary:
If the password is empty or null, the user will be prompted to update it when confirming the account. If everything is set, the account will be confirmed without any prompt.

This is how it looks like:
![image](https://user-images.githubusercontent.com/13711415/85856634-a3e85800-b7b8-11ea-8c88-644e0cda6a04.png)

