### PR TITLE
Fixes for Cypress tests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
     "video": false,
-    "baseUrl": "http://ninja.test:8000/"
+    "baseUrl": "http://invoiceninja.wip/"
 }

--- a/cypress/integration/client_portal/credits.spec.js
+++ b/cypress/integration/client_portal/credits.spec.js
@@ -14,7 +14,7 @@ describe('Credits', () => {
         cy.visit('/client/credits');
 
         cy.get('body')
-            .find('h3')
+            .find('span')
             .first()
             .should('contain.text', 'Credits');
     });

--- a/cypress/integration/client_portal/invoices.spec.js
+++ b/cypress/integration/client_portal/invoices.spec.js
@@ -14,7 +14,7 @@ context('Invoices', () => {
         cy.visit('/client/invoices');
 
         cy.get('body')
-            .find('h3')
+            .find('span')
             .first()
             .should('contain.text', 'Invoices');
     });

--- a/cypress/integration/client_portal/login.spec.js
+++ b/cypress/integration/client_portal/login.spec.js
@@ -39,7 +39,7 @@ context('Login', () => {
                             .click();
                         cy.location().should(location => {
                             expect(location.pathname).to.eq(
-                                '/client/dashboard'
+                                '/client/invoices'
                             );
                         });
                     });

--- a/cypress/integration/client_portal/payment_methods.spec.js
+++ b/cypress/integration/client_portal/payment_methods.spec.js
@@ -14,18 +14,9 @@ context('Payment methods', () => {
         cy.visit('/client/payment_methods');
 
         cy.get('body')
-            .find('h3')
+            .find('span')
             .first()
             .should('contain.text', 'Payment Method');
-    });
-
-    it('should show add payment method button', () => {
-        cy.visit('/client/payment_methods');
-
-        cy.get('body')
-            .find('a.button.button-primary')
-            .first()
-            .should('contain.text', 'Add Payment Method');
     });
 
     it('should have per page options dropdown', () => {

--- a/cypress/integration/client_portal/payments.spec.js
+++ b/cypress/integration/client_portal/payments.spec.js
@@ -14,7 +14,7 @@ context('Payments', () => {
         cy.visit('/client/payments');
 
         cy.get('body')
-            .find('h3')
+            .find('span')
             .first()
             .should('contain.text', 'Payments');
     });

--- a/cypress/integration/client_portal/quotes.spec.js
+++ b/cypress/integration/client_portal/quotes.spec.js
@@ -14,7 +14,7 @@ describe('Quotes', () => {
         cy.visit('/client/quotes');
 
         cy.get('body')
-            .find('h3')
+            .find('span')
             .first()
             .should('contain.text', 'Quotes');
     });

--- a/cypress/integration/client_portal/recurring_invoices.spec.js
+++ b/cypress/integration/client_portal/recurring_invoices.spec.js
@@ -16,7 +16,7 @@ context('Recurring invoices', () => {
     it('should show reucrring invoices text', () => {
         cy.visit('/client/recurring_invoices');
 
-        cy.get('h3')
+        cy.get('span')
             .first()
             .should('contain.text', 'Recurring Invoices');
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1037,6 +1037,7 @@
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/@cypress/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
             "integrity": "sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=",
+            "dev": true,
             "requires": {
                 "chalk": "^1.1.3",
                 "cli-cursor": "^1.0.2",
@@ -1047,12 +1048,14 @@
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
                 },
                 "chalk": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^2.2.1",
                         "escape-string-regexp": "^1.0.2",
@@ -1064,7 +1067,8 @@
                 "supports-color": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
                 }
             }
         },
@@ -1072,6 +1076,7 @@
             "version": "2.88.5",
             "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.5.tgz",
             "integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+            "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
                 "aws4": "^1.8.0",
@@ -1098,7 +1103,8 @@
                 "qs": {
                     "version": "6.5.2",
                     "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+                    "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+                    "dev": true
                 }
             }
         },
@@ -1106,6 +1112,7 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@cypress/xvfb/-/xvfb-1.2.4.tgz",
             "integrity": "sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==",
+            "dev": true,
             "requires": {
                 "debug": "^3.1.0",
                 "lodash.once": "^4.1.1"
@@ -1139,6 +1146,7 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
             "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
+            "dev": true,
             "requires": {
                 "any-observable": "^0.3.0"
             }
@@ -1201,12 +1209,14 @@
         "@types/sinonjs__fake-timers": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
-            "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA=="
+            "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+            "dev": true
         },
         "@types/sizzle": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
-            "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg=="
+            "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
+            "dev": true
         },
         "@vue/component-compiler-utils": {
             "version": "3.1.1",
@@ -1562,7 +1572,8 @@
         "ansi-escapes": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ=="
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+            "dev": true
         },
         "ansi-html": {
             "version": "0.0.7",
@@ -1585,7 +1596,8 @@
         "any-observable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
-            "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog=="
+            "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+            "dev": true
         },
         "anymatch": {
             "version": "2.0.0",
@@ -1614,7 +1626,8 @@
         "arch": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-            "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
+            "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+            "dev": true
         },
         "argparse": {
             "version": "1.0.10",
@@ -1676,6 +1689,7 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
             }
@@ -1724,7 +1738,8 @@
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+            "dev": true
         },
         "assign-symbols": {
             "version": "1.0.0",
@@ -1757,7 +1772,8 @@
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
         },
         "atob": {
             "version": "2.1.2",
@@ -1781,12 +1797,14 @@
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
         },
         "aws4": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-            "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+            "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+            "dev": true
         },
         "axios": {
             "version": "0.19.2",
@@ -1945,6 +1963,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -2259,7 +2278,8 @@
         "cachedir": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.3.0.tgz",
-            "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw=="
+            "integrity": "sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==",
+            "dev": true
         },
         "call-me-maybe": {
             "version": "1.0.1",
@@ -2338,7 +2358,8 @@
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "chalk": {
             "version": "2.4.2",
@@ -2358,7 +2379,8 @@
         "check-more-types": {
             "version": "2.24.0",
             "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-            "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA="
+            "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+            "dev": true
         },
         "chokidar": {
             "version": "3.4.0",
@@ -2466,7 +2488,8 @@
         "ci-info": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "dev": true
         },
         "cipher-base": {
             "version": "1.0.4",
@@ -2522,6 +2545,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
             "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+            "dev": true,
             "requires": {
                 "restore-cursor": "^1.0.1"
             }
@@ -2530,6 +2554,7 @@
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.5.1.tgz",
             "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
+            "dev": true,
             "requires": {
                 "colors": "^1.1.2",
                 "object-assign": "^4.1.0",
@@ -2540,6 +2565,7 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
             "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+            "dev": true,
             "requires": {
                 "slice-ansi": "0.0.4",
                 "string-width": "^1.0.1"
@@ -2549,6 +2575,7 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
                     "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+                    "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -2557,6 +2584,7 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
                     "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                    "dev": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -2674,12 +2702,14 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
             "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+            "dev": true,
             "optional": true
         },
         "combined-stream": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
@@ -2692,7 +2722,8 @@
         "common-tags": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
+            "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==",
+            "dev": true
         },
         "commondir": {
             "version": "1.0.1",
@@ -3177,6 +3208,7 @@
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/cypress/-/cypress-4.6.0.tgz",
             "integrity": "sha512-vIPXAceRP+Nxvnm/O9ruY9EQaRGmVVybtk9F1sfC9mH3067YbitrdBTynaaLuHFj90p9e0U2ZCV7OkX4x4V/Wg==",
+            "dev": true,
             "requires": {
                 "@cypress/listr-verbose-renderer": "0.4.1",
                 "@cypress/request": "2.88.5",
@@ -3220,12 +3252,14 @@
                 "commander": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.0.tgz",
-                    "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
+                    "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw==",
+                    "dev": true
                 },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
                     "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "dev": true,
                     "requires": {
                         "ms": "^2.1.1"
                     }
@@ -3234,6 +3268,7 @@
                     "version": "1.7.0",
                     "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
                     "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+                    "dev": true,
                     "requires": {
                         "concat-stream": "^1.6.2",
                         "debug": "^2.6.9",
@@ -3245,6 +3280,7 @@
                             "version": "2.6.9",
                             "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                            "dev": true,
                             "requires": {
                                 "ms": "2.0.0"
                             }
@@ -3252,7 +3288,8 @@
                         "ms": {
                             "version": "2.0.0",
                             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
                         }
                     }
                 },
@@ -3260,6 +3297,7 @@
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
                     "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+                    "dev": true,
                     "requires": {
                         "pend": "~1.2.0"
                     }
@@ -3268,6 +3306,7 @@
                     "version": "8.1.0",
                     "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
                     "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.2.0",
                         "jsonfile": "^4.0.0",
@@ -3277,12 +3316,14 @@
                 "has-flag": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
                 },
                 "mkdirp": {
                     "version": "0.5.5",
                     "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
                     "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+                    "dev": true,
                     "requires": {
                         "minimist": "^1.2.5"
                     }
@@ -3290,12 +3331,14 @@
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "7.1.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
                     "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -3304,6 +3347,7 @@
                     "version": "2.10.0",
                     "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
                     "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+                    "dev": true,
                     "requires": {
                         "buffer-crc32": "~0.2.3",
                         "fd-slicer": "~1.1.0"
@@ -3324,6 +3368,7 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -3331,7 +3376,8 @@
         "date-fns": {
             "version": "1.30.1",
             "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-            "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+            "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==",
+            "dev": true
         },
         "de-indent": {
             "version": "1.0.2",
@@ -3477,7 +3523,8 @@
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
         },
         "depd": {
             "version": "1.1.2",
@@ -3634,6 +3681,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -3652,7 +3700,8 @@
         "elegant-spinner": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
-            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4="
+            "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+            "dev": true
         },
         "elliptic": {
             "version": "6.5.2",
@@ -3877,7 +3926,8 @@
         "eventemitter2": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-4.1.2.tgz",
-            "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU="
+            "integrity": "sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=",
+            "dev": true
         },
         "eventemitter3": {
             "version": "4.0.4",
@@ -3964,6 +4014,7 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/executable/-/executable-4.1.1.tgz",
             "integrity": "sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==",
+            "dev": true,
             "requires": {
                 "pify": "^2.2.0"
             },
@@ -3971,14 +4022,16 @@
                 "pify": {
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
                 }
             }
         },
         "exit-hook": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
+            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -4103,7 +4156,8 @@
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -4213,7 +4267,8 @@
         "extsprintf": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+            "dev": true
         },
         "fast-deep-equal": {
             "version": "3.1.1",
@@ -4268,6 +4323,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+            "dev": true,
             "requires": {
                 "escape-string-regexp": "^1.0.5",
                 "object-assign": "^4.1.0"
@@ -4409,12 +4465,14 @@
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
         },
         "form-data": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -5038,6 +5096,7 @@
             "version": "3.1.4",
             "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.4.tgz",
             "integrity": "sha512-UORPzguEB/7UG5hqiZai8f0vQ7hzynMQyJLxStoQ8dPGAcmgsfXOPA4iE/fGtweHYkK+z4zc9V0g+CIFRf5HYw==",
+            "dev": true,
             "requires": {
                 "async": "^3.1.0"
             },
@@ -5045,7 +5104,8 @@
                 "async": {
                     "version": "3.2.0",
                     "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-                    "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw=="
+                    "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+                    "dev": true
                 }
             }
         },
@@ -5053,6 +5113,7 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -5098,6 +5159,7 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+            "dev": true,
             "requires": {
                 "ini": "^1.3.4"
             }
@@ -5204,12 +5266,14 @@
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
         },
         "har-validator": {
             "version": "5.1.3",
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
             "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "dev": true,
             "requires": {
                 "ajv": "^6.5.5",
                 "har-schema": "^2.0.0"
@@ -5450,6 +5514,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -5731,6 +5796,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
             "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+            "dev": true,
             "requires": {
                 "ci-info": "^2.0.0"
             }
@@ -5823,6 +5889,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+            "dev": true,
             "requires": {
                 "global-dirs": "^0.1.0",
                 "is-path-inside": "^1.0.0"
@@ -5832,6 +5899,7 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
                     "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+                    "dev": true,
                     "requires": {
                         "path-is-inside": "^1.0.1"
                     }
@@ -5865,6 +5933,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
             "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
+            "dev": true,
             "requires": {
                 "symbol-observable": "^1.1.0"
             }
@@ -5901,7 +5970,8 @@
         "is-promise": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+            "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+            "dev": true
         },
         "is-regex": {
             "version": "1.0.5",
@@ -5940,7 +6010,8 @@
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -5970,7 +6041,8 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
         },
         "jest-worker": {
             "version": "25.1.0",
@@ -6020,7 +6092,8 @@
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
         },
         "jsesc": {
             "version": "2.5.2",
@@ -6040,7 +6113,8 @@
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
         },
         "json-schema-traverse": {
             "version": "0.4.1",
@@ -6050,7 +6124,8 @@
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
         },
         "json3": {
             "version": "3.3.3",
@@ -6077,6 +6152,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -6181,7 +6257,8 @@
         "lazy-ass": {
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-            "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM="
+            "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+            "dev": true
         },
         "lcid": {
             "version": "2.0.0",
@@ -6208,6 +6285,7 @@
             "version": "0.14.3",
             "resolved": "https://registry.npmjs.org/listr/-/listr-0.14.3.tgz",
             "integrity": "sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==",
+            "dev": true,
             "requires": {
                 "@samverschueren/stream-to-observable": "^0.3.0",
                 "is-observable": "^1.1.0",
@@ -6223,19 +6301,22 @@
                 "p-map": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-                    "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
+                    "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+                    "dev": true
                 }
             }
         },
         "listr-silent-renderer": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
-            "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4="
+            "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+            "dev": true
         },
         "listr-update-renderer": {
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.5.0.tgz",
             "integrity": "sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==",
+            "dev": true,
             "requires": {
                 "chalk": "^1.1.3",
                 "cli-truncate": "^0.2.1",
@@ -6250,12 +6331,14 @@
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
                 },
                 "chalk": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
                     "requires": {
                         "ansi-styles": "^2.2.1",
                         "escape-string-regexp": "^1.0.2",
@@ -6267,12 +6350,14 @@
                 "indent-string": {
                     "version": "3.2.0",
                     "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-                    "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok="
+                    "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+                    "dev": true
                 },
                 "log-symbols": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
                     "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+                    "dev": true,
                     "requires": {
                         "chalk": "^1.0.0"
                     }
@@ -6280,7 +6365,8 @@
                 "supports-color": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
                 }
             }
         },
@@ -6288,6 +6374,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.5.0.tgz",
             "integrity": "sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==",
+            "dev": true,
             "requires": {
                 "chalk": "^2.4.1",
                 "cli-cursor": "^2.1.0",
@@ -6299,6 +6386,7 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
                     "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "dev": true,
                     "requires": {
                         "restore-cursor": "^2.0.0"
                     }
@@ -6307,6 +6395,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
                     "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+                    "dev": true,
                     "requires": {
                         "escape-string-regexp": "^1.0.5"
                     }
@@ -6314,12 +6403,14 @@
                 "mimic-fn": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                    "dev": true
                 },
                 "onetime": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
                     "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "dev": true,
                     "requires": {
                         "mimic-fn": "^1.0.0"
                     }
@@ -6328,6 +6419,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
                     "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "dev": true,
                     "requires": {
                         "onetime": "^2.0.0",
                         "signal-exit": "^3.0.2"
@@ -6382,7 +6474,8 @@
         "lodash.once": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+            "dev": true
         },
         "lodash.toarray": {
             "version": "4.4.0",
@@ -6398,6 +6491,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
             "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+            "dev": true,
             "requires": {
                 "chalk": "^2.4.2"
             }
@@ -6406,6 +6500,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/log-update/-/log-update-2.3.0.tgz",
             "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
+            "dev": true,
             "requires": {
                 "ansi-escapes": "^3.0.0",
                 "cli-cursor": "^2.0.0",
@@ -6415,12 +6510,14 @@
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
                 },
                 "cli-cursor": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
                     "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+                    "dev": true,
                     "requires": {
                         "restore-cursor": "^2.0.0"
                     }
@@ -6428,12 +6525,14 @@
                 "mimic-fn": {
                     "version": "1.2.0",
                     "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+                    "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+                    "dev": true
                 },
                 "onetime": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
                     "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+                    "dev": true,
                     "requires": {
                         "mimic-fn": "^1.0.0"
                     }
@@ -6442,6 +6541,7 @@
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
                     "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+                    "dev": true,
                     "requires": {
                         "onetime": "^2.0.0",
                         "signal-exit": "^3.0.2"
@@ -6451,6 +6551,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
@@ -6459,6 +6560,7 @@
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-3.0.1.tgz",
                     "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
+                    "dev": true,
                     "requires": {
                         "string-width": "^2.1.1",
                         "strip-ansi": "^4.0.0"
@@ -6769,7 +6871,8 @@
         "moment": {
             "version": "2.24.0",
             "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+            "dev": true
         },
         "move-concurrently": {
             "version": "1.0.1",
@@ -6998,7 +7101,8 @@
         "oauth-sign": {
             "version": "0.9.0",
             "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
@@ -7161,7 +7265,8 @@
         "onetime": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+            "dev": true
         },
         "opn": {
             "version": "5.5.0",
@@ -7206,7 +7311,8 @@
         "ospath": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
-            "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs="
+            "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
+            "dev": true
         },
         "p-defer": {
             "version": "1.0.0",
@@ -7400,7 +7506,8 @@
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
         },
         "picomatch": {
             "version": "2.2.2",
@@ -8162,7 +8269,8 @@
         "pretty-bytes": {
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-            "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+            "integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg==",
+            "dev": true
         },
         "pretty-hrtime": {
             "version": "1.0.3",
@@ -8221,7 +8329,8 @@
         "psl": {
             "version": "1.8.0",
             "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+            "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+            "dev": true
         },
         "public-encrypt": {
             "version": "4.0.3",
@@ -8361,7 +8470,8 @@
         "ramda": {
             "version": "0.26.1",
             "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-            "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+            "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
+            "dev": true
         },
         "randombytes": {
             "version": "2.1.0",
@@ -8566,6 +8676,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
             "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+            "dev": true,
             "requires": {
                 "throttleit": "^1.0.0"
             }
@@ -8701,6 +8812,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
             "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+            "dev": true,
             "requires": {
                 "exit-hook": "^1.0.0",
                 "onetime": "^1.0.0"
@@ -8776,6 +8888,7 @@
             "version": "6.5.5",
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.5.tgz",
             "integrity": "sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==",
+            "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
             }
@@ -9073,7 +9186,8 @@
         "slice-ansi": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
-            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU="
+            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+            "dev": true
         },
         "snapdragon": {
             "version": "0.8.2",
@@ -9356,6 +9470,7 @@
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -9583,7 +9698,8 @@
         "symbol-observable": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
+            "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+            "dev": true
         },
         "tailwindcss": {
             "version": "1.4.5",
@@ -9935,7 +10051,8 @@
         "throttleit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-            "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
+            "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+            "dev": true
         },
         "through": {
             "version": "2.3.8",
@@ -9973,6 +10090,7 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
             "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+            "dev": true,
             "requires": {
                 "rimraf": "^2.6.3"
             }
@@ -10034,6 +10152,7 @@
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
             "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "dev": true,
             "requires": {
                 "psl": "^1.1.28",
                 "punycode": "^2.1.1"
@@ -10058,6 +10177,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -10065,7 +10185,8 @@
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
         },
         "type": {
             "version": "1.2.0",
@@ -10229,7 +10350,8 @@
         "untildify": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
-            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw=="
+            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+            "dev": true
         },
         "upath": {
             "version": "1.2.0",
@@ -10344,6 +10466,7 @@
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@babel/plugin-proposal-class-properties": "^7.10.1",
         "laravel-mix-purgecss": "^5.0.0-rc.1",
         "vue-template-compiler": "^2.6.11",
-        "cypress": "^4.6.0",
+        "cypress": "^4.6.0"
     },
     "dependencies": {
         "@tailwindcss/ui": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -8,13 +8,15 @@
         "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
         "prod": "npm run production",
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-        "test": "cypress run"
+        "test": "cypress run",
+        "test:gui": "cypress open"
     },
     "devDependencies": {
         "@babel/compat-data": "7.9.0",
         "@babel/plugin-proposal-class-properties": "^7.10.1",
         "laravel-mix-purgecss": "^5.0.0-rc.1",
-        "vue-template-compiler": "^2.6.11"
+        "vue-template-compiler": "^2.6.11",
+        "cypress": "^4.6.0",
     },
     "dependencies": {
         "@tailwindcss/ui": "^0.1.3",
@@ -22,7 +24,6 @@
         "card-js": "^1.0.13",
         "card-validator": "^6.2.0",
         "cross-env": "^7.0",
-        "cypress": "^4.6.0",
         "jsignature": "^2.1.3",
         "laravel-mix": "^5.0.1",
         "lodash": "^4.17.13",


### PR DESCRIPTION
Changes:
- Cypress is now moved to dev dependencies
- New `test:gui` command


![Screenshot_20200630_150906](https://user-images.githubusercontent.com/13711415/86129887-aa8e0c80-bae3-11ea-9cf6-ecb16ad273dc.png)