### PR TITLE
Markdown support for line items

### DIFF
--- a/app/Services/PdfMaker/Design.php
+++ b/app/Services/PdfMaker/Design.php
@@ -347,7 +347,7 @@ class Design extends BaseDesign
 
         $items = $this->transformLineItems($this->entity->line_items, $type);
 
-        //        $this->processMarkdownOnLineItems($items);
+        $this->processMarkdownOnLineItems($items);
 
         if (count($items) == 0) {
             return [];

--- a/app/Services/PdfMaker/Designs/Utilities/DesignHelpers.php
+++ b/app/Services/PdfMaker/Designs/Utilities/DesignHelpers.php
@@ -12,6 +12,7 @@
 
 namespace App\Services\PdfMaker\Designs\Utilities;
 
+use App\Utils\MarkdownParser;
 use App\Utils\Traits\MakesHash;
 use DOMDocument;
 use DOMXPath;
@@ -338,7 +339,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
         foreach ($items as $key => $item) {
             foreach ($item as $variable => $value) {
-                $item[$variable] = DesignHelpers::parseMarkdownToHtml($value ?? '');
+                $item[$variable] = MarkdownParser::parse($value ?? '');
             }
 
             $items[$key] = $item;

--- a/app/Services/PdfMaker/PdfMakerUtilities.php
+++ b/app/Services/PdfMaker/PdfMakerUtilities.php
@@ -108,8 +108,10 @@ trait PdfMakerUtilities
                     continue;
                 }
 
-                $contains_html = preg_match("/\/[a-z]*>/i", $child['content'], $m) != 0;
+                $contains_html = preg_match('#(?<=<)\w+(?=[^<]*?>)#', $child['content'], $m) != 0;
             }
+
+            info(['contains_html' => $contains_html, 'content' => $child['content'] ?? '']);
 
             if ($contains_html) {
                 // If the element contains the HTML, we gonna display it as is. DOMDocument, is going to

--- a/app/Services/PdfMaker/PdfMakerUtilities.php
+++ b/app/Services/PdfMaker/PdfMakerUtilities.php
@@ -95,7 +95,7 @@ trait PdfMakerUtilities
                 // Commented cause it keeps adding <br> at the end, if markdown parsing is turned on.
                 // Should update with 'parse_markdown_on_pdfs' setting.
 
-                 $child['content'] = nl2br($child['content']);
+                //  $child['content'] = nl2br($child['content']);
             }
 
             // "/\/[a-z]*>/i" -> checks for HTML-like tags:
@@ -121,7 +121,7 @@ trait PdfMakerUtilities
                 $_child->setAttribute('data-state', 'encoded-html');
                 $_child->nodeValue = htmlspecialchars($child['content']);
             } else {
-                // .. in case string doesn't contain any HTML, we'll just return
+                // .. in case string doesn't contaig any HTML, we'll just return
                 // raw $content.
 
                 $_child = $this->document->createElement($child['element'], isset($child['content']) ? htmlspecialchars($child['content']) : '');

--- a/app/Services/PdfMaker/PdfMakerUtilities.php
+++ b/app/Services/PdfMaker/PdfMakerUtilities.php
@@ -121,7 +121,7 @@ trait PdfMakerUtilities
                 $_child->setAttribute('data-state', 'encoded-html');
                 $_child->nodeValue = htmlspecialchars($child['content']);
             } else {
-                // .. in case string doesn't contaig any HTML, we'll just return
+                // .. in case string doesn't contain any HTML, we'll just return
                 // raw $content.
 
                 $_child = $this->document->createElement($child['element'], isset($child['content']) ? htmlspecialchars($child['content']) : '');

--- a/app/Utils/MarkdownParser.php
+++ b/app/Utils/MarkdownParser.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Utils;
+
+class MarkdownParser
+{
+    public static function parse(string $original): string
+    {
+        $lines = \preg_split("/\r\n|\n|\r/", $original);
+        $markdowns = [];
+
+        foreach ($lines as $line) {
+            if (\Illuminate\Support\Str::startsWith(\trim($line), ['#'])) {
+                $markdowns[] = \trim($line);
+            }
+        }
+
+        foreach ($markdowns as $key => $markdown) {
+            $parts = \explode('#', $markdown);
+
+            $tag = self::getHtmlTag($markdown);
+
+            $wrap = \sprintf('<%s>%s<%s>', $tag, \implode('', $parts), $tag);
+
+            $original = \str_replace($markdown, $wrap, $original);
+        }
+
+        return $original;
+    }
+
+    protected static function getHtmlTag(string $markdown): ?string
+    {
+        $count = 0;
+
+        $parts = \explode('#', $markdown);
+
+        foreach ($parts as $key => $value) {
+            if (empty($value)) {
+                $count++;
+            }
+        }
+
+        return 'h' . $count;
+    }
+}


### PR DESCRIPTION
This will let us use a (limited) subset of markdown in line items.

Roadmap:
- [x] Initial version with H tags
- [ ] Support for bold, italic
- [ ] Make it work with configurable setting (nl2br & parsing)
- [ ] Unit tests for MarkdownParser