### PR TITLE
Update Kanban column to allow vertical scroll

### DIFF
--- a/resources/views/tasks/kanban.blade.php
+++ b/resources/views/tasks/kanban.blade.php
@@ -30,6 +30,8 @@
             vertical-align: top;
             white-space: normal;
             cursor: pointer;
+            max-height:70vh;
+            overflow-y: scroll;
         }
 
         .kanban-column-last {


### PR DESCRIPTION
Update the Kanban Column to allow for vertical scroll with the screen. This makes it easier for your to scroll horizontally when you have a very big list.
It's a quick workaround that fixes user experience for users with small screens and big lists.
