### PR TITLE
Fix PHP 7.4 - implode glue after array deprecation

### DIFF
--- a/app/Models/Traits/Inviteable.php
+++ b/app/Models/Traits/Inviteable.php
@@ -74,7 +74,7 @@ trait Inviteable
             }
         }
 
-        return $hasValue ? implode($parts, '<br/>') : false;
+        return $hasValue ? implode('<br/>', $parts) : false;
     }
 
     /**


### PR DESCRIPTION
As of PHP 7.4, the separator has to be in front of the array element.