### PR TITLE
Update foooter elements to use new $total_columns

### DIFF
--- a/app/Services/PdfMaker/Designs/Bold.php
+++ b/app/Services/PdfMaker/Designs/Bold.php
@@ -186,28 +186,21 @@ class Bold extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial)], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right text-xl text-teal-600 font-semibold', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            ['element' => 'tr', 'properties' => ['hidden' => 'false'], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 }

--- a/app/Services/PdfMaker/Designs/Business.php
+++ b/app/Services/PdfMaker/Designs/Business.php
@@ -186,28 +186,21 @@ class Business extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial)], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right text-xl text-blue-900 font-semibold', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'px-4 py-2 text-right text-blue-900 font-semibold']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            ['element' => 'tr', 'properties' => ['hidden' => 'false'], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 }

--- a/app/Services/PdfMaker/Designs/Clean.php
+++ b/app/Services/PdfMaker/Designs/Clean.php
@@ -186,28 +186,21 @@ class Clean extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial), 'class' => 'mt-8 px-4 py-2'], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right font-semibold', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            ['element' => 'tr', 'properties' => ['hidden' => 'false'], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 }

--- a/app/Services/PdfMaker/Designs/Creative.php
+++ b/app/Services/PdfMaker/Designs/Creative.php
@@ -186,28 +186,21 @@ class Creative extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+        
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount()), 'class' => 'mt-8 px-4 py-2'], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial), 'class' => 'mt-8 px-4 py-2'], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2 border-t-4 border-pink-700'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'px-4 py-2 text-right font-semibold text-pink-700']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            ['element' => 'tr', 'properties' => ['hidden' => 'false'], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 }

--- a/app/Services/PdfMaker/Designs/Elegant.php
+++ b/app/Services/PdfMaker/Designs/Elegant.php
@@ -187,28 +187,21 @@ class Elegant extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial), 'class' => 'mt-8 px-4 py-2'], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'px-4 text-right text-xl text-green-600 font-semibold', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'px-4 py-2 text-right text-green-600']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            ['element' => 'tr', 'properties' => ['hidden' => 'false'], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 }

--- a/app/Services/PdfMaker/Designs/Hipster.php
+++ b/app/Services/PdfMaker/Designs/Hipster.php
@@ -186,28 +186,21 @@ class Hipster extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'px-4 py-4 text-rightt', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'border-l-2 border-black px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'border-l-2 border-black px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial), 'class' => 'mt-8 px-4 py-2'], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'border-l-2 border-black px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'border-l-2 border-black px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'border-l-2 border-black px-4 py-2 text-right']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'px-4 py-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            ['element' => 'tr', 'properties' => ['hidden' => 'false'], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'border-l-2 border-black px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 }

--- a/app/Services/PdfMaker/Designs/Modern.php
+++ b/app/Services/PdfMaker/Designs/Modern.php
@@ -160,29 +160,22 @@ class Modern extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial)], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2 bg-gray-900 text-white text-xl'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right font-semibold', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            ['element' => 'tr', 'properties' => ['hidden' => 'false'], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 
     public function companyDetails()

--- a/app/Services/PdfMaker/Designs/Plain.php
+++ b/app/Services/PdfMaker/Designs/Plain.php
@@ -135,29 +135,22 @@ class Plain extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 py-4', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial)], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2 bg-gray-300'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            $elements[] = ['element' => 'tr', 'properties' => ['hidden' => 'false'], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 
     public function buildTableHeader(): array

--- a/app/Services/PdfMaker/Designs/Playful.php
+++ b/app/Services/PdfMaker/Designs/Playful.php
@@ -186,28 +186,21 @@ class Playful extends BaseDesign
 
     public function tableFooter()
     {
-        return [
+        $variables = $this->entity->company->settings->pdf_variables->total_columns;
+
+        $elements = [
             ['element' => 'tr', 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(3)]],
-                ['element' => 'td', 'content' => '$subtotal_label', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-4 text-right', 'colspan' => '2']],
-                ['element' => 'td', 'content' => '$subtotal', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getSubTotal()), 'class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
-                ['element' => 'td', 'content' => '$discount_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$discount', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->partial), 'class' => 'mt-8 px-4 py-2'], 'elements' => [
-                ['element' => 'td', 'content' => '$partial_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$partial_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotal())], 'content' => '', 'properties' => ['class' => 'mt-8 px-4 py-2'], 'elements' => [
-                ['element' => 'td', 'content' => '$total_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$total', 'properties' => ['class' => 'px-4 py-2 text-right']],
-            ]],
-            ['element' => 'tr', 'content' => '', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->balance), 'class' => 'mt-8 px-4 py-2'], 'elements' => [
-                ['element' => 'td', 'content' => '$balance_due_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right font-semibold text-teal-600', 'colspan' => $this->calculateColspan(1)]],
-                ['element' => 'td', 'content' => '$balance_due', 'properties' => ['class' => 'px-4 py-2 text-right']],
+                ['element' => 'td', 'content' => '$entity.public_notes', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => '100%']],
             ]],
         ];
+
+        foreach ($variables as $variable) {
+            $elements[] = ['element' => 'tr', 'properties' => ['hidden' => $this->toggleHiddenProperty($this->entity->calc()->getTotalDiscount())], 'content' => '', 'elements' => [
+                ['element' => 'td', 'content' => $variable . '_label', 'properties' => ['class' => 'border-l-4 border-white px-4 text-right', 'colspan' => $this->calculateColspan(1)]],
+                ['element' => 'td', 'content' => $variable, 'properties' => ['class' => 'px-4 py-2 text-right']],
+            ]];
+        }
+
+        return $elements;
     }
 }


### PR DESCRIPTION
Summary:
Instead of hardcoding values, now footer elements are pulled from `total_columns` setting key.
