### PR TITLE
(v5) Add support for custom Chromium path (ie. support for Windows & Mac)

### DIFF
--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -221,9 +221,13 @@ class SetupController extends Controller
                 return $this->testPhantom();
             }
 
-            $snappdf = new Snappdf();
+            $pdf = new Snappdf();
 
-            $pdf = $snappdf
+            if (config('ninja.snappdf_chromium_path')) {
+                $pdf->setChromiumPath(config('ninja.snappdf_chromium_path'));
+            }
+
+            $pdf = $pdf
                 ->setHtml('GENERATING PDFs WORKS! Thank you for using Invoice Ninja!')
                 ->generate();
 

--- a/app/Utils/Traits/Pdf/PdfMaker.php
+++ b/app/Utils/Traits/Pdf/PdfMaker.php
@@ -29,6 +29,10 @@ trait PdfMaker
     {
         $pdf = new Snappdf();
 
+        if (config('ninja.snappdf_chromium_path')) {
+            $pdf->setChromiumPath(config('ninja.snappdf_chromium_path'));
+        }
+
         return $pdf
             ->setHtml($html)
             ->generate();

--- a/config/ninja.php
+++ b/config/ninja.php
@@ -137,4 +137,5 @@ return [
     ],
     'log_pdf_html' => env('LOG_PDF_HTML', false),
     'expanded_logging' => env('EXPANDED_LOGGING', false),
+    'snappdf_chromium_path' => env('SNAPPDF_CHROMIUM_PATH', false),
 ];

--- a/tests/Pdf/PdfGenerationTest.php
+++ b/tests/Pdf/PdfGenerationTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Invoice Ninja (https://invoiceninja.com).
  *
@@ -8,6 +9,7 @@
  *
  * @license https://opensource.org/licenses/AAL
  */
+
 namespace Tests\Pdf;
 
 use Beganovich\Snappdf\Snappdf;
@@ -19,16 +21,20 @@ use Tests\TestCase;
  */
 class PdfGenerationTest extends TestCase
 {
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
     }
 
     public function testPdfGeneration()
     {
-        $snappdf = new Snappdf();
+        $pdf = new Snappdf();
 
-        $pdf = $snappdf
+        if (config('ninja.snappdf_chromium_path')) {
+            $pdf->setChromiumPath(config('ninja.snappdf_chromium_path'));
+        }
+
+        $pdf = $pdf
             ->setHtml('<h1>Invoice Ninja</h1>')
             ->generate();
 


### PR DESCRIPTION
Windows / Mac users can now point their Chromium/Chrome browser by .env variable:

SNAPPDF_CHROMIUM_PATH
