### PR TITLE
Fixes for recurring

### DIFF
--- a/app/Jobs/Cron/RecurringInvoicesCron.php
+++ b/app/Jobs/Cron/RecurringInvoicesCron.php
@@ -21,6 +21,8 @@ class RecurringInvoicesCron
 {
     use Dispatchable;
 
+    public $tries = 1;
+    
     /**
      * Create a new job instance.
      *

--- a/app/Jobs/Entity/EmailEntity.php
+++ b/app/Jobs/Entity/EmailEntity.php
@@ -60,6 +60,8 @@ class EmailEntity implements ShouldQueue
 
     public $template_data; //The data to be merged into the template
 
+    public $tries = 1;
+   
     /**
      * EmailEntity constructor.
      *

--- a/app/Jobs/RecurringInvoice/SendRecurring.php
+++ b/app/Jobs/RecurringInvoice/SendRecurring.php
@@ -94,7 +94,14 @@ class SendRecurring implements ShouldQueue
 
         $invoice->invitations->each(function ($invitation) use ($invoice) {
             if ($invitation->contact && strlen($invitation->contact->email) >=1) {
-                EmailEntity::dispatch($invitation, $invoice->company);
+
+                try{
+                    EmailEntity::dispatch($invitation, $invoice->company);
+                }
+                catch(\Exception $e) {
+                    nlog($e->getMessage());
+                }
+
                 nlog("Firing email for invoice {$invoice->number}");
             }
         });

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -395,8 +395,18 @@ class Invoice extends BaseModel
     public function pdf_file_path($invitation = null, string $type = 'url')
     {
         if (! $invitation) {
-            $invitation = $this->invitations->first();
+
+            if($this->invitations()->exists())
+                $invitation = $this->invitations()->first();
+            else{
+                $this->service()->createInvitations();
+                $invitation = $this->invitations()->first();
+            }
+
         }
+
+        if(!$invitation)
+            throw new \Exception('Hard fail, could not create an invitation - is there a valid contact?');
 
         $storage_path = Storage::$type($this->client->invoice_filepath().$this->numberFormatter().'.pdf');
 

--- a/app/Services/Invoice/CreateInvitations.php
+++ b/app/Services/Invoice/CreateInvitations.php
@@ -55,6 +55,16 @@ class CreateInvitations extends AbstractService
             }
         });
 
+        if($this->invoice->invitations()->count() == 0) {
+            
+            $contact = $this->createBlankContact();
+
+                $ii = InvoiceInvitationFactory::create($this->invoice->company_id, $this->invoice->user_id);
+                $ii->invoice_id = $this->invoice->id;
+                $ii->client_contact_id = $contact->id;
+                $ii->save();
+        }
+
         return $this->invoice;
     }
 
@@ -65,5 +75,7 @@ class CreateInvitations extends AbstractService
         $new_contact->contact_key = Str::random(40);
         $new_contact->is_primary = true;
         $new_contact->save();
+
+        return $new_contact;
     }
 }


### PR DESCRIPTION
Fixes an error when sending recurring invoices - if no invitation is present, the job failure causing a loop of failing jobs.

This fix forces an invitation to be present at all times, and as a fail safe an exception is thrown if the invitation cannot be created.