### PR TITLE
Show archived payments in client portal

### DIFF
--- a/app/Http/Livewire/PaymentsTable.php
+++ b/app/Http/Livewire/PaymentsTable.php
@@ -44,6 +44,7 @@ class PaymentsTable extends Component
             ->where('company_id', $this->company->id)
             ->where('client_id', auth('contact')->user()->client->id)
             ->orderBy($this->sort_field, $this->sort_asc ? 'asc' : 'desc')
+            ->withTrashed()
             ->paginate($this->per_page);
 
         return render('components.livewire.payments-table', [


### PR DESCRIPTION
This will include archived payments in the payments table (client portal), making it consistent with invoices table.