### PR TITLE
(v5) Show the feedback message if invoice is unpayable

### DIFF
--- a/app/Http/Controllers/ClientPortal/InvoiceController.php
+++ b/app/Http/Controllers/ClientPortal/InvoiceController.php
@@ -77,7 +77,9 @@ class InvoiceController extends Controller
             return $this->downloadInvoicePDF((array) $transformed_ids);
         }
 
-        return redirect()->back();
+        return redirect()
+            ->back()
+            ->with('message', ctrans('texts.no_action_provided'));
     }
 
     private function makePayment(array $ids)
@@ -93,7 +95,8 @@ class InvoiceController extends Controller
         });
 
         if ($invoices->count() == 0) {
-            return back()->with(['warning' => 'No payable invoices selected']);
+            return back()
+                ->with('message', ctrans('texts.no_payable_invoices_selected'));
         }
 
         $invoices->map(function ($invoice) {

--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -3363,4 +3363,7 @@ return [
 
     'endless' => 'Endless',
     'minimum_payment' => 'Minimum Payment',
+
+    'no_action_provided' => 'No action provided. If you believe this is wrong, please contact the support.',
+    'no_payable_invoices_selected' => 'No payable invoices selected. Make sure you are not trying to pay draft invoice or invoice with zero balance due.',
 ];


### PR DESCRIPTION
If the user selects the invoice which is draft/unpayable the nice feedback message will be shown:

> No payable invoices selected. Make sure you are not trying to pay draft invoice or invoice with zero balance due.