### PR TITLE
Fix mail TLS options wording

### DIFF
--- a/resources/views/setup/_mail.blade.php
+++ b/resources/views/setup/_mail.blade.php
@@ -68,8 +68,8 @@
                 </dt>
                 <dd class="text-sm leading-5 text-gray-900 sm:mt-0 sm:col-span-2">
                     <select name="encryption" class="input w-full form-select">
-                        <option value="tls">TLS</option>
-                        <option value="ssl">SSL</option>
+                        <option value="tls">STARTTLS</option>
+                        <option value="ssl">SSL/TLS</option>
                     </select>
                 </dd>
             </div>


### PR DESCRIPTION
When trying out invoiceninja v5 I noticed the two TLS options for smtp were SSL, and TLS. This is inaccurate and confusing.

When choosing SSL, TLS is used in reality. When choosing TLS, TLS is also used, but through the STARTTLS command on the standard submissions port.

I've edited it to be accurate, and the same as email clients such as Thunderbird and Outlook. 😁 