### PR TITLE
(v5) ACH: Fix blank screen after payment

### DIFF
--- a/resources/views/portal/ninja2020/gateways/stripe/ach/pay.blade.php
+++ b/resources/views/portal/ninja2020/gateways/stripe/ach/pay.blade.php
@@ -23,7 +23,7 @@
                     <label class="mr-4">
                         <input
                             type="radio"
-                            data-token="{{ $token->token }}"
+                            data-token="{{ $token->hashed_id }}"
                             name="payment-type"
                             class="form-radio cursor-pointer toggle-payment-with-token"/>
                         <span class="ml-1 cursor-pointer">{{ ctrans('texts.bank_transfer') }} (*{{ $token->meta->last4 }})</span>


### PR DESCRIPTION
Changes:
- Fix blank screen after hitting the payment button
- Pass token hashed_id instead of token value