### PR TITLE
(v5) Quotes improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release notes
 
 ## [Unreleased (daily channel)](https://github.com/invoiceninja/invoiceninja/tree/v5-develop)
+## Added:
+- Client portal: Show message when trying to approve non-approvable quotes
+- Client portal: Remove "Approve" button from single quote page if quote is non-approvable
+
+## Fixed:
+- Client portal: Showing message instead of blank page when trying to download zero quotes.
 
 ## [v5.2.0-release](https://github.com/invoiceninja/invoiceninja/releases/tag/v5.2.0-release)
 ## Added:

--- a/app/Http/Controllers/ClientPortal/QuoteController.php
+++ b/app/Http/Controllers/ClientPortal/QuoteController.php
@@ -85,7 +85,9 @@ class QuoteController extends Controller
             ->get();
 
         if (! $quotes || $quotes->count() == 0) {
-            return;
+            return redirect()
+                ->route('client.quotes.index')
+                ->with('message', ctrans('texts.no_quotes_available_for_download'));
         }
 
         if ($quotes->count() == 1) {

--- a/app/Http/Controllers/ClientPortal/QuoteController.php
+++ b/app/Http/Controllers/ClientPortal/QuoteController.php
@@ -121,7 +121,9 @@ class QuoteController extends Controller
             ->get();
 
         if (!$quotes || $quotes->count() == 0) {
-            return redirect()->route('client.quotes.index');
+            return redirect()
+                ->route('client.quotes.index')
+                ->with('message', ctrans('texts.quotes_with_status_sent_can_be_approved'));
         }
 
         if ($process) {

--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -4279,6 +4279,7 @@ $LANG = array(
     'recurring_purchases' => 'Recurring purchases',
     'you_might_be_interested_in_following' => 'You might be interested in following',
     'quotes_with_status_sent_can_be_approved' => 'Only quotes with "Sent" status can be approved.',
+    'no_quotes_available_for_download' => 'No quotes available for download.',
 );
 
 return $LANG;

--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -4278,6 +4278,7 @@ $LANG = array(
     'one_time_purchases' => 'One time purchases',
     'recurring_purchases' => 'Recurring purchases',
     'you_might_be_interested_in_following' => 'You might be interested in following',
+    'quotes_with_status_sent_can_be_approved' => 'Only quotes with "Sent" status can be approved.',
 );
 
 return $LANG;

--- a/resources/views/portal/ninja2020/quotes/show.blade.php
+++ b/resources/views/portal/ninja2020/quotes/show.blade.php
@@ -19,10 +19,12 @@
         @endcomponent
     @endif
 
-    @if(!$quote->isApproved())
+    @if($quote->status_id === \App\Models\Quote::STATUS_SENT)
         <div class="mb-4">
             @include('portal.ninja2020.quotes.includes.actions', ['quote' => $quote])
         </div>
+    @else
+        <p class="text-right text-gray-900 text-sm mb-4">{{ ctrans('texts.quotes_with_status_sent_can_be_approved') }}</p>
     @endif
 
     @include('portal.ninja2020.components.entity-documents', ['entity' => $quote])

--- a/tests/Browser/ClientPortal/QuotesTest.php
+++ b/tests/Browser/ClientPortal/QuotesTest.php
@@ -74,10 +74,22 @@ class QuotesTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser
                 ->visitRoute('client.quotes.index')
+                ->clickLink('View')
+                ->assertSee('Only quotes with "Sent" status can be approved.')
+                ->visitRoute('client.logout');
+        });
+    }
+
+    public function testMessageForNonApprovableQuotesIsVisible()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visitRoute('client.quotes.index')
                 ->check('.form-check.form-check-child')
                 ->press('Approve')
                 ->assertPathIs('/client/quotes')
                 ->assertDontSee('Quote(s) approved successfully.')
+                ->assertSee('Only quotes with "Sent" status can be approved.')
                 ->visitRoute('client.logout');
         });
     }

--- a/tests/Browser/ClientPortal/QuotesTest.php
+++ b/tests/Browser/ClientPortal/QuotesTest.php
@@ -93,4 +93,14 @@ class QuotesTest extends DuskTestCase
                 ->visitRoute('client.logout');
         });
     }
+
+    public function testNoQuotesAvailableForDownloadMessage()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visitRoute('client.quotes.index')
+                ->press('Download')
+                ->assertSee('No quotes available for download.');
+        });
+    }
 }


### PR DESCRIPTION
## Added:
- Client portal: Show message when trying to approve non-approvable quotes
- Client portal: Remove "Approve" button from single quote page if quote is non-approvable

## Fixed:
- Client portal: Showing message instead of blank page when trying to download zero quotes.