### PR TITLE
(v5) Support for internally-resolved assets while using Docker

### DIFF
--- a/app/Utils/Helpers.php
+++ b/app/Utils/Helpers.php
@@ -42,11 +42,9 @@ class Helpers
      * Return absolute url to asset based on envinronment.
      *  
      * @param string $path 
-     * @param string $url 
-     * 
      * @return null|string 
      */
-    public static function asset(string $path, string $url = 'app'): ?string
+    public static function asset(string $path): ?string
     {
         if (config('ninja.docker_url')) {
             return config('ninja.docker_url') . parse_url(asset($path), PHP_URL_PATH);

--- a/app/Utils/Helpers.php
+++ b/app/Utils/Helpers.php
@@ -37,4 +37,21 @@ class Helpers
 
         return $elements;
     }
+
+    /**
+     * Return absolute url to asset based on envinronment.
+     *  
+     * @param string $path 
+     * @param string $url 
+     * 
+     * @return null|string 
+     */
+    public static function asset(string $path, string $url = 'app'): ?string
+    {
+        if (config('ninja.docker_url')) {
+            return config('ninja.docker_url') . parse_url(asset($path), PHP_URL_PATH);
+        }
+
+        return asset($path);
+    }
 }

--- a/app/Utils/HtmlEngine.php
+++ b/app/Utils/HtmlEngine.php
@@ -328,7 +328,7 @@ class HtmlEngine
 
         $data['$font_size'] = ['value' => $this->settings->font_size . 'px', 'label' => ''];
 
-        $data['$invoiceninja.whitelabel'] = ['value' => asset('images/created-by-invoiceninja-new.png'), 'label' => ''];
+        $data['$invoiceninja.whitelabel'] = ['value' => Helpers::asset('images/created-by-invoiceninja-new.png'), 'label' => ''];
 
         $data['$primary_color'] = ['value' => $this->settings->primary_color, 'label' => ''];
         $data['$secondary_color'] = ['value' => $this->settings->secondary_color, 'label' => ''];

--- a/config/ninja.php
+++ b/config/ninja.php
@@ -133,4 +133,5 @@ return [
     'designs' => [
         'base_path' => resource_path('views/pdf-designs/'),
     ],
+    'docker_url' => env('DOCKER_URL', false),
 ];


### PR DESCRIPTION
When we know asset might be resolved inside of Docker container (like assets that are rendered using Puppeteer/Browsershot) it is advised to use:

```php
App\Utils\Helpers::asset('invoiceninja.png');
```

Based on my knowledge, we only have Invoice Ninja white-labeled logo needing this at the moment.

In order for this to work inside of Docker, the environment variable must be set.

DOCKER_URL=http://server (https://github.com/invoiceninja/dockerfiles/blob/master/docker-compose.yml#L4)

**Note:** This is only for assets on the local network. For any external network, it should be just fine.

![image](https://user-images.githubusercontent.com/13711415/98961685-22def280-2506-11eb-897d-17a73563397c.png)
