### PR TITLE
Update 'Clean' PDF Design

### DIFF
--- a/resources/views/pdf-designs/clean.html
+++ b/resources/views/pdf-designs/clean.html
@@ -37,7 +37,7 @@
         flex-direction: column;
     }
 
-    #company-details > span:first-child {
+    #company-details > p:first-child {
         color: var(--primary-color);
     }
 


### PR DESCRIPTION
The span-selector in #company-details in the Clean PDF template seems incorrect here, and the selector should be a p-selector as children of #company-details are paragraphs. 

Tested on v5-stable in the in-app CSS editor. 