### PR TITLE
(v5) Provide action selectors to match PDF elements

### DIFF
--- a/app/Jobs/Entity/CreateEntityPdf.php
+++ b/app/Jobs/Entity/CreateEntityPdf.php
@@ -157,6 +157,10 @@ class CreateEntityPdf implements ShouldQueue
             info(print_r($e->getMessage(), 1));
         }
 
+        if (config('ninja.log_pdf_html')) {
+            info($maker->getCompiledHTML());
+        }
+
         if ($pdf) {
             $instance = Storage::disk($this->disk)->put($file_path, $pdf);
         }

--- a/app/Services/Invoice/GenerateDeliveryNote.php
+++ b/app/Services/Invoice/GenerateDeliveryNote.php
@@ -88,6 +88,10 @@ class GenerateDeliveryNote
 
         $pdf = $this->makePdf(null, null, $maker->getCompiledHTML());
 
+        if (config('ninja.log_pdf_html')) {
+            info($maker->getCompiledHTML());
+        }
+
         Storage::disk($this->disk)->put($file_path, $pdf);
 
         return $file_path;

--- a/app/Services/PdfMaker/Design.php
+++ b/app/Services/PdfMaker/Design.php
@@ -134,7 +134,7 @@ class Design extends BaseDesign
         $elements = [];
 
         foreach ($variables as $variable) {
-            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false];
+            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false, 'properties' => ['data-ref' => 'company_details-' . substr($variable, 1)]];
         }
 
         return $elements;
@@ -147,7 +147,7 @@ class Design extends BaseDesign
         $elements = [];
 
         foreach ($variables as $variable) {
-            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false];
+            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false, 'properties' => ['data-ref' => 'company_address-' . substr($variable, 1)]];
         }
 
         return $elements;
@@ -159,15 +159,19 @@ class Design extends BaseDesign
 
         if ($this->type == 'delivery_note') {
             $elements = [
-                ['element' => 'p', 'content' => $this->entity->client->name, 'show_empty' => false],
-                ['element' => 'p', 'content' => $this->entity->client->shipping_address1, 'show_empty' => false],
-                ['element' => 'p', 'content' => $this->entity->client->shipping_address2, 'show_empty' => false],
-                ['element' => 'p', 'content' => "{$this->entity->client->shipping_city} {$this->entity->client->shipping_state} {$this->entity->client->shipping_postal_code}", 'show_empty' => false],
+                ['element' => 'p', 'content' => $this->entity->client->name, 'show_empty' => false, 'properties' => ['data-ref' => 'delivery_note-client.name']],
+                ['element' => 'p', 'content' => $this->entity->client->shipping_address1, 'show_empty' => false, 'properties' => ['data-ref' => 'delivery_note-client.shipping_address1']],
+                ['element' => 'p', 'content' => $this->entity->client->shipping_address2, 'show_empty' => false, 'properties' => ['data-ref' => 'delivery_note-client.shipping_address2']],
+                ['element' => 'p', 'show_empty' => false, 'elements' => [
+                    ['element' => 'span', 'content' => "{$this->entity->client->shipping_city} ", 'properties' => ['ref' => 'delivery_note-client.shipping_city']],
+                    ['element' => 'span', 'content' => "{$this->entity->client->shipping_state} ", 'properties' => ['ref' => 'delivery_note-client.shipping_state']],
+                    ['element' => 'span', 'content' => "{$this->entity->client->shipping_postal_code} ", 'properties' => ['ref' => 'delivery_note-client.shipping_postal_code']],
+                ]],
                 ['element' => 'p', 'content' => optional($this->entity->client->shipping_country)->name, 'show_empty' => false],
             ];
 
             if (!is_null($this->context['contact'])) {
-                $elements[] = ['element' => 'p', 'content' => $this->context['contact']->email, 'show_empty' => false];
+                $elements[] = ['element' => 'p', 'content' => $this->context['contact']->email, 'show_empty' => false, 'properties' => ['data-ref' => 'delivery_note-contact.email']];
             }
 
             return $elements;
@@ -176,7 +180,7 @@ class Design extends BaseDesign
         $variables = $this->context['pdf_variables']['client_details'];
 
         foreach ($variables as $variable) {
-            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false];
+            $elements[] = ['element' => 'p', 'content' => $variable, 'show_empty' => false, 'properties' => ['data-ref' => 'client_details-' . substr($variable, 1)]];
         }
 
         return $elements;
@@ -205,13 +209,13 @@ class Design extends BaseDesign
 
             if (in_array($_variable, $_customs)) {
                 $elements[] = ['element' => 'tr', 'elements' => [
-                    ['element' => 'th', 'content' => $variable . '_label'],
-                    ['element' => 'th', 'content' => $variable],
+                    ['element' => 'th', 'content' => $variable . '_label', 'properties' => ['data-ref' => 'entity_details-' . substr($variable, 1) . '_label']],
+                    ['element' => 'th', 'content' => $variable, 'properties' => ['data-ref' => 'entity_details-' . substr($variable, 1)]],
                 ]];
             } else {
                 $elements[] = ['element' => 'tr', 'properties' => ['hidden' => $this->entityVariableCheck($variable)], 'elements' => [
-                    ['element' => 'th', 'content' => $variable . '_label'],
-                    ['element' => 'th', 'content' => $variable],
+                    ['element' => 'th', 'content' => $variable . '_label', 'properties' => ['data-ref' => 'entity_details-' . substr($variable, 1) . '_label']],
+                    ['element' => 'th', 'content' => $variable, 'properties' => ['data-ref' => 'entity_details-' . substr($variable, 1)]],
                 ]];
             }
         }
@@ -225,16 +229,14 @@ class Design extends BaseDesign
             return [];
         }
 
-        $elements = [
+        return [
             ['element' => 'thead', 'elements' => [
-                ['element' => 'th', 'content' => '$item_label'],
-                ['element' => 'th', 'content' => '$description_label'],
-                ['element' => 'th', 'content' => '$product.quantity_label'],
+                ['element' => 'th', 'content' => '$item_label', 'properties' => ['data-ref' => 'delivery_note-item_label']],
+                ['element' => 'th', 'content' => '$description_label', 'properties' => ['data-ref' => 'delivery_note-description_label']],
+                ['element' => 'th', 'content' => '$product.quantity_label', 'properties' => ['data-ref' => 'delivery_note-product.quantity_label']],
             ]],
             ['element' => 'tbody', 'elements' => $this->buildTableBody('delivery_note')],
         ];
-
-        return $elements;
     }
 
     /**
@@ -256,7 +258,7 @@ class Design extends BaseDesign
             return [];
         }
 
-        return  [
+        return [
             ['element' => 'thead', 'elements' => $this->buildTableHeader('product')],
             ['element' => 'tbody', 'elements' => $this->buildTableBody('$product')],
         ];
@@ -306,7 +308,7 @@ class Design extends BaseDesign
             if (array_key_exists($column, $aliases)) {
                 $elements[] = ['element' => 'th', 'content' => $aliases[$column] . '_label'];
             } else {
-                $elements[] = ['element' => 'th', 'content' => $column . '_label'];
+                $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th']];
             }
         }
 
@@ -333,9 +335,9 @@ class Design extends BaseDesign
             foreach ($items as $row) {
                 $element = ['element' => 'tr', 'elements' => []];
 
-                $element['elements'][] = ['element' => 'td', 'content' => $row['delivery_note.product_key']];
-                $element['elements'][] = ['element' => 'td', 'content' => $row['delivery_note.notes']];
-                $element['elements'][] = ['element' => 'td', 'content' => $row['delivery_note.quantity']];
+                $element['elements'][] = ['element' => 'td', 'content' => $row['delivery_note.product_key'], 'properties' => ['data-ref' => 'delivery_note_table.product_key-td']];
+                $element['elements'][] = ['element' => 'td', 'content' => $row['delivery_note.notes'], 'properties' => ['data-ref' => 'delivery_note_table.notes-td']];
+                $element['elements'][] = ['element' => 'td', 'content' => $row['delivery_note.quantity'], 'properties' => ['data-ref' => 'delivery_note_table.quantity-td']];
 
                 $elements[] = $element;
             }
@@ -378,21 +380,21 @@ class Design extends BaseDesign
                     // $task.quantity => $task.hours
 
                     if ($cell == '$task.rate') {
-                        $element['elements'][] = ['element' => 'td', 'content' => $row['$task.cost']];
+                        $element['elements'][] = ['element' => 'td', 'content' => $row['$task.cost'], 'properties' => ['data-ref' => 'task_table-task.cost-td']];
                     } elseif ($cell == '$task.hours') {
-                        $element['elements'][] = ['element' => 'td', 'content' => $row['$task.quantity']];
+                        $element['elements'][] = ['element' => 'td', 'content' => $row['$task.quantity'], 'properties' => ['data-ref' => 'task_table-task.hours-td']];
                     } elseif ($cell == '$task.description') {
                         $_element = ['element' => 'td', 'content' => '', 'elements' => [
-                            ['element' => 'span', 'content' => $row[$cell]],
+                            ['element' => 'span', 'content' => $row[$cell], 'properties' => ['data-ref' => 'task_table-task.description-td']],
                         ]];
 
                         foreach ($this->getTaskTimeLogs($row) as $log) {
-                            $_element['elements'][] = ['element' => 'span', 'content' => $log, 'properties' => ['class' => 'task-duration']];
+                            $_element['elements'][] = ['element' => 'span', 'content' => $log, 'properties' => ['class' => 'task-duration', 'data-ref' => 'task_table-task.duration']];
                         }
 
                         $element['elements'][] = $_element;
                     } else {
-                        $element['elements'][] = ['element' => 'td', 'content' => $row[$cell]];
+                        $element['elements'][] = ['element' => 'td', 'content' => $row[$cell], 'properties' => ['data-ref' => "{$_type}_table-" . substr($cell, 1) . '-td']];
                     }
                 }
             }
@@ -413,7 +415,7 @@ class Design extends BaseDesign
 
         $elements = [
             ['element' => 'div', 'elements' => [
-                ['element' => 'span', 'content' => '$entity.public_notes', 'properties' => ['data-element' => 'total-table-public-notes-label', 'style' => 'text-align: left;']],
+                ['element' => 'span', 'content' => '$entity.public_notes', 'properties' => ['data-ref' => 'total_table-public_notes-label', 'style' => 'text-align: left;']],
             ]],
         ];
 
@@ -465,7 +467,7 @@ class Design extends BaseDesign
             } else {
                 $elements[] = ['element' => 'div', 'elements' => [
                     ['element' => 'span', 'content' => 'This is placeholder for the 3rd fraction of element.', 'properties' => ['style' => 'opacity: 0%']], // Placeholder for fraction of element (3fr)
-                    ['element' => 'span', 'content' => $variable . '_label'],
+                    ['element' => 'span', 'content' => $variable . '_label', 'properties' => ['data-ref' => 'totals_table-' . substr($variable, 1)]],
                     ['element' => 'span', 'content' => $variable],
                 ]];
             }

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "require": {
         "php": "^7.3|^7.4",
         "ext-json": "*",
+        "ext-libxml": "*",
         "asgrim/ofxparser": "^1.2",
         "authorizenet/authorizenet": "^2.0",
         "beganovich/chromium-pdf": "dev-master",
@@ -64,7 +65,8 @@
         "stripe/stripe-php": "^7.50",
         "turbo124/beacon": "^1",
         "turbo124/laravel-gmail": "^5.0",
-        "webpatser/laravel-countries": "dev-master#75992ad"
+        "webpatser/laravel-countries": "dev-master#75992ad",
+        "ext-dom": "*"
     },
     "require-dev": {
         "anahkiasen/former": "^4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aeacc9e2738ddc41353c497c14feadb0",
+    "content-hash": "591cb6a81d2d0b2f4cc0bf1db7fde22c",
     "packages": [
         {
             "name": "asgrim/ofxparser",
@@ -13888,7 +13888,9 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^7.3|^7.4",
-        "ext-json": "*"
+        "ext-json": "*",
+        "ext-libxml": "*",
+        "ext-dom": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.0.0"

--- a/config/ninja.php
+++ b/config/ninja.php
@@ -137,4 +137,5 @@ return [
     ],
     'experimental_pdf_engine' => env('EXPERIMENTAL_PDF_ENGINE', false),
     'experimental_pdf_engine_chromium_path' => env('EXPERIMENTAL_PDF_ENGINE_CHROMIUM_PATH', null),
+    'log_pdf_html' => env('LOG_PDF_HTML', false),
 ];


### PR DESCRIPTION
- Add ext-libxml to composer.json
- Support outputting the PDF in CreateEntityPdf.php & GenerateDeliveryNote.php
- Add reference names to Design.php

This will let people that make custom design or modify existing ones target specific elements more easily by providing custom selectors.

Here's an example:

All elements now have `data-ref` on themselves:
![image](https://user-images.githubusercontent.com/13711415/102502521-01ca6e00-407f-11eb-827c-789bca58684f.png)


which makes targeting dead simple:

![image](https://user-images.githubusercontent.com/13711415/102502591-1b6bb580-407f-11eb-8685-a059a0254f3d.png)
