### PR TITLE
Braintree: Add MAID references

### DIFF
--- a/app/PaymentDrivers/Braintree/CreditCard.php
+++ b/app/PaymentDrivers/Braintree/CreditCard.php
@@ -151,11 +151,6 @@ class CreditCard
             ],
         ];
 
-        if ($this->braintree->company_gateway->getConfigField('merchantAccountId')) {
-            /** https://developer.paypal.com/braintree/docs/reference/request/payment-method/create#options.verification_merchant_account_id */
-            $data['verificationMerchantAccountId'] = $this->braintree->company_gateway->getConfigField('merchantAccountId');
-        }
-
         $response = $this->braintree->gateway->paymentMethod()->create($data);
 
         if ($response->success) {


### PR DESCRIPTION
This will add merchant account id reference to the pre-payment token.

Note: I tried adding `verificationMerchantAccountId` to token creation request. Even though that's listed in their docs, it fails on tests. Please have a look at the screenshot.

https://developer.paypal.com/braintree/docs/reference/request/payment-method/create#options.verification_merchant_account_id

![image](https://user-images.githubusercontent.com/13711415/133104463-cad2a0fd-0fd4-4c36-a54f-a8085dae38da.png)
