### PR TITLE
(v5) Fix issue with balance due label

### DIFF
--- a/app/Utils/HtmlEngine.php
+++ b/app/Utils/HtmlEngine.php
@@ -156,10 +156,10 @@ class HtmlEngine
             $data['$balance_due'] = ['value' => Number::formatMoney($this->entity->balance, $this->client) ?: '&nbsp;', 'label' => ctrans('texts.balance_due')];
         }
         
-        $data['$quote.balance_due'] = &$data['$balance_due'];
-        $data['$invoice.balance_due'] = &$data['$balance_due'];
-        $data['$balance_due'] = &$data['$balance_due'];
-        $data['$outstanding'] = &$data['$balance_due'];
+        $data['$quote.balance_due'] = $data['$balance_due'];
+        $data['$invoice.balance_due'] = $data['$balance_due'];
+        $data['$balance_due'] = $data['$balance_due'];
+        $data['$outstanding'] = $data['$balance_due'];
         $data['$partial_due'] = ['value' => Number::formatMoney($this->entity->partial, $this->client) ?: '&nbsp;', 'label' => ctrans('texts.partial_due')];
         $data['$total'] = ['value' => Number::formatMoney($this->entity_calc->getTotal(), $this->client) ?: '&nbsp;', 'label' => ctrans('texts.total')];
         $data['$amount'] = &$data['$total'];


### PR DESCRIPTION
The Balance Due label was showing as Account Balance on the PDF. This fixes it.

![chrome_drScdsd6nm](https://user-images.githubusercontent.com/13711415/101486845-8faaa880-395d-11eb-9e58-1fa7fd5e4a12.png)

Note: There's still "Account balance" in the totals table. That reference comes from $outstanding.