### PR TITLE
(v5) Use correct formula when adjust_fee_percent=true

### DIFF
--- a/app/Models/CompanyGateway.php
+++ b/app/Models/CompanyGateway.php
@@ -287,7 +287,11 @@ class CompanyGateway extends BaseModel
         }
 
         if ($fees_and_limits->fee_percent) {
-            $fee += round(($amount * $fees_and_limits->fee_percent / 100),2);
+            if ($fees_and_limits->adjust_fee_percent) {
+                $fee += round(($amount / (1 - $fees_and_limits->fee_percent / 100) - $amount),2);
+            } else {
+                $fee += round(($amount * $fees_and_limits->fee_percent / 100),2);
+            }
             info("fee after adding fee percent = {$fee}");
         }
 


### PR DESCRIPTION
The formula introduced in #2324 appears to have been lost among all the various refactors of fee calculations. This PR fixes that.