### PR TITLE
(v5) Support for multiline text on PDF

### DIFF
--- a/app/Services/PdfMaker/PdfMakerUtilities.php
+++ b/app/Services/PdfMaker/PdfMakerUtilities.php
@@ -111,6 +111,10 @@ trait PdfMakerUtilities
     {
         foreach ($children as $child) {
             $contains_html = false;
+            
+            if (isset($child['content'])) {
+                $child['content'] = nl2br($child['content']);
+            }
 
             // "/\/[a-z]*>/i" -> checks for HTML-like tags:
             // <my-tag></my-tag> => true


### PR DESCRIPTION
Example:

```html
This is my awesome
multiline text.

.. with <b>HTML</b> <i>support</i>

<span style="background-color: #FFFF00">Your highlighted text here.</span>
```

![image](https://user-images.githubusercontent.com/13711415/102997564-beac4700-4525-11eb-86e5-8849c98589cd.png)
