### PR TITLE
Remove blank lines from pdf content when designated pdf variables are empty

### DIFF
--- a/app/Services/PdfMaker/Design.php
+++ b/app/Services/PdfMaker/Design.php
@@ -125,7 +125,7 @@ class Design extends BaseDesign
         $elements = [];
 
         foreach ($variables as $variable) {
-            $elements[] = ['element' => 'p', 'content' => $variable];
+            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false];
         }
 
         return $elements;
@@ -138,7 +138,7 @@ class Design extends BaseDesign
         $elements = [];
 
         foreach ($variables as $variable) {
-            $elements[] = ['element' => 'p', 'content' => $variable];
+            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false];
         }
 
         return $elements;
@@ -151,7 +151,7 @@ class Design extends BaseDesign
         $elements = [];
 
         foreach ($variables as $variable) {
-            $elements[] = ['element' => 'p', 'content' => $variable];
+            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false];
         }
 
         return $elements;
@@ -170,7 +170,7 @@ class Design extends BaseDesign
         foreach ($variables as $variable) {
             $_variable = explode('.', $variable)[1];
             $_customs = ['custom1', 'custom2', 'custom3', 'custom4'];
-            
+
             if (in_array($_variable, $_customs)) {
                 $elements[] = ['element' => 'tr', 'elements' => [
                     ['element' => 'th', 'content' => $variable . '_label'],

--- a/app/Services/PdfMaker/PdfMaker.php
+++ b/app/Services/PdfMaker/PdfMaker.php
@@ -56,6 +56,10 @@ class PdfMaker
 
     public function build()
     {
+        if (isset($this->data['template']) && isset($this->data['variables'])) {
+          $this->getEmptyElements($this->data['template'], $this->data['variables']);
+        }
+
         if (isset($this->data['template'])) {
             $this->updateElementProperties($this->data['template']);
         }
@@ -72,7 +76,7 @@ class PdfMaker
     public function getCompiledHTML($final = false)
     {
         $html =  $this->document->saveHTML();
-    
+
         return str_replace('%24', '$', $html);
     }
 }

--- a/app/Services/PdfMaker/PdfMakerUtilities.php
+++ b/app/Services/PdfMaker/PdfMakerUtilities.php
@@ -117,8 +117,12 @@ trait PdfMakerUtilities
             // <my-tag /> => true
             // <my-tag> => false
 
-             if (isset($child['content'])) {
-                $contains_html = preg_match("/\/[a-z]*>/i", $child['content'],$m) != 0;
+            if (isset($child['content'])) {
+                if (isset($child['is_empty']) && $child['is_empty'] === true) {
+                    continue;
+                }
+
+                $contains_html = preg_match("/\/[a-z]*>/i", $child['content'], $m) != 0;
             }
 
             if ($contains_html) {
@@ -318,5 +322,28 @@ trait PdfMakerUtilities
             $footer->parentNode->removeChild($footer);
             $this->document->getElementById('repeat-footer')->appendChild($clone);
         }
+    }
+
+    public function getEmptyElements(array &$elements, array $variables) {
+      foreach ($elements as &$element) {
+        if (isset($element['elements'])) {
+          $this->getEmptyChildrens($element['elements'], $variables);
+        }
+      }
+    }
+
+    public function getEmptyChildrens(array &$children, array $variables) {
+      foreach ($children as $key => &$child) {
+        if (isset($child['content']) && isset($child['show_empty']) && $child['show_empty'] === false) {
+          $value = strtr($child['content'], $variables['values']);
+          if ($value === '' || $value === '&nbsp;') {
+            $child['is_empty'] = true;
+          }
+        }
+
+        if (isset($child['elements'])) {
+          $this->getEmptyChildrens($child['elements'], $variables);
+        }
+      }
     }
 }


### PR DESCRIPTION
Remove blank lines from pdf content when designated pdf variables are empty.
Best example : the address2 field no longer displays an empty line if the field is configured to be present on the pdf and is empty.

Can be improved at some points : 
- Define the variables to be checked and to hide if they are empty in a more appropriate place
- Rename functions ?