### PR TITLE
Fixes for `processReservedKeywords`

### DIFF
--- a/app/Utils/Helpers.php
+++ b/app/Utils/Helpers.php
@@ -103,11 +103,11 @@ class Helpers
     /**
      * Process reserved keywords on PDF.
      *  
-     * @param string $value 
+     * @param mixed $value 
      * @param Client $client 
      * @return null|string 
      */
-    public static function processReservedKeywords(string $value, Client $client): ?string
+    public static function processReservedKeywords($value, Client $client): ?string
     {
         Carbon::setLocale($client->locale());
 

--- a/app/Utils/Helpers.php
+++ b/app/Utils/Helpers.php
@@ -107,8 +107,12 @@ class Helpers
      * @param Client $client 
      * @return null|string 
      */
-    public static function processReservedKeywords($value, Client $client): ?string
+    public static function processReservedKeywords($value = null, Client $client): ?string
     {
+        if (\is_null($value)) {
+            return '';
+        }
+
         Carbon::setLocale($client->locale());
 
         $replacements = [


### PR DESCRIPTION
Removing the `string` type requirement that was causing 500 error.