### PR TITLE
Adding payment methods from menu

### DIFF
--- a/app/Models/Client.php
+++ b/app/Models/Client.php
@@ -400,6 +400,17 @@ class Client extends BaseModel implements HasLocalePreference
         return null;
     }
 
+    public function getBankTransferMethodType()
+    {
+        if ($this->currency()->code == 'USD') {
+            return GatewayType::BANK_TRANSFER;
+        }
+
+        if ($this->currency()->code == 'EUR') {
+            return GatewayType::SEPA;
+        }
+    }
+
     public function getCurrencyCode()
     {
         if ($this->currency()) {

--- a/app/PaymentDrivers/CheckoutComPaymentDriver.php
+++ b/app/PaymentDrivers/CheckoutComPaymentDriver.php
@@ -82,6 +82,11 @@ class CheckoutComPaymentDriver extends BasePaymentDriver
         }
     }
 
+    public function authorizeView($data)
+    {
+        return render('gateways.checkout.authorize');
+    }
+
     public function processPaymentView(array $data)
     {
         $data['gateway'] = $this;

--- a/app/PaymentDrivers/Stripe/ACH.php
+++ b/app/PaymentDrivers/Stripe/ACH.php
@@ -87,7 +87,7 @@ class ACH
             $client_gateway_token->save();
         }
 
-        return redirect()->route('client.payment_methods.verification', $client_gateway_token->hashed_id);
+        return redirect()->route('client.payment_methods.verification', ['id' => $client_gateway_token->hashed_id, 'method' => GatewayType::BANK_TRANSFER]);
     }
 
     public function verificationView(ClientGatewayToken $token)
@@ -168,7 +168,7 @@ class ACH
             return $this->processUnsuccessfulPayment($state);
         } catch (\Exception $e) {
             if ($e instanceof \Stripe\Exception\CardException) {
-                return redirect()->route('client.payment_methods.verification', ClientGatewayToken::first()->hashed_id);
+                return redirect()->route('client.payment_methods.verification', ['id' => ClientGatewayToken::first()->hashed_id, 'method' => GatewayType::BANK_TRANSFER]);
             }
         }
     }

--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -3234,4 +3234,6 @@ return [
     'enable_only_for_development' => 'Enable only for development',
 
     'test_pdf' => 'Test PDF',
+
+    'checkout_authorize_label' => 'Checkout.com can be can saved as payment method for future use, once you complete your first transaction. Don\'t forget to check "Save card" during payment process.',
 ];

--- a/resources/views/portal/ninja2020/components/livewire/payment-methods-table.blade.php
+++ b/resources/views/portal/ninja2020/components/livewire/payment-methods-table.blade.php
@@ -9,10 +9,24 @@
                 <option>20</option>
             </select>
         </div>
-        @if($client->getCreditCardGateway())
-            <a href="{{ route('client.payment_methods.create') }}" id="add-payment-method"
-               class="button button-primary">{{ ctrans('texts.add_payment_method') }}</a>
-        @endif
+        <div class="relative" x-data="{ open: false }" x-on:click.away="open = false">
+            <button x-on:click="open = !open" class="button button-primary">{{ ctrans('texts.add_payment_method') }}</button>
+            <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="transform opacity-0 scale-95" x-transition:enter-end="transform opacity-100 scale-100" x-transition:leave="transition ease-in duration-75" x-transition:leave-start="transform opacity-100 scale-100" x-transition:leave-end="transform opacity-0 scale-95" class="origin-top-right absolute right-0 mt-2 w-48 rounded-md shadow-lg">
+                <div class="py-1 rounded-md bg-white shadow-xs">
+                    @if($client->getCreditCardGateway())
+                        <a href="{{ route('client.payment_methods.create', ['method' => App\Models\GatewayType::CREDIT_CARD]) }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition ease-in-out duration-150">
+                            {{ ctrans('texts.credit_card') }}
+                        </a>
+                    @endif
+                    
+                    @if($client->getBankTransferGateway())
+                        <a href="{{ route('client.payment_methods.create', ['method' => $client->getBankTransferMethodType()]) }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100 transition ease-in-out duration-150">
+                            {{ ctrans('texts.bank_account') }}
+                        </a>
+                    @endif
+                </div>
+            </div>
+        </div>
     </div>
     <div class="-my-2 py-2 overflow-x-auto sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8">
         <div class="align-middle inline-block min-w-full overflow-hidden rounded">

--- a/resources/views/portal/ninja2020/gateways/checkout/authorize.blade.php
+++ b/resources/views/portal/ninja2020/gateways/checkout/authorize.blade.php
@@ -1,0 +1,19 @@
+@extends('portal.ninja2020.layout.app')
+@section('meta_title', ctrans('texts.checkout_com'))
+
+@section('body')
+    <div class="container mx-auto">
+        <div class="grid grid-cols-6 gap-4">
+            <div class="col-span-6 md:col-start-2 md:col-span-4">
+                <div class="alert alert-failure mb-4" hidden id="errors"></div>
+                <div class="bg-white shadow overflow-hidden sm:rounded-lg">
+                    <div class="bg-white px-4 py-5 sm:px-6 flex items-center">
+                        <dt class="text-sm leading-5 font-medium text-gray-500 mr-4">
+                            {{ ctrans('texts.checkout_authorize_label') }}
+                        </dt>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+@endsection

--- a/resources/views/portal/ninja2020/gateways/stripe/ach/authorize.blade.php
+++ b/resources/views/portal/ninja2020/gateways/stripe/ach/authorize.blade.php
@@ -6,7 +6,7 @@
 @endpush
 
 @section('body')
-    <form action="{{ route('client.payment_methods.store') }}" method="post" id="server_response">
+    <form action="{{ route('client.payment_methods.store', ['method' => App\Models\GatewayType::BANK_TRANSFER]) }}" method="post" id="server_response">
         @csrf
         <input type="hidden" name="company_gateway_id" value="{{ $gateway->id }}">
         <input type="hidden" name="gateway_type_id" value="2">

--- a/resources/views/portal/ninja2020/gateways/stripe/add_credit_card.blade.php
+++ b/resources/views/portal/ninja2020/gateways/stripe/add_credit_card.blade.php
@@ -6,7 +6,7 @@
 @endpush
 
 @section('body')
-    <form action="{{ route('client.payment_methods.store') }}" method="post" id="server_response">
+    <form action="{{ route('client.payment_methods.store', ['method' => App\Models\GatewayType::CREDIT_CARD]) }}" method="post" id="server_response">
         @csrf
         <input type="hidden" name="company_gateway_id" value="{{ $gateway->gateway_id }}">
         <input type="hidden" name="payment_method_id" value="1">


### PR DESCRIPTION
This will let us selectively add payment methods:

Currently supported:
- Credit Card (Stripe)
- Bank account (ACH)

Not implemented:
- SEPA

Not supported (directly):
- SOFORT (one-use-only payments)
- AliPay (can be added after first payment)
- Credit Card (using Checkout, available after first payment)
