### PR TITLE
(v5) Update default margin for PDFs

### DIFF
--- a/app/Utils/HtmlEngine.php
+++ b/app/Utils/HtmlEngine.php
@@ -92,7 +92,7 @@ class HtmlEngine
         }
 
         $data = [];
-        $data['$global_margin'] = ['value' => '1cm', 'label' => ''];
+        $data['$global_margin'] = ['value' => '0cm', 'label' => ''];
         $data['$tax'] = ['value' => '', 'label' => ctrans('texts.tax')];
         $data['$app_url'] = ['value' => $this->generateAppUrl(), 'label' => ''];
         $data['$from'] = ['value' => '', 'label' => ctrans('texts.from')];


### PR DESCRIPTION
We now let Google define margins for PDFs, which are recommended A4. They can be overwritten with $global_margin property.