### PR TITLE
Show taxes/fees on bottom of PDFs

### DIFF
--- a/app/Utils/HtmlEngine.php
+++ b/app/Utils/HtmlEngine.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Invoice Ninja (https://invoiceninja.com).
  *
@@ -108,10 +109,11 @@ class HtmlEngine
         $data['$invoice.due_date'] = &$data['$due_date'];
         $data['$invoice.number'] = ['value' => $this->entity->number ?: '&nbsp;', 'label' => ctrans('texts.invoice_number')];
         $data['$invoice.po_number'] = ['value' => $this->entity->po_number ?: '&nbsp;', 'label' => ctrans('texts.po_number')];
-        $data['$line_taxes'] = ['value' => $this->makeLineTaxes() ?: '&nbsp;', 'label' => ctrans('texts.taxes')];
-        $data['$invoice.line_taxes'] = &$data['$line_taxes'];
-        $data['$total_taxes'] = ['value' => $this->makeTotalTaxes() ?: '&nbsp;', 'label' => ctrans('texts.taxes')];
-        $data['$invoice.total_taxes'] = &$data['$total_taxes'];
+        // $data['$line_taxes'] = ['value' => $this->makeLineTaxes() ?: '&nbsp;', 'label' => ctrans('texts.taxes')];
+        // $data['$invoice.line_taxes'] = &$data['$line_taxes'];
+        
+        // $data['$total_taxes'] = ['value' => $this->makeTotalTaxes() ?: '&nbsp;', 'label' => ctrans('texts.taxes')];
+        // $data['$invoice.total_taxes'] = &$data['$total_taxes'];
 
         if ($this->entity_string == 'invoice') {
             $data['$entity'] = ['value' => '', 'label' => ctrans('texts.invoice')];


### PR DESCRIPTION
This will show taxes on the bottom of PDFs.

Other changes:
- $this->client variable is now available on the main Design class
- $total_taxes & $line_taxes have been moved out from HtmlEngine and processed manually in Design

![image](https://user-images.githubusercontent.com/13711415/92890292-48bd1d80-f417-11ea-85a7-5c1541cc1f46.png)
