### PR TITLE
Allow configuring mailgun endpoint by setting MAILGUN_ENDPOINT

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -21,6 +21,7 @@ return [
 	'mailgun' => [
 		'domain' => env('MAILGUN_DOMAIN',''),
 		'secret' => env('MAILGUN_SECRET',''),
+		'endpoint' => env('MAILGUN_ENDPOINT', 'api.mailgun.net'),
 	],
 
 	'mandrill' => [


### PR DESCRIPTION
This introduces a solution for issue https://github.com/invoiceninja/invoiceninja/issues/2537

The setup is similar to https://laravel.com/docs/8.x/mail#mailgun-driver but keeping the default the same as current US endpoint. In other words, people that want to use the EU mailgun service can now set the `MAILGUN_ENDPOINT` env variable to `api.eu.mailgun.net`.