### PR TITLE
(wip) Change Downloads translation to Documents in CP

### DIFF
--- a/app/Http/ViewComposers/PortalComposer.php
+++ b/app/Http/ViewComposers/PortalComposer.php
@@ -65,7 +65,7 @@ class PortalComposer
         $data[] = ['title' => ctrans('texts.quotes'), 'url' => 'client.quotes.index', 'icon' => 'align-left'];
         $data[] = ['title' => ctrans('texts.credits'), 'url' => 'client.credits.index', 'icon' => 'credit-card'];
         $data[] = ['title' => ctrans('texts.payment_methods'), 'url' => 'client.payment_methods.index', 'icon' => 'shield'];
-        $data[] = ['title' => ctrans('texts.downloads'), 'url' => 'client.downloads.index', 'icon' => 'download'];
+        $data[] = ['title' => ctrans('texts.documents'), 'url' => 'client.downloads.index', 'icon' => 'download'];
 
         return $data;
     }

--- a/resources/views/portal/ninja2020/downloads/index.blade.php
+++ b/resources/views/portal/ninja2020/downloads/index.blade.php
@@ -1,5 +1,5 @@
 @extends('portal.ninja2020.layout.app')
-@section('meta_title', ctrans('texts.downloads'))
+@section('meta_title', ctrans('texts.documents'))
 
 @section('header')
     @if($client->getSetting('client_portal_enable_uploads'))


### PR DESCRIPTION
Rename "Downloads" to "Documents" in the client portal.

![image](https://user-images.githubusercontent.com/13711415/94417355-429d9f80-0180-11eb-8538-3c507d80c0b6.png)
