### PR TITLE
Fix bug with passing correct $amount when paying for invoices

### DIFF
--- a/resources/views/portal/ninja2020/invoices/payment.blade.php
+++ b/resources/views/portal/ninja2020/invoices/payment.blade.php
@@ -112,7 +112,11 @@
                                     <!-- App\Utils\Number::formatMoney($invoice->amount, $invoice->client) -->
                                     <!-- Disabled input field don't send it's value with request. -->
                                     @if(!$settings->client_portal_allow_under_payment && !$settings->client_portal_allow_over_payment)
-                                        <span class="mt-1 text-sm text-gray-800">{{ App\Utils\Number::formatMoney($invoice->amount, $invoice->client) }}</span>
+                                        <input 
+                                            name="payable_invoices[{{$key}}][amount]" 
+                                            value="{{ $invoice->partial > 0 ? $invoice->partial : $invoice->balance }}"
+                                            class="mt-1 text-sm text-gray-800"
+                                            readonly />
                                     @else
                                         <div class="flex items-center">
                                             <input 


### PR DESCRIPTION
$amount was missing from the request resulting in error 500. This fixes it.