### PR TITLE
Allow configuring mailgun endpoint by setting MAILGUN_ENDPOINT

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -19,6 +19,7 @@ return [
     'mailgun' => [
         'domain' => env('MAILGUN_DOMAIN',''),
         'secret' => env('MAILGUN_SECRET',''),
+        'endpoint' => env('MAILGUN_ENDPOINT', 'api.mailgun.net'),
     ],
 
     'mandrill' => [


### PR DESCRIPTION
See: https://github.com/invoiceninja/invoiceninja/pull/5770

Similar to https://laravel.com/docs/8.x/mail#mailgun-driver but keeping default the same as current US endpoint.
