### PR TITLE
(v5) Start migration on v5 with correct data key 

### DIFF
--- a/app/Jobs/Util/StartMigration.php
+++ b/app/Jobs/Util/StartMigration.php
@@ -107,7 +107,7 @@ class StartMigration implements ShouldQueue
 
             $data = json_decode(file_get_contents($file), 1);
 
-            Import::dispatchNow($data, $this->company, $this->user);
+            Import::dispatchNow($data['data'], $this->company, $this->user);
         } catch (NonExistingMigrationFile | ProcessingMigrationArchiveFailed | ResourceNotAvailableForMigration | MigrationValidatorFailed | ResourceDependencyMissing $e) {
 
             Mail::to($this->user)->send(new MigrationFailed($e, $e->getMessage()));


### PR DESCRIPTION
V4 migration JSON looks like this: 

```json
{
    "data": {},
    "force": {}
}
```

It was required to pass $data['data'] in order for the migration class to pickup all resources, otherwise, it was searching for "data" and "force" resources - which is obviously not what we looking for. This fixes it.