### PR TITLE
(v5) Authorize.net, Checkout: Pass token hash id's instead of plain tokens

### DIFF
--- a/app/PaymentDrivers/Authorize/AuthorizeCreditCard.php
+++ b/app/PaymentDrivers/Authorize/AuthorizeCreditCard.php
@@ -12,6 +12,7 @@
 
 namespace App\PaymentDrivers\Authorize;
 
+use App\Exceptions\PaymentFailed;
 use App\Jobs\Mail\PaymentFailureMailer;
 use App\Jobs\Util\SystemLogger;
 use App\Models\ClientGatewayToken;
@@ -81,7 +82,14 @@ class AuthorizeCreditCard
 
     private function processTokenPayment($request)
     {
-        $client_gateway_token =ClientGatewayToken::where('token', $request->token)->firstOrFail();
+        $client_gateway_token = ClientGatewayToken::query()
+            ->where('id', $this->decodePrimaryKey($request->token))
+            ->where('company_id', auth('contact')->user()->client->company->id)
+            ->first();
+
+        if (!$client_gateway_token) {
+            throw new PaymentFailed(ctrans('texts.payment_token_not_found'), 401);
+        }
 
         $data = (new ChargePaymentProfile($this->authorize))->chargeCustomerProfile($client_gateway_token->gateway_customer_reference, $client_gateway_token->token, $request->input('amount_with_fee'));
 
@@ -129,7 +137,7 @@ class AuthorizeCreditCard
             PaymentFailureMailer::dispatch($this->authorize->client, $response->getTransactionResponse()->getTransId(), $this->authorize->client->company, $amount);
 
             SystemLogger::dispatch($logger_message, SystemLog::CATEGORY_GATEWAY_RESPONSE, SystemLog::EVENT_GATEWAY_FAILURE, SystemLog::TYPE_AUTHORIZE, $this->authorize->client);
-                
+
             return false;
         }
     }
@@ -157,7 +165,7 @@ class AuthorizeCreditCard
         $payment_record = [];
         $payment_record['amount'] = $amount;
         $payment_record['payment_type'] = PaymentType::CREDIT_CARD_OTHER;
-        $payment_record['gateway_type_id'] = GatewayType::CREDIT_CARD;        
+        $payment_record['gateway_type_id'] = GatewayType::CREDIT_CARD;
         $payment_record['transaction_reference'] = $response->getTransactionResponse()->getTransId();
 
         $payment = $this->authorize->createPayment($payment_record);

--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -3383,5 +3383,5 @@ return [
     'create_webhook_failure' => 'Failed to create Webhook',
     'number' => 'Number',
     'payment_message_extended' => 'Thank you for your payment of :amount for :invoice',
-
+    'payment_token_not_found' => 'Payment token not found, please try again. If an issue still persist, try with another payment method',
 ];

--- a/resources/views/portal/ninja2020/gateways/authorize/credit_card/pay.blade.php
+++ b/resources/views/portal/ninja2020/gateways/authorize/credit_card/pay.blade.php
@@ -38,7 +38,7 @@
                 <label class="mr-4">
                     <input
                         type="radio"
-                        data-token="{{ $token->token }}"
+                        data-token="{{ $token->hashed_id }}"
                         name="payment-type"
                         class="form-radio cursor-pointer toggle-payment-with-token"/>
                     <span class="ml-1 cursor-pointer">**** {{ optional($token->meta)->last4 }}</span>

--- a/resources/views/portal/ninja2020/gateways/checkout/credit_card/pay.blade.php
+++ b/resources/views/portal/ninja2020/gateways/checkout/credit_card/pay.blade.php
@@ -141,7 +141,7 @@
                 <label class="mr-4">
                     <input
                         type="radio"
-                        data-token="{{ $token->token }}"
+                        data-token="{{ $token->hashed_id }}"
                         name="payment-type"
                         class="form-radio cursor-pointer toggle-payment-with-token"/>
                     <span class="ml-1 cursor-pointer">**** {{ optional($token->meta)->last4 }}</span>

--- a/resources/views/portal/ninja2020/invoices/show.blade.php
+++ b/resources/views/portal/ninja2020/invoices/show.blade.php
@@ -48,7 +48,8 @@
         <div class="sm:flex sm:items-start sm:justify-between">
             <div>
                 <h3 class="text-lg leading-6 font-medium text-gray-900">
-                    {{ ctrans('texts.invoice_number_placeholder', ['invoice' => $invoice->number])}} - {{ ctrans('texts.unpaid') }}
+                    {{ ctrans('texts.invoice_number_placeholder', ['invoice' => $invoice->number])}}
+                    - {{ ctrans('texts.paid') }}
                 </h3>
             </div>
         </div>
@@ -70,7 +71,7 @@
                     </svg>
                 </button>
             </div>
-            <span class="text-sm text-gray-700 ml-2">{{ ctrans('texts.page') }}: 
+            <span class="text-sm text-gray-700 ml-2">{{ ctrans('texts.page') }}:
                 <span id="current-page-container"></span>
                 <span>{{ strtolower(ctrans('texts.of')) }}</span>
                 <span id="total-page-container"></span>

--- a/resources/views/portal/ninja2020/invoices/show/fullscreen.blade.php
+++ b/resources/views/portal/ninja2020/invoices/show/fullscreen.blade.php
@@ -21,7 +21,8 @@
                             </div>
                         </div>
                         <div class="mt-5 sm:mt-0 sm:ml-6 sm:flex-shrink-0 sm:flex sm:items-center">
-                            <a href="{{ route('client.invoice.show', $invoice->hashed_id) }}?mode=portal" class="mr-4 text-primary">
+                            <a href="{{ route('client.invoice.show', $invoice->hashed_id) }}?mode=portal"
+                               class="mr-4 text-primary">
                                 &#8592; {{ ctrans('texts.client_portal') }}
                             </a>
 
@@ -36,15 +37,17 @@
             </div>
         </form>
     @else
-        <div class="bg-white shadow sm:rounded-lg mb-4" translate>
+        <div class="bg-white shadow sm:rounded-lg mb-4">
             <div class="px-4 py-5 sm:p-6">
                 <div class="sm:flex sm:items-start sm:justify-between">
-                    <div>
-                        <h3 class="text-lg leading-6 font-medium text-gray-900">
-                            {{ ctrans('texts.invoice_number_placeholder', ['invoice' => $invoice->number])}}
-                            - {{ ctrans('texts.unpaid') }}
-                        </h3>
-                    </div>
+                    <h3 class="text-lg leading-6 font-medium text-gray-900">
+                        {{ ctrans('texts.invoice_number_placeholder', ['invoice' => $invoice->number])}}
+                        - {{ ctrans('texts.paid') }}
+                    </h3>
+                    <a href="{{ route('client.invoice.show', $invoice->hashed_id) }}?mode=portal"
+                       class="mr-4 text-primary">
+                        &#8592; {{ ctrans('texts.client_portal') }}
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Changes:
- Authorize.net: Throw a PaymentFailed exception if token not found
- Checkout.com: Throw a PaymentFailed exception if token not found
- Show the "Client portal" button even when the invoice is paid
- Authorize.net: Pass token hashed_id instead of token to frontend
- Checkout.com: Pass token hashed_id instead of token to frontend
- Show "Paid" label for paid invoices
- Translation for not found token