### PR TITLE
(v5) Client portal: Remove drafts from the quotes table

### DIFF
--- a/app/Http/Livewire/QuotesTable.php
+++ b/app/Http/Livewire/QuotesTable.php
@@ -36,6 +36,7 @@ class QuotesTable extends Component
 
         $query = $query
             ->where('client_id', auth('contact')->user()->client->id)
+            ->where('status_id', '<>', Quote::STATUS_DRAFT)
             ->paginate($this->per_page);
 
         return render('components.livewire.quotes-table', [

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -228,6 +228,7 @@ class Quote extends BaseModel
                 break;
             case self::STATUS_CONVERTED:
                 return '<h5><span class="badge badge-light">'.ctrans('texts.converted').'</span></h5>';
+                break;
             default:
                 // code...
                 break;

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -226,6 +226,8 @@ class Quote extends BaseModel
             case self::STATUS_EXPIRED:
                 return '<h5><span class="badge badge-danger">'.ctrans('texts.expired').'</span></h5>';
                 break;
+            case self::STATUS_CONVERTED:
+                return '<h5><span class="badge badge-light">'.ctrans('texts.converted').'</span></h5>';
             default:
                 // code...
                 break;


### PR DESCRIPTION
Changes:
- Removed "draft" quotes from the being shown in the table
- Support for "converted" status