### PR TITLE
Call ksort correctly for migration files

### DIFF
--- a/app/Http/Controllers/Migration/StepsController.php
+++ b/app/Http/Controllers/Migration/StepsController.php
@@ -252,9 +252,11 @@ class StepsController extends BaseController
 
             $file = storage_path("migrations/{$fileName}.zip");
 
+            ksort($localMigrationData);
+
             $zip = new \ZipArchive();
             $zip->open($file, \ZipArchive::CREATE | \ZipArchive::OVERWRITE);
-            $zip->addFromString('migration.json', json_encode(ksort($localMigrationData), JSON_PRETTY_PRINT));
+            $zip->addFromString('migration.json', json_encode($localMigrationData, JSON_PRETTY_PRINT));
             $zip->close();
 
             $localMigrationData['file'] = $file;


### PR DESCRIPTION
The migration.json file will always contain 'true' instead of the data string as the return value of ksort serves as the input to the json_encode function. This patch calls ksort before