### PR TITLE
Show navigation bar only if `enable_client_portal` is toggled

### DIFF
--- a/resources/views/portal/ninja2020/components/general/sidebar/main.blade.php
+++ b/resources/views/portal/ninja2020/components/general/sidebar/main.blade.php
@@ -5,18 +5,20 @@
     id="main-sidebar">
 
     @if($settings->enable_client_portal)
-    <!-- Off-canvas menu for mobile -->
-    @include('portal.ninja2020.components.general.sidebar.mobile')
+        <!-- Off-canvas menu for mobile -->
+        @include('portal.ninja2020.components.general.sidebar.mobile')
 
-    <!-- Static sidebar for desktop -->
-    @unless(request()->query('sidebar') === 'hidden')
-        @include('portal.ninja2020.components.general.sidebar.desktop')
-    @endunless
-
+        <!-- Static sidebar for desktop -->
+        @unless(request()->query('sidebar') === 'hidden')
+            @include('portal.ninja2020.components.general.sidebar.desktop')
+        @endunless
     @endif
 
     <div class="flex flex-col w-0 flex-1 overflow-hidden">
-        @include('portal.ninja2020.components.general.sidebar.header')
+        @if($settings->enable_client_portal)
+            @include('portal.ninja2020.components.general.sidebar.header')
+        @endif
+        
         <main
             class="flex-1 relative z-0 overflow-y-auto pt-6 focus:outline-none"
             tabindex="0" x-data


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13711415/132122720-7317acf3-322d-46f6-8909-7f5079a901f4.png)
