### PR TITLE
(v5) Command to generate app_key value

### DIFF
--- a/app/Console/Commands/GenerateSetupKey.php
+++ b/app/Console/Commands/GenerateSetupKey.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2020. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://opensource.org/licenses/AAL
+ */
+
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;

--- a/app/Console/Commands/GenerateSetupKey.php
+++ b/app/Console/Commands/GenerateSetupKey.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class GenerateSetupKey extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ninja:generate-setup-key';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate random APP_KEY value';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $randomString = base64_encode(\Illuminate\Support\Str::random(32));
+
+        $this->info('Success! Copy the following content into your .env or docker-compose.yml:');
+        $this->warn('base64:' . $randomString);
+    }
+}


### PR DESCRIPTION
This is a simple command that helps users to generate APP_KEY value. Useful for Docker installations.

![image](https://user-images.githubusercontent.com/13711415/103094712-bffd7280-45fe-11eb-8402-e505ad5b6978.png)
