### PR TITLE
WePay: Initialize Javascript with the postcode after fields checking

### DIFF
--- a/resources/views/portal/ninja2020/gateways/wepay/credit_card/pay.blade.php
+++ b/resources/views/portal/ninja2020/gateways/wepay/credit_card/pay.blade.php
@@ -74,8 +74,6 @@
     <script>
         Livewire.on('passed-required-fields-check', (event) => {
             if (event.hasOwnProperty('client_postal_code')) {
-                console.log('Got POSTCODE');
-
                 document.querySelector('meta[name=client-postal-code]').content = event.client_postal_code;
             }
         });

--- a/resources/views/portal/ninja2020/gateways/wepay/credit_card/pay.blade.php
+++ b/resources/views/portal/ninja2020/gateways/wepay/credit_card/pay.blade.php
@@ -71,5 +71,15 @@
 @endsection
 
 @section('gateway_footer')
+    <script>
+        Livewire.on('passed-required-fields-check', (event) => {
+            if (event.hasOwnProperty('client_postal_code')) {
+                console.log('Got POSTCODE');
+
+                document.querySelector('meta[name=client-postal-code]').content = event.client_postal_code;
+            }
+        });
+    </script>
+
     <script src="{{ asset('js/clients/payments/wepay-credit-card.js') }}"></script>
 @endsection


### PR DESCRIPTION
This will let us use the postcode from post-field checking in the Javascript.