### PR TITLE
Add missing semicolons

### DIFF
--- a/app/Http/Requests/Company/DefaultCompanyRequest.php
+++ b/app/Http/Requests/Company/DefaultCompanyRequest.php
@@ -22,7 +22,7 @@ class DefaultCompanyRequest extends Request
      */
     public function authorize() : bool
     {
-        return auth()->user()->isAdmin()
+        return auth()->user()->isAdmin();
     }
 
     public function rules()

--- a/app/PaymentDrivers/Eway/Token.php
+++ b/app/PaymentDrivers/Eway/Token.php
@@ -95,7 +95,7 @@ class Token
 
         $response_status = ErrorCode::getStatus($response->ResponseMessage);
 
-    	$error = $response_status['message']
+    	$error = $response_status['message'];
     	$error_code = $response->ResponseMessage;
     	
         $data = [

--- a/app/PaymentDrivers/Stripe/SEPA.php
+++ b/app/PaymentDrivers/Stripe/SEPA.php
@@ -43,7 +43,7 @@ class SEPA
           'customer' => $customer->id,
         ], $this->stripe_driver->stripe_connect_auth);
 
-        $client_secret = $setup_intent->client_secret
+        $client_secret = $setup_intent->client_secret;
         // Pass the client secret to the client
 
 


### PR DESCRIPTION
During deployment an automated `php -l` job found a few missing semicolons resulting in syntax errors. Hope my PR is up to standards, otherwise please let me know!