### PR TITLE
(v5) Support for custom products table columns

### DIFF
--- a/app/Http/Controllers/PreviewController.php
+++ b/app/Http/Controllers/PreviewController.php
@@ -113,6 +113,7 @@ class PreviewController extends BaseController
                     'client' => $entity_obj->client,
                     'entity' => $entity_obj,
                     'pdf_variables' => (array) $entity_obj->company->settings->pdf_variables,
+                    'products' => request()->design['design']['product'],
                 ]),
                 'variables' => $html->generateLabelsAndValues(),
             ];
@@ -184,6 +185,7 @@ class PreviewController extends BaseController
                 'client' => $invoice->client,
                 'entity' => $invoice,
                 'pdf_variables' => (array) $invoice->company->settings->pdf_variables,
+                'products' => request()->design['design']['product'],
             ]),
             'variables' => $html->generateLabelsAndValues(),
         ];

--- a/app/Jobs/Invoice/CreateInvoicePdf.php
+++ b/app/Jobs/Invoice/CreateInvoicePdf.php
@@ -94,6 +94,7 @@ class CreateInvoicePdf implements ShouldQueue
                 'client' => $this->invoice->client,
                 'entity' => $this->invoice,
                 'pdf_variables' => (array) $this->invoice->company->settings->pdf_variables,
+                'products' => $design->design->product,
             ]),
             'variables' => $html->generateLabelsAndValues(),
             'options' => [

--- a/app/Jobs/Quote/CreateQuotePdf.php
+++ b/app/Jobs/Quote/CreateQuotePdf.php
@@ -92,6 +92,7 @@ class CreateQuotePdf implements ShouldQueue
                 'client' => $this->quote->client,
                 'entity' => $this->quote,
                 'pdf_variables' => (array) $this->quote->company->settings->pdf_variables,
+                'products' => $design->design->product,
             ]),
             'variables' => $html->generateLabelsAndValues(),
             'options' => [


### PR DESCRIPTION
This will let us write custom table bodies for the products table.

- Add a new "products" key to $context of Design.php
- Add custom products table body handling in Design.php