### PR TITLE
(v5) Change default view for invoices as full-screen

### DIFF
--- a/resources/views/portal/ninja2020/components/livewire/invoices-table.blade.php
+++ b/resources/views/portal/ninja2020/components/livewire/invoices-table.blade.php
@@ -104,8 +104,8 @@
                                         </button>
                                     </form>
                                 @endif
-                                <a href="{{ route('client.invoice.show', $invoice->hashed_id) }}" class="button-link text-primary">
-                                    @lang('texts.view')
+                                <a href="{{ route('client.invoice.show', $invoice->hashed_id) }}?mode=fullscreen" class="button-link text-primary">
+                                    {{ ctrans('texts.view') }}
                                 </a>
                             </td>
                         </tr>

--- a/resources/views/portal/ninja2020/components/primary-color.blade.php
+++ b/resources/views/portal/ninja2020/components/primary-color.blade.php
@@ -1,6 +1,6 @@
 <style>
     :root {
-        --primary-color: {{ $settings->primary_color }};
+        --primary-color: {{ isset($settings) ? optional($settings)->primary_color : '#1c64f2' }};
     }
 
     .bg-primary {
@@ -8,7 +8,7 @@
     }
 
     .bg-primary-darken {
-        background-color: vaR(--primary-color);
+        background-color: var(--primary-color);
         filter: brightness(90%);
     }
 

--- a/resources/views/portal/ninja2020/invoices/show/fullscreen.blade.php
+++ b/resources/views/portal/ninja2020/invoices/show/fullscreen.blade.php
@@ -19,7 +19,11 @@
                             </div>
                         </div>
                         <div class="mt-5 sm:mt-0 sm:ml-6 sm:flex-shrink-0 sm:flex sm:items-center">
-                            <div class="inline-flex rounded-md shadow-sm">
+                            <a href="{{ route('client.invoice.show', $invoice->hashed_id) }}" class="mr-4 text-primary">
+                                &#8592; {{ ctrans('texts.client_portal') }}
+                            </a>
+
+                            <div class="inline-flex items-center rounded-md shadow-sm">
                                 <input type="hidden" name="invoices[]" value="{{ $invoice->hashed_id }}">
                                 <input type="hidden" name="action" value="payment">
                                 <button class="button button-primary bg-primary">{{ ctrans('texts.pay_now') }}</button>

--- a/resources/views/portal/ninja2020/invoices/show/fullscreen.blade.php
+++ b/resources/views/portal/ninja2020/invoices/show/fullscreen.blade.php
@@ -15,7 +15,6 @@
                             <div class="mt-2 max-w-xl text-sm leading-5 text-gray-500">
                                 <p translate>
                                     {{ ctrans('texts.invoice_still_unpaid') }}
-                                    <!-- This invoice is still not paid. Click the button to complete the payment. -->
                                 </p>
                             </div>
                         </div>

--- a/resources/views/portal/ninja2020/layout/clean.blade.php
+++ b/resources/views/portal/ninja2020/layout/clean.blade.php
@@ -66,6 +66,8 @@
         <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css" />
     </head>
 
+    @include('portal.ninja2020.components.primary-color')
+
     <body class="antialiased {{ $custom_body_class ?? '' }}">
         @yield('body')
 


### PR DESCRIPTION
As of this moment, when clicking on View in the invoices table, default view will be full-screen.
![image](https://user-images.githubusercontent.com/13711415/104462133-7629fb80-55b0-11eb-8bbb-b3e9b9afa83e.png)
