### PR TITLE
Update default gateway preferences

### DIFF
--- a/resources/views/portal/ninja2020/gateways/braintree/ach/authorize.blade.php
+++ b/resources/views/portal/ninja2020/gateways/braintree/ach/authorize.blade.php
@@ -73,6 +73,7 @@
 
     @component('portal.ninja2020.components.general.card-element', ['title' => ctrans('texts.state')])
         <select class="input w-full" id="billing-region">
+            <option disabled selected></option>
             @foreach(\App\DataProviders\USStates::get() as $code => $state)
                 <option value="{{ $code }}">{{ $state }} ({{ $code }})</option>
             @endforeach

--- a/resources/views/portal/ninja2020/gateways/stripe/ach/authorize.blade.php
+++ b/resources/views/portal/ninja2020/gateways/stripe/ach/authorize.blade.php
@@ -43,7 +43,8 @@
     @endcomponent
 
     @component('portal.ninja2020.components.general.card-element', ['title' => ctrans('texts.country')])
-        <select name="countries" id="country" class="form-select input w-full" required>
+        <select name="countries" id="country" class="form-select input w-full">
+            <option disabled selected></option>
             @foreach($countries as $country)
                 <option value="{{ $country->iso_3166_2 }}">{{ $country->iso_3166_2 }} ({{ $country->name }})</option>
             @endforeach
@@ -52,6 +53,7 @@
 
     @component('portal.ninja2020.components.general.card-element', ['title' => ctrans('texts.currency')])
         <select name="currencies" id="currency" class="form-select input w-full">
+            <option disabled selected></option>
             @foreach($currencies as $currency)
                 <option value="{{ $currency->code }}">{{ $currency->code }} ({{ $currency->name }})</option>
             @endforeach


### PR DESCRIPTION
Changes:
- Default to blank country/currency for Stripe ACH 
- Default to empty state for Braintree ACH