### PR TITLE
Stripe: Change accepted webhook type

### DIFF
--- a/app/PaymentDrivers/StripePaymentDriver.php
+++ b/app/PaymentDrivers/StripePaymentDriver.php
@@ -422,7 +422,7 @@ class StripePaymentDriver extends BaseDriver
         // Allow app to catch up with webhook request.
         sleep(2);
 
-        if ($request->type === 'charge.succeeded' || $request->type === 'source.chargeable') {
+        if ($request->type === 'charge.succeeded' || $request->type === 'payment_intent.succeeded') {
             foreach ($request->data as $transaction) {
                 $payment = Payment::query()
                         ->where('transaction_reference', $transaction['id'])


### PR DESCRIPTION
Related to https://github.com/invoiceninja/invoiceninja/issues/6612.

This will change when to trigger a successful transaction. Previously it was once source becomes chargeable, which is wrong. According to Stripe documentation, we can use `payment_intent.succeeded` & `charge.succeeded`.

Ref:
- https://stripe.com/docs/payments/payment-intents/verifying-status
- https://stripe.com/docs/api/events