### PR TITLE
(v5) Show empty string on PDF if country is not set 

### DIFF
--- a/app/Http/Livewire/Profile/Settings/PersonalAddress.php
+++ b/app/Http/Livewire/Profile/Settings/PersonalAddress.php
@@ -53,6 +53,10 @@ class PersonalAddress extends Component
     {
         $data = $this->validate($this->rules);
 
+        if ($data['country_id'] == 'none') {
+            $data['country_id'] = null;
+        }
+
         $this->profile
             ->fill($data)
             ->save();

--- a/app/Http/Livewire/Profile/Settings/ShippingAddress.php
+++ b/app/Http/Livewire/Profile/Settings/ShippingAddress.php
@@ -53,6 +53,10 @@ class ShippingAddress extends Component
     {
         $data = $this->validate($this->rules);
 
+        if ($data['shipping_country_id'] == 'none') {
+            $data['shipping_country_id'] = null;
+        }
+
         $this->profile
             ->fill($data)
             ->save();

--- a/app/Utils/HtmlEngine.php
+++ b/app/Utils/HtmlEngine.php
@@ -111,7 +111,7 @@ class HtmlEngine
         $data['$invoice.po_number'] = ['value' => $this->entity->po_number ?: '&nbsp;', 'label' => ctrans('texts.po_number')];
         // $data['$line_taxes'] = ['value' => $this->makeLineTaxes() ?: '&nbsp;', 'label' => ctrans('texts.taxes')];
         // $data['$invoice.line_taxes'] = &$data['$line_taxes'];
-        
+
         // $data['$total_taxes'] = ['value' => $this->makeTotalTaxes() ?: '&nbsp;', 'label' => ctrans('texts.taxes')];
         // $data['$invoice.total_taxes'] = &$data['$total_taxes'];
 
@@ -217,7 +217,7 @@ class HtmlEngine
         $data['$vat_number'] = ['value' => $this->client->vat_number ?: '&nbsp;', 'label' => ctrans('texts.vat_number')];
         $data['$website'] = ['value' => $this->client->present()->website() ?: '&nbsp;', 'label' => ctrans('texts.website')];
         $data['$phone'] = ['value' => $this->client->present()->phone() ?: '&nbsp;', 'label' => ctrans('texts.phone')];
-        $data['$country'] = ['value' => isset($this->client->country->name) ? $this->client->country->name : 'No Country Set', 'label' => ctrans('texts.country')];
+        $data['$country'] = ['value' => isset($this->client->country->name) ? $this->client->country->name : '', 'label' => ctrans('texts.country')];
         $data['$email'] = ['value' => isset($this->contact) ? $this->contact->email : 'no contact email on record', 'label' => ctrans('texts.email')];
         $data['$client_name'] = ['value' => $this->entity->present()->clientName() ?: '&nbsp;', 'label' => ctrans('texts.client_name')];
         $data['$client.name'] = &$data['$client_name'];
@@ -550,7 +550,7 @@ class HtmlEngine
 }
 
 @media print {
-   thead {display: table-header-group;} 
+   thead {display: table-header-group;}
    tfoot {display: table-footer-group;}
    button {display: none;}
    body {margin: 0;}
@@ -568,7 +568,7 @@ class HtmlEngine
 }
 
 @media print {
-   thead {display: table-header-group;} 
+   thead {display: table-header-group;}
    button {display: none;}
    body {margin: 0;}
 }';

--- a/resources/views/portal/ninja2020/profile/settings/personal-address.blade.php
+++ b/resources/views/portal/ninja2020/profile/settings/personal-address.blade.php
@@ -61,6 +61,7 @@
                         <div class="col-span-6 sm:col-span-2">
                             <label for="country" class="input-label">@lang('texts.country')</label>
                             <select id="country" class="input w-full form-select" wire:model.defer="country_id">
+                                <option value="none"></option>
                                 @foreach($countries as $country)
                                     <option value="{{ $country->id }}">
                                         {{ $country->iso_3166_2 }} ({{ $country->name }})

--- a/resources/views/portal/ninja2020/profile/settings/shipping-address.blade.php
+++ b/resources/views/portal/ninja2020/profile/settings/shipping-address.blade.php
@@ -61,7 +61,8 @@
                             </div>
                             <div class="col-span-4 sm:col-span-2">
                                 <label for="shipping_country" class="input-label">@lang('texts.shipping_country')</label>
-                                <select id="shippking_country" class="input w-full form-select" wire:model.defer="shipping_country_id">
+                                <select id="shipping_country" class="input w-full form-select" wire:model.defer="shipping_country_id">
+                                    <option value="none"></option>
                                     @foreach($countries as $country)
                                     <option value="{{ $country->id }}">
                                         {{ $country->iso_3166_2 }} ({{ $country->name }})


### PR DESCRIPTION
- Replace "No country set" with empty string in HtmlEngine.php
- Allow country_id & shipping_country_id to be null in shipping-address.blade.php & personal-address.blade.php