### PR TITLE
(v5) Always show invoice total on the PDFs

### DIFF
--- a/app/Services/PdfMaker/Designs/Utilities/DesignHelpers.php
+++ b/app/Services/PdfMaker/Designs/Utilities/DesignHelpers.php
@@ -195,6 +195,11 @@ trait DesignHelpers
         // Extract $invoice.date => date
         // so we can append date as $entity->date and not $entity->$invoice.date;
 
+        // When it comes to invoice balance, we'll always show it.
+        if ($variable == '$invoice.total') {
+            return false;
+        }
+
         try {
             $_variable = explode('.', $variable)[1];
         } catch (Exception $e) {


### PR DESCRIPTION
Previously, if the invoice total was $0 it was hidden.

![image](https://user-images.githubusercontent.com/13711415/99805695-3230f200-2b3d-11eb-9a7c-9b6c9a74b4f8.png)
