### PR TITLE
Disable V4 after migrating to V5

### DIFF
--- a/app/Console/Commands/SendRecurringInvoices.php
+++ b/app/Console/Commands/SendRecurringInvoices.php
@@ -70,7 +70,9 @@ class SendRecurringInvoices extends Command
             ->get();
 
         foreach ($accounts as $account) {
-            $account->checkCounterReset();
+
+            if(!$account->is_disabled)
+                $account->checkCounterReset();
         }
     }
 
@@ -94,6 +96,11 @@ class SendRecurringInvoices extends Command
             $this->info(date('r') . ' Processing Invoice: '. $recurInvoice->id);
 
             $account = $recurInvoice->account;
+
+            if($account->is_disabled){
+                continue;
+            }
+
             $account->loadLocalizationSettings($recurInvoice->client);
             Auth::loginUsingId($recurInvoice->activeUser()->id);
 
@@ -127,7 +134,7 @@ class SendRecurringInvoices extends Command
         foreach ($expenses as $expense) {
             $shouldSendToday = $expense->shouldSendToday();
 
-            if (! $shouldSendToday) {
+            if (! $shouldSendToday || $expense->account->is_disabled) {
                 continue;
             }
 

--- a/app/Console/Commands/SendRecurringInvoices.php
+++ b/app/Console/Commands/SendRecurringInvoices.php
@@ -71,7 +71,7 @@ class SendRecurringInvoices extends Command
 
         foreach ($accounts as $account) {
 
-            if(!$account->is_disabled)
+            if(!$account->account_email_settings->is_disabled)
                 $account->checkCounterReset();
         }
     }
@@ -97,7 +97,7 @@ class SendRecurringInvoices extends Command
 
             $account = $recurInvoice->account;
 
-            if($account->is_disabled){
+            if($account->account_email_settings->is_disabled){
                 continue;
             }
 
@@ -134,7 +134,7 @@ class SendRecurringInvoices extends Command
         foreach ($expenses as $expense) {
             $shouldSendToday = $expense->shouldSendToday();
 
-            if (! $shouldSendToday || $expense->account->is_disabled) {
+            if (! $shouldSendToday || $expense->account->account_email_settings->is_disabled) {
                 continue;
             }
 

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -128,7 +128,7 @@ class SendReminders extends Command
         $this->info(date('r ') . $accounts->count() . ' accounts found with fees enabled');
 
         foreach ($accounts as $account) {
-            if (! $account->hasFeature(FEATURE_EMAIL_TEMPLATES_REMINDERS) || $account->is_disabled) {
+            if (! $account->hasFeature(FEATURE_EMAIL_TEMPLATES_REMINDERS) || $account->account_email_settings->is_disabled) {
                 continue;
             }
 
@@ -155,7 +155,7 @@ class SendReminders extends Command
         $this->info(date('r ') . count($accounts) . ' accounts found with reminders enabled');
 
         foreach ($accounts as $account) {
-            if (! $account->hasFeature(FEATURE_EMAIL_TEMPLATES_REMINDERS) || $account->is_disabled) {
+            if (! $account->hasFeature(FEATURE_EMAIL_TEMPLATES_REMINDERS) || $account->account_email_settings->is_disabled) {
                 continue;
             }
 
@@ -201,7 +201,7 @@ class SendReminders extends Command
             $account = $scheduledReport->account;
             $account->loadLocalizationSettings();
 
-            if (! $account->hasFeature(FEATURE_REPORTS) || $account->is_disabled) {
+            if (! $account->hasFeature(FEATURE_REPORTS) || $account->account_email_settings->is_disabled) {
                 continue;
             }
 

--- a/app/Console/Commands/SendReminders.php
+++ b/app/Console/Commands/SendReminders.php
@@ -109,7 +109,7 @@ class SendReminders extends Command
 
         /** @var Invoice $invoice */
         foreach ($delayedAutoBillInvoices as $invoice) {
-            if ($invoice->isPaid()) {
+            if ($invoice->isPaid() || $invoice->account->is_deleted) {
                 continue;
             }
 
@@ -128,7 +128,7 @@ class SendReminders extends Command
         $this->info(date('r ') . $accounts->count() . ' accounts found with fees enabled');
 
         foreach ($accounts as $account) {
-            if (! $account->hasFeature(FEATURE_EMAIL_TEMPLATES_REMINDERS)) {
+            if (! $account->hasFeature(FEATURE_EMAIL_TEMPLATES_REMINDERS) || $account->is_disabled) {
                 continue;
             }
 
@@ -155,7 +155,7 @@ class SendReminders extends Command
         $this->info(date('r ') . count($accounts) . ' accounts found with reminders enabled');
 
         foreach ($accounts as $account) {
-            if (! $account->hasFeature(FEATURE_EMAIL_TEMPLATES_REMINDERS)) {
+            if (! $account->hasFeature(FEATURE_EMAIL_TEMPLATES_REMINDERS) || $account->is_disabled) {
                 continue;
             }
 
@@ -201,7 +201,7 @@ class SendReminders extends Command
             $account = $scheduledReport->account;
             $account->loadLocalizationSettings();
 
-            if (! $account->hasFeature(FEATURE_REPORTS)) {
+            if (! $account->hasFeature(FEATURE_REPORTS) || $account->is_disabled) {
                 continue;
             }
 

--- a/app/Http/Controllers/ClientPortalController.php
+++ b/app/Http/Controllers/ClientPortalController.php
@@ -67,6 +67,17 @@ class ClientPortalController extends BaseController
         $client = $invoice->client;
         $account = $invoice->account;
 
+        /* Forward requests from V4 to V5 if the domain is set */
+        if(strlen($account->forward_url_for_v5) >1){
+
+            if ($invoice->isType(INVOICE_TYPE_QUOTE)) 
+                $entity = 'quote';
+            else
+                $entity = 'invoice';
+
+            return redirect($account->forward_url_for_v5."/client/".$entity."/".$invitationKey);
+        }
+
         if (request()->silent) {
             session(['silent:' . $client->id => true]);
             return redirect(request()->url() . (request()->borderless ? '?borderless=true' : ''));

--- a/app/Http/Controllers/ClientPortalController.php
+++ b/app/Http/Controllers/ClientPortalController.php
@@ -68,14 +68,14 @@ class ClientPortalController extends BaseController
         $account = $invoice->account;
 
         /* Forward requests from V4 to V5 if the domain is set */
-        if(strlen($account->forward_url_for_v5) >1){
+        if(strlen($account->account_email_settings->forward_url_for_v5) >1){
 
             if ($invoice->isType(INVOICE_TYPE_QUOTE)) 
                 $entity = 'quote';
             else
                 $entity = 'invoice';
 
-            return redirect($account->forward_url_for_v5."/client/".$entity."/".$invitationKey);
+            return redirect($account->account_email_settings->forward_url_for_v5."/client/".$entity."/".$invitationKey);
         }
 
         if (request()->silent) {

--- a/app/Http/Controllers/Migration/StepsController.php
+++ b/app/Http/Controllers/Migration/StepsController.php
@@ -101,17 +101,17 @@ class StepsController extends BaseController
                 ->withInput();
         }
 
-        $account = \Auth::user()->account;
+        $account_settings = \Auth::user()->account->account_email_settings;
 
         if(strlen($request->input('url')) == 0) {
-            $account->is_disabled = false;
+            $account_settings->is_disabled = false;
         }
         else {
-            $account->is_disabled = true;
+            $account_settings->is_disabled = true;
         }
 
-        $account->forward_url_for_v5 = rtrim($request->input('url'),'/');
-        $account->save();
+        $account_settings->forward_url_for_v5 = rtrim($request->input('url'),'/');
+        $account_settings->save();
 
         return back();
     }

--- a/app/Http/Controllers/Migration/StepsController.php
+++ b/app/Http/Controllers/Migration/StepsController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\BaseController;
 use App\Http\Requests\MigrationAuthRequest;
 use App\Http\Requests\MigrationCompaniesRequest;
 use App\Http\Requests\MigrationEndpointRequest;
+use App\Http\Requests\MigrationForwardRequest;
 use App\Http\Requests\MigrationTypeRequest;
 use App\Libraries\Utils;
 use App\Models\Account;
@@ -15,6 +16,8 @@ use App\Services\Migration\CompleteService;
 use App\Traits\GenerateMigrationResources;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
+use Validator;
+use Illuminate\Http\Request;
 
 class StepsController extends BaseController
 {
@@ -81,6 +84,28 @@ class StepsController extends BaseController
         return redirect(
             url('/migration/endpoint')
         );
+    }
+
+    public function forwardUrl(Request $request)
+    {
+
+        $rules = [
+            'url' => 'nullable|url',
+        ];
+
+        $validator = Validator::make($request->all(), $rules);
+
+        if ($validator->fails()) {
+            return back()
+                ->withErrors($validator)
+                ->withInput();
+        }
+
+        $account = \Auth::user()->account;
+        $account->forward_url_for_v5 = rtrim($request->input('url'),'/');
+        $account->save();
+
+        return back();
     }
 
     public function endpoint()

--- a/app/Http/Requests/MigrationForwardRequest.php
+++ b/app/Http/Requests/MigrationForwardRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class MigrationForwardRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'url' => 'nullable|url',
+        ];
+    }
+}

--- a/app/Traits/GenerateMigrationResources.php
+++ b/app/Traits/GenerateMigrationResources.php
@@ -211,7 +211,51 @@ info("get company");
             'auto_archive_quote' => $this->account->auto_archive_quote ? (bool) $this->account->auto_archive_quote : false,
             'auto_email_invoice' => $this->account->auto_email_invoice ? (bool) $this->account->auto_email_invoice : false,
             'counter_padding' => $this->account->invoice_number_padding ?: 4,
+            'reply_to_email' => $this->account->account_email_settings->reply_to_email ?: '',
+            'bcc_email' => $this->account->account_email_settings->bcc_email ?: '',
+            'email_subject_invoice' => $this->account->account_email_settings->email_subject_invoice ?: '',
+            'email_subject_quote' => $this->account->account_email_settings->email_subject_quote ?: '',
+            'email_subject_payment' => $this->account->account_email_settings->email_subject_payment ?: '',
+            'email_template_invoice' => $this->account->account_email_settings->email_template_invoice ?: '',
+            'email_template_quote' => $this->account->account_email_settings->email_template_quote ?: '',
+            'email_template_payment' => $this->account->account_email_settings->email_template_payment ?: '',
+            'email_subject_reminder1' => $this->account->account_email_settings->email_subject_reminder1 ?: '',
+            'email_subject_reminder2' => $this->account->account_email_settings->email_subject_reminder2 ?: '',
+            'email_subject_reminder3' => $this->account->account_email_settings->email_subject_reminder3 ?: '',
+            'email_subject_reminder_endless' => $this->account->account_email_settings->email_subject_reminder4 ?: '',
+            'email_template_reminder1' => $this->account->account_email_settings->email_template_reminder1 ?: '',
+            'email_template_reminder2' => $this->account->account_email_settings->email_template_reminder2 ?: '',
+            'email_template_reminder3' => $this->account->account_email_settings->email_template_reminder3 ?: '',
+            'email_template_reminder_endless' => $this->account->account_email_settings->email_template_reminder4 ?: '',
+            'late_fee_amount1' => $this->account->account_email_settings->late_fee1_amount ?: 0,
+            'late_fee_amount2' => $this->account->account_email_settings->late_fee2_amount ?: 0,
+            'late_fee_amount3' => $this->account->account_email_settings->late_fee3_amount ?: 0,
+            'late_fee_percent1' => $this->account->account_email_settings->late_fee1_percent ?: 0,
+            'late_fee_percent2' => $this->account->account_email_settings->late_fee2_percent ?: 0,
+            'late_fee_percent3' => $this->account->account_email_settings->late_fee3_percent ?: 0,
+            'enable_reminder1' => $this->account->enable_reminder1 ? true : false,
+            'enable_reminder2' => $this->account->enable_reminder2 ? true : false,
+            'enable_reminder3' => $this->account->enable_reminder3 ? true : false,
+            'enable_reminder_endless' => $this->account->enable_reminder4 ? true : false,
+            'num_days_reminder1' => $this->account->num_days_reminder1 ?: 0,
+            'num_days_reminder2' => $this->account->num_days_reminder2 ?: 0,
+            'num_days_reminder3' => $this->account->num_days_reminder3 ?: 0,
+            'schedule_reminder1' => $this->buildReminderString($this->account->direction_reminder1, $this->account->field_reminder1),
+            'schedule_reminder2' => $this->buildReminderString($this->account->direction_reminder2, $this->account->field_reminder2),
+            'schedule_reminder3' => $this->buildReminderString($this->account->direction_reminder3, $this->account->field_reminder3),
+            'endless_reminder_frequency_id' => $this->account->account_email_settings->reset_counter_frequency_id ? $this->transformFrequencyId($this->account->account_email_settings->reset_counter_frequency_id) : 0,
+            'email_signature' => $this->account->email_footer ?: '',
         ];
+    }
+
+    private function buildReminderString($direction, $field)
+    {
+
+        $direction_string = $direction == 1 ? "after_" : "before_";
+        $field_string = $field == 1 ? "due_date" : "invoice_date";
+
+        return $direction_string.$field_string;
+
     }
 
     public function getTaxRates()

--- a/app/Traits/GenerateMigrationResources.php
+++ b/app/Traits/GenerateMigrationResources.php
@@ -171,7 +171,7 @@ info("get company");
             'all_pages_footer' => $this->account->all_pages_footer ? (bool) $this->account->all_pages_footer : true,
             'all_pages_header' => $this->account->all_pages_header ? (bool) $this->account->all_pages_header : true,
             'show_currency_code' => $this->account->show_currency_code ? (bool) $this->account->show_currency_code : false,
-            'enable_client_portal_password' => $this->account->enable_portal_password ? (bool) $this->account->enable_portal_password : true,
+            'enable_client_portal_password' => $this->account->enable_portal_password ? (bool) $this->account->enable_portal_password : false,
             'send_portal_password' => $this->account->send_portal_password ? (bool) $this->account->send_portal_password : false,
             'recurring_number_prefix' => $this->account->recurring_invoice_number_prefix ? $this->account->recurring_invoice_number_prefix : 'R',
             'enable_client_portal' => $this->account->enable_client_portal ? (bool) $this->account->enable_client_portal : false,

--- a/database/migrations/2021_06_22_234707_add_forward_url_for_v5.php
+++ b/database/migrations/2021_06_22_234707_add_forward_url_for_v5.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddForwardUrlForV5 extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('accounts', function ($table) {
+             $table->text('forward_url_for_v5')->default('');
+         });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/database/migrations/2021_06_22_234707_add_forward_url_for_v5.php
+++ b/database/migrations/2021_06_22_234707_add_forward_url_for_v5.php
@@ -13,7 +13,7 @@ class AddForwardUrlForV5 extends Migration
      */
     public function up()
     {
-        Schema::table('accounts', function ($table) {
+        Schema::table('account_email_settings', function ($table) {
              $table->text('forward_url_for_v5')->default('');
              $table->boolean('is_disabled')->default(false);
          });

--- a/database/migrations/2021_06_22_234707_add_forward_url_for_v5.php
+++ b/database/migrations/2021_06_22_234707_add_forward_url_for_v5.php
@@ -15,6 +15,7 @@ class AddForwardUrlForV5 extends Migration
     {
         Schema::table('accounts', function ($table) {
              $table->text('forward_url_for_v5')->default('');
+             $table->boolean('is_disabled')->default(false);
          });
     }
 

--- a/resources/views/accounts/management.blade.php
+++ b/resources/views/accounts/management.blade.php
@@ -264,8 +264,44 @@
 				</div>
 			</div>
 		</div>
-
 		{!! Former::close() !!}
+
+		<div class="panel panel-default">
+			<div class="panel-heading">
+				<h3 class="panel-title">Forward customers to V5</h3>
+			</div>
+			<div class="panel-body">
+				<form action="{{ url('/migration/forward') }}" method="post" id="forward-form">
+        		{{ csrf_field() }}
+        		<div class="form-group">
+					<label for="modules" class="control-label col-lg-4 col-sm-4"></label>
+					<div class="col-lg-8 col-sm-8">
+						<div class="help-block">
+							Once you are ready to forward your customers, enter your client portal URL for V5 here:<br/>
+						</div><br/>
+					</div>
+        		</div>
+				<div class="form-group">                    
+                    <label for="url"  class="control-label col-lg-4 col-sm-4 text-right">{!! trans('texts.url') !!}</label>
+                    <div class="col-lg-8 col-sm-8">
+                    <input type="text" name="url" placeholder="https://subdomain.invoicing.co" class="form form-control" value="{{ $account->forward_url_for_v5}}">
+		        	@if($errors->has('url')) 
+		                <div class="col-sm-5">
+		                    @foreach ($errors->get('url') as $message)
+		                        <span class="help-block">
+		                            <span class="glyphicon glyphicon-warning-sign"></span> 
+		                            {{ $message }}
+		                        </span>
+		                    @endforeach
+		                </div>
+		            @endif
+		        	<br/>
+		        		<button form="forward-form" class="btn btn-primary btn-lg">{!! trans('texts.submit') !!}</button>
+                	</div>
+				</div>
+				</form>
+			</div>
+		</div>
 
 		@if (! Auth::user()->account->isNinjaOrLicenseAccount())
 			<div class="panel panel-default">

--- a/resources/views/accounts/management.blade.php
+++ b/resources/views/accounts/management.blade.php
@@ -277,7 +277,8 @@
 					<label for="modules" class="control-label col-lg-4 col-sm-4"></label>
 					<div class="col-lg-8 col-sm-8">
 						<div class="help-block">
-							Once you are ready to forward your customers, enter your client portal URL for V5 here:<br/>
+							Once you are ready to forward your customers, enter your client portal URL for V5 here:<br/><br/>
+							<b>Please note once enabled. Your V4 account will become disabled. This means that your recurring invoices and any reminders will no longer fire from V4.</b> <br/><br/>To renable your V4 installation simply set the forwarding url to a blank/empty value.
 						</div><br/>
 					</div>
         		</div>

--- a/resources/views/accounts/management.blade.php
+++ b/resources/views/accounts/management.blade.php
@@ -285,7 +285,7 @@
 				<div class="form-group">                    
                     <label for="url"  class="control-label col-lg-4 col-sm-4 text-right">{!! trans('texts.url') !!}</label>
                     <div class="col-lg-8 col-sm-8">
-                    <input type="text" name="url" placeholder="https://subdomain.invoicing.co" class="form form-control" value="{{ $account->forward_url_for_v5}}">
+                    <input type="text" name="url" placeholder="https://subdomain.invoicing.co" class="form form-control" value="{{ $account->account_email_settings->forward_url_for_v5}}">
 		        	@if($errors->has('url')) 
 		                <div class="col-sm-5">
 		                    @foreach ($errors->get('url') as $message)

--- a/routes/web.php
+++ b/routes/web.php
@@ -159,6 +159,7 @@ Route::group(['middleware' => ['lookup:user', 'auth:user']], function () {
     Route::get('migration/companies', 'Migration\StepsController@companies');
     Route::post('migration/companies', 'Migration\StepsController@handleCompanies');
     Route::get('migration/completed', 'Migration\StepsController@completed');
+    Route::post('migration/forward', 'Migration\StepsController@forwardUrl');
 
     Route::get('migration/import', 'Migration\StepsController@import');
 


### PR DESCRIPTION
This PR enables a user to define the forwarding URL to divert V4 requests to V5 installation.

If the URL is set, the V4 installation will also enter a disabled state where Recurring Invoices are not generated and/or autobilling/reminders are no longer sent from V4.