### PR TITLE
(v5) Support for weekly notations

### DIFF
--- a/app/Utils/Traits/MakesInvoiceValues.php
+++ b/app/Utils/Traits/MakesInvoiceValues.php
@@ -358,6 +358,12 @@ trait MakesInvoiceValues
                 ':MONTH' => Carbon::createFromDate(now()->year, now()->month)->translatedFormat('F'),
                 ':YEAR' => now()->year,
                 ':QUARTER' => 'Q' . now()->quarter,
+                ':WEEK_BEFORE' => \sprintf(
+                    '%s %s %s',
+                    Carbon::now()->subDays(7)->translatedFormat($this->client->date_format()),
+                    ctrans('texts.to'),
+                    Carbon::now()->translatedFormat($this->client->date_format())
+                ),
                 ':WEEK' => \sprintf(
                     '%s %s %s', 
                     Carbon::now()->translatedFormat($this->client->date_format()), 

--- a/app/Utils/Traits/MakesInvoiceValues.php
+++ b/app/Utils/Traits/MakesInvoiceValues.php
@@ -364,6 +364,12 @@ trait MakesInvoiceValues
                     ctrans('texts.to'),
                     Carbon::now()->translatedFormat($this->client->date_format())
                 ),
+                ':WEEK_AHEAD' => \sprintf(
+                    '%s %s %s',
+                    Carbon::now()->addDays(7)->translatedFormat($this->client->date_format()),
+                    ctrans('texts.to'),
+                    Carbon::now()->addDays(14)->translatedFormat($this->client->date_format())
+                ),
                 ':WEEK' => \sprintf(
                     '%s %s %s', 
                     Carbon::now()->translatedFormat($this->client->date_format()), 

--- a/app/Utils/Traits/MakesInvoiceValues.php
+++ b/app/Utils/Traits/MakesInvoiceValues.php
@@ -358,6 +358,12 @@ trait MakesInvoiceValues
                 ':MONTH' => Carbon::createFromDate(now()->year, now()->month)->translatedFormat('F'),
                 ':YEAR' => now()->year,
                 ':QUARTER' => 'Q' . now()->quarter,
+                ':WEEK' => \sprintf(
+                    '%s %s %s', 
+                    Carbon::now()->translatedFormat($this->client->date_format()), 
+                    ctrans('texts.to'), 
+                    Carbon::now()->addDays(7)->translatedFormat($this->client->date_format())
+                ),
             ],
             'raw' => [
                 ':MONTH' => now()->month,


### PR DESCRIPTION
Support for `:WEEK` `:WEEK_BEFORE` `:WEEK_AHEAD` notation.

https://github.com/invoiceninja/invoiceninja/issues/6206

![image](https://user-images.githubusercontent.com/13711415/128508204-c4258c4c-46a1-41f8-a0f4-74520a88c804.png)
