### PR TITLE
(v5) Allow variables in the custom payment driver

### DIFF
--- a/app/PaymentDrivers/CustomPaymentDriver.php
+++ b/app/PaymentDrivers/CustomPaymentDriver.php
@@ -14,13 +14,18 @@ namespace App\PaymentDrivers;
 
 use App\Models\ClientGatewayToken;
 use App\Models\GatewayType;
+use App\Models\Invoice;
 use App\Models\Payment;
+use App\Utils\HtmlEngine;
+use App\Utils\Traits\MakesHash;
 
 /**
  * Class CustomPaymentDriver.
  */
 class CustomPaymentDriver extends BaseDriver
 {
+    use MakesHash;
+
     public $token_billing = false;
 
     public $can_authorise_credit_card = false;
@@ -52,12 +57,18 @@ class CustomPaymentDriver extends BaseDriver
      */
     public function processPaymentView($data)
     {
+        $invitation = Invoice::findOrFail(
+            $this->decodePrimaryKey($data['invoices']['0']['invoice_id'])
+        )->invitations->first();
+
+        $variables = (new HtmlEngine($invitation))->generateLabelsAndValues();
+
         $data['title'] = $this->company_gateway->getConfigField('name');
-        $data['instructions'] = $this->company_gateway->getConfigField('text');
-        
+        $data['instructions'] = strtr($this->company_gateway->getConfigField('text'), $variables['values']);
+
         $this->payment_hash->data = array_merge((array) $this->payment_hash->data, $data);
         $this->payment_hash->save();
-        
+
         $data['gateway'] = $this;
 
         return render('gateways.custom.payment', $data);


### PR DESCRIPTION
Summary:
This will let users make use of variables in the custom payment driver.

![image](https://user-images.githubusercontent.com/13711415/107363280-359f9e00-6ada-11eb-97aa-2fe5f38a8b93.png)

will produce the following:

![image](https://user-images.githubusercontent.com/13711415/107363300-3cc6ac00-6ada-11eb-9614-fa061e5a8d23.png)

For review: 
To construct HtmlEngine class we need an invitation. Is this correct way @turbo124?

```php
$invitation = Invoice::findOrFail(
    $this->decodePrimaryKey($data['invoices']['0']['invoice_id'])
)->invitations->first();
```

$invitation property isn't available in BaseDriver nor CustomPaymentDriver.