### PR TITLE
(v5) Hide empty columns on the PDF

### DIFF
--- a/app/Jobs/Entity/CreateEntityPdf.php
+++ b/app/Jobs/Entity/CreateEntityPdf.php
@@ -158,11 +158,11 @@ class CreateEntityPdf implements ShouldQueue
         }
 
         if (config('ninja.log_pdf_html')) {
-            nlog($maker->getCompiledHTML());
+            info($maker->getCompiledHTML());
         }
 
         if ($pdf) {
-            $instance = Storage::disk($this->disk)->put($file_path, $pdf);
+            Storage::disk($this->disk)->put($file_path, $pdf);
         }
 
         return $file_path;

--- a/app/Services/PdfMaker/Design.php
+++ b/app/Services/PdfMaker/Design.php
@@ -309,13 +309,13 @@ class Design extends BaseDesign
 
         foreach ($this->context['pdf_variables']["{$type}_columns"] as $column) {
             if (array_key_exists($column, $aliases)) {
-                $elements[] = ['element' => 'th', 'content' => $aliases[$column] . '_label', 'properties' => ['hidden' => true]];
+                $elements[] = ['element' => 'th', 'content' => $aliases[$column] . '_label', 'properties' => ['hidden' => $this->client->company->hide_empty_columns_on_pdf]];
             } elseif ($column == '$product.discount' && !$this->client->company->enable_product_discount) {
                 $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th', 'style' => 'display: none;']];
             } elseif ($column == '$product.quantity' && !$this->client->company->enable_product_quantity) {
                 $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th', 'style' => 'display: none;']];
             } else {
-                $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th', 'hidden' => true]];
+                $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th', 'hidden' => $this->client->company->hide_empty_columns_on_pdf]];
             }
         }
 

--- a/app/Services/PdfMaker/Design.php
+++ b/app/Services/PdfMaker/Design.php
@@ -127,7 +127,7 @@ class Design extends BaseDesign
         ];
     }
 
-    public function companyDetails()
+    public function companyDetails(): array
     {
         $variables = $this->context['pdf_variables']['company_details'];
 
@@ -309,13 +309,13 @@ class Design extends BaseDesign
 
         foreach ($this->context['pdf_variables']["{$type}_columns"] as $column) {
             if (array_key_exists($column, $aliases)) {
-                $elements[] = ['element' => 'th', 'content' => $aliases[$column] . '_label'];
+                $elements[] = ['element' => 'th', 'content' => $aliases[$column] . '_label', 'properties' => ['hidden' => true]];
             } elseif ($column == '$product.discount' && !$this->client->company->enable_product_discount) {
                 $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th', 'style' => 'display: none;']];
             } elseif ($column == '$product.quantity' && !$this->client->company->enable_product_quantity) {
                 $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th', 'style' => 'display: none;']];
             } else {
-                $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th']];
+                $elements[] = ['element' => 'th', 'content' => $column . '_label', 'properties' => ['data-ref' => "{$type}_table-" . substr($column, 1) . '-th', 'hidden' => true]];
             }
         }
 

--- a/app/Services/PdfMaker/Designs/Utilities/DesignHelpers.php
+++ b/app/Services/PdfMaker/Designs/Utilities/DesignHelpers.php
@@ -118,7 +118,7 @@ trait DesignHelpers
         // This sprintf() will help us convert "task" or "product" into "$task" or "$product" without
         // evaluating the variable.
 
-        if (in_array(sprintf('%s%s.tax', '$', $type), (array) $this->context['pdf_variables']["{$type}_columns"])) {
+        if (in_array(sprintf('%s%s.tax', '$', $type), (array)$this->context['pdf_variables']["{$type}_columns"])) {
             $line_items = collect($this->entity->line_items)->filter(function ($item) use ($type_id) {
                 return $item->type_id = $type_id;
             });
@@ -157,9 +157,9 @@ trait DesignHelpers
      */
     public function calculateColspan(int $taken): int
     {
-        $total = (int) count($this->context['pdf_variables']['product_columns']);
+        $total = (int)count($this->context['pdf_variables']['product_columns']);
 
-        return (int) $total - $taken;
+        return (int)$total - $taken;
     }
 
     /**
@@ -184,11 +184,38 @@ trait DesignHelpers
 
     public function sharedFooterElements()
     {
-        // return ['element' => 'div', 'properties' => ['style' => 'display: flex; justify-content: space-between; margin-top: 1.5rem; page-break-inside: avoid;'], 'elements' => [
-        //     ['element' => 'img', 'properties' => ['src' => '$invoiceninja.whitelabel', 'style' => 'height: 5rem;', 'hidden' => $this->entity->user->account->isPaid() ? 'true' : 'false']],
-        // ]];
+        // Unminified version, just for the reference.
+        // By default all table headers are hidden with HTML `hidden` property.
+        // This will check for table data values & if they're not empty it will remove hidden from the column itself.
 
-        return ['element' => 'img', 'properties' => ['src' => '$invoiceninja.whitelabel', 'style' => 'height: 3rem; position: fixed; bottom: 0; left: 0; padding: 5px; margin: 5px;', 'hidden' => $this->entity->user->account->isPaid() ? 'true' : 'false', 'id' => 'invoiceninja-whitelabel-logo']];
+        /*  document.querySelectorAll("tbody > tr > td").forEach(e => {
+                if ("" !== e.innerText) {
+                    let t = e.getAttribute("data-ref").slice(0, -3);
+                    document.querySelector(`th[data-ref="${t}-th"]`).removeAttribute("hidden");
+                }
+            });
+
+            document.querySelectorAll("tbody > tr > td").forEach(e => {
+                let t = e.getAttribute("data-ref").slice(0, -3);
+                t = document.querySelector(`th[data-ref="${t}-th"]`);
+
+                if (!t.hasAttribute('hidden')) {
+                    return;
+                }
+
+                if ("" == e.innerText) {
+                    e.setAttribute('hidden', 'true');
+                }
+            });
+        */
+
+
+        $javascript = 'document.querySelectorAll("tbody > tr > td").forEach(t=>{if(""!==t.innerText){let e=t.getAttribute("data-ref").slice(0,-3);document.querySelector(`th[data-ref="${e}-th"]`).removeAttribute("hidden")}}),document.querySelectorAll("tbody > tr > td").forEach(t=>{let e=t.getAttribute("data-ref").slice(0,-3);(e=document.querySelector(`th[data-ref="${e}-th"]`)).hasAttribute("hidden")&&""==t.innerText&&t.setAttribute("hidden","true")});';
+
+        return ['element' => 'div', 'elements' => [
+            ['element' => 'img', 'properties' => ['src' => '$invoiceninja.whitelabel', 'style' => 'height: 3rem; position: fixed; bottom: 0; left: 0; padding: 5px; margin: 5px;', 'hidden' => $this->entity->user->account->isPaid() ? 'true' : 'false', 'id' => 'invoiceninja-whitelabel-logo']],
+            ['element' => 'script', 'content' => $javascript],
+        ]];
     }
 
     public function entityVariableCheck(string $variable): bool
@@ -234,7 +261,7 @@ trait DesignHelpers
     {
         $custom_columns = [];
 
-        foreach ((array) $this->client->company->custom_fields as $field => $value) {
+        foreach ((array)$this->client->company->custom_fields as $field => $value) {
             info($field);
 
             if (\Illuminate\Support\Str::startsWith($field, $type)) {


### PR DESCRIPTION
If company `hide_empty_columns_on_pdf` is true, it will hide the columns if content is empty.

Behaviour:

If the setting is `true` but any of the present columns have content, it'll be ignored:

![image](https://user-images.githubusercontent.com/13711415/103674942-a30e5b00-4f7f-11eb-8f24-069275de0140.png)

However, if there's no content for the whole table (on a specific column), the column itself will be hidden:

![image](https://user-images.githubusercontent.com/13711415/103675024-be796600-4f7f-11eb-9431-a843de6ecaab.png)

... and finally, if the setting is off, it will be present, no matter what.

![image](https://user-images.githubusercontent.com/13711415/103675108-d51fbd00-4f7f-11eb-9bdc-f367c3d8264b.png)


