### PR TITLE
(v5) Refactor webhooks

### DIFF
--- a/app/Http/Controllers/PaymentWebhookController.php
+++ b/app/Http/Controllers/PaymentWebhookController.php
@@ -13,26 +13,14 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\Payments\PaymentWebhookRequest;
-use App\Libraries\MultiDB;
-use Auth;
 
 class PaymentWebhookController extends Controller
 {
-    public function __invoke(PaymentWebhookRequest $request, string $company_key, string $company_gateway_id)
+    public function __invoke(PaymentWebhookRequest $request)
     {
-
-        $payment = $request->getPayment();
-        
-        if(!$payment)
-        	return response()->json(['message' => 'Payment record not found.'], 400);
-
-        $client = is_null($payment) ? $request->getClient() : $payment->client;
-
-        if(!$client)
-	        return response()->json(['message' => 'Client record not found.'], 400);
-
-        return $request->getCompanyGateway()
-            ->driver($client)
-            ->processWebhookRequest($request, $payment);
+        return $request
+            ->getCompanyGateway()
+            ->driver()
+            ->processWebhookRequest($request);
     }
 }

--- a/app/Http/Requests/Payments/PaymentWebhookRequest.php
+++ b/app/Http/Requests/Payments/PaymentWebhookRequest.php
@@ -66,54 +66,6 @@ class PaymentWebhookRequest extends Request
     }
 
     /**
-     * Resolve possible payment in the request.
-     *
-     * @return null|\App\Models\Payment
-     */
-    public function getPayment()
-    {
-        // For testing purposes we'll slow down the webhook processing by 2 seconds
-        // to make sure webhook request doesn't came before our processing.
-        //if (app()->environment() !== 'production') {
-            sleep(2);
-        //}
-
-        // Some gateways, like Checkout, we can dynamically pass payment hash,
-        // which we will resolve here and get payment information from it.
-        if ($this->getPaymentHash()) {
-            return $this->getPaymentHash()->payment;
-        }
-
-        // While for some gateways, we need to extract the payment source/reference from the webhook request.
-        // Gateways like this: Stripe
-        if ($this->has('api_version') && $this->has('type') && $this->has('data')) {
-            $src = $this->data['object']['id'];
-
-            return Payment::where('transaction_reference', $src)->firstOrFail();
-        }
-
-        // If none of previously done logics is correct, we'll just display
-        // not found page.
-        return false;
-    }
-
-    /**
-     * Resolve client from payment hash.
-     *
-     * @return null|\App\Models\Client|bool
-     */
-    public function getClient()
-    {
-        $hash = $this->getPaymentHash();
-
-        if($hash) {
-            return Client::find($hash->data->client_id)->firstOrFail();
-        }
-
-        return false;
-    }
-
-    /**
      * Resolve company from company_key parameter.
      *
      * @return null|\App\Models\Company

--- a/app/Models/CompanyGateway.php
+++ b/app/Models/CompanyGateway.php
@@ -118,7 +118,7 @@ class CompanyGateway extends BaseModel
     }
 
     /* This is the public entry point into the payment superclass */
-    public function driver(Client $client)
+    public function driver(Client $client = null)
     {
         $class = static::driver_class();
 

--- a/app/PaymentDrivers/CheckoutComPaymentDriver.php
+++ b/app/PaymentDrivers/CheckoutComPaymentDriver.php
@@ -332,7 +332,7 @@ class CheckoutComPaymentDriver extends BaseDriver
         }
     }
 
-    public function processWebhookRequest(PaymentWebhookRequest $request, Payment $payment = null)
+    public function processWebhookRequest(PaymentWebhookRequest $request)
     {
         return true;
     }

--- a/app/PaymentDrivers/WePayPaymentDriver.php
+++ b/app/PaymentDrivers/WePayPaymentDriver.php
@@ -168,6 +168,8 @@ class WePayPaymentDriver extends BaseDriver
 
         $input = $request->all();
 
+        $config = $this->company_gateway->getConfig();
+
         $accountId = $this->company_gateway->getConfigField('accountId');
 
         foreach (array_keys($input) as $key) {


### PR DESCRIPTION
This will refactor the webhooks process to a simpler and modular approach.

Roadmap:
- [x] Refactor `WebhooksController`
- [x] Allow $client to be nullable in `driver()` method
- [x] Cleanup methods in `PaymentWebhookRequest` 
- [ ] Update developer docs

Gateways:
- [x] Stripe
- [x] Authorize.net (not supported)
- [x] Checkout.com (not supported)
- [x] PayPal (not supported)
- [x] Braintree (not supported)
- [ ] WePay (on hold)
- [ ] Paytrace (different branch - still in development)
- [x] Mollie (implemented in Mollie PR)