### PR TITLE
Client portal: Statements page in pure Javascript

### DIFF
--- a/resources/js/clients/shared/pdf.js
+++ b/resources/js/clients/shared/pdf.js
@@ -80,6 +80,15 @@ class PDF {
             .getElementById('zoom-out')
             .addEventListener('click', () => this.handleZoomChange());
 
+        document
+            .querySelector('meta[name=pdf-url]')
+            .addEventListener('change', () => {
+                this.canvas.getContext('2d').clearRect(0, 0, this.canvas.width, this.canvas.height);
+                this.url = document.querySelector("meta[name='pdf-url']").content;
+
+                this.handle();
+            })
+
         return this;
     }
 

--- a/resources/views/portal/ninja2020/statement/index.blade.php
+++ b/resources/views/portal/ninja2020/statement/index.blade.php
@@ -2,6 +2,49 @@
 
 @section('meta_title', ctrans('texts.statement'))
 
+@push('head')
+    <meta name="pdf-url" content="{{ route('client.statement.raw') }}">
+@endpush
+
 @section('body')
-    @livewire('statement')
+    <div class="flex flex-col md:flex-row md:justify-between">
+        <div class="flex flex-col md:flex-row md:items-center">
+            <div class="flex">
+                <label for="from" class="block w-full flex items-center mr-4">
+                    <span class="mr-2">{{ ctrans('texts.from') }}:</span>
+                    <input type="date" class="input w-full">
+                </label>
+
+                <label for="to" class="block w-full flex items-center mr-4">
+                    <span class="mr-2">{{ ctrans('texts.to') }}:</span>
+                    <input type="date" class="input w-full">
+                </label>
+            </div> <!-- End date range -->
+
+            <label for="show_payments" class="block flex items-center mr-4 mt-4 md:mt-0">
+                <input type="checkbox" class="form-checkbox" autocomplete="off">
+                <span class="ml-2">{{ ctrans('texts.show_payments') }}</span>
+            </label> <!-- End show payments checkbox -->
+
+            <label for="show_aging" class="block flex items-center">
+                <input type="checkbox" class="form-checkbox" autocomplete="off">
+                <span class="ml-2">{{ ctrans('texts.show_aging') }}</span>
+            </label> <!-- End show aging checkbox -->
+        </div>
+        <button class="button button-primary bg-primary mt-4 md:mt-0">{{ ctrans('texts.download') }}</button>
+    </div>
+
+    @include('portal.ninja2020.components.pdf-viewer', ['url' => route('client.statement.raw')])
 @endsection
+
+@push('footer')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            // document
+            //     .querySelector('meta[name=pdf-url]')
+            //     .content = 'https://google.com';
+
+            // document.querySelector('meta[name=pdf-url]').dispatchEvent(new Event('change'));
+        });
+    </script>
+@endpush


### PR DESCRIPTION
This will implement statements showing in pure JS. For some reason, Livewire state crashes on request (it happens randomly). Thankfully, it's a fairly simple thing so we can make this work in pure JS.

Roadmap:
- [ ] Extract markup from the `Statement` component
- [ ] Make PDF hot swappable for `iframe` and `PDF.js`
- [ ] Data binding for date, payments & aging table
- [ ] Remove leftovers (statement blade markup & Livewire component)