### PR TITLE
Add $entity.datetime variable for invoice designs

### DIFF
--- a/app/Utils/HtmlEngine.php
+++ b/app/Utils/HtmlEngine.php
@@ -113,6 +113,11 @@ class HtmlEngine
         $data['$invoice.due_date'] = &$data['$due_date'];
         $data['$invoice.number'] = ['value' => $this->entity->number ?: '&nbsp;', 'label' => ctrans('texts.invoice_number')];
         $data['$invoice.po_number'] = ['value' => $this->entity->po_number ?: '&nbsp;', 'label' => ctrans('texts.po_number')];
+        $data['$entity.datetime'] = ['value' => $this->formatDatetime($this->entity->created_at, $this->entity->client->date_format()), 'label' => ctrans('texts.date')];
+        $data['$invoice.datetime'] = &$data['$entity.datetime'];
+        $data['$quote.datetime'] = &$data['$entity.datetime'];
+        $data['$credit.datetime'] = &$data['$entity.datetime'];
+
         // $data['$line_taxes'] = ['value' => $this->makeLineTaxes() ?: '&nbsp;', 'label' => ctrans('texts.taxes')];
         // $data['$invoice.line_taxes'] = &$data['$line_taxes'];
 

--- a/app/Utils/Traits/MakesDates.php
+++ b/app/Utils/Traits/MakesDates.php
@@ -72,6 +72,17 @@ trait MakesDates
     }
 
     /**
+     * Formats a datedate.
+     * @param  Carbon|string $date   Carbon object or date string
+     * @param  string $format The date display format
+     * @return string         The formatted date
+     */
+    public function formatDatetime($date, string $format) :string
+    {
+        return Carbon::createFromTimestamp($date)->format($format . " g:i a");
+    }
+
+    /**
      * Formats a date.
      * @param  Carbon/String $date   Carbon object or date string
      * @param  string $format The date display format


### PR DESCRIPTION
The generic $entity.datetime is available along with

$invoice.datetime
$quote.datetime
$credit.datetime