### PR TITLE
Use PDF.js for mobile devices

### DIFF
--- a/resources/views/portal/ninja2020/components/pdf-viewer.blade.php
+++ b/resources/views/portal/ninja2020/components/pdf-viewer.blade.php
@@ -1,5 +1,5 @@
 @php
-    $android = stripos($_SERVER['HTTP_USER_AGENT'], 'Android');
+    $mobile = stripos($_SERVER['HTTP_USER_AGENT'], 'Android') || stripos($_SERVER['HTTP_USER_AGENT'], 'iPhone') || stripos($_SERVER['HTTP_USER_AGENT'], 'iPod') || stripos($_SERVER['HTTP_USER_AGENT'], 'iPad');
 @endphp
 
 @push('head')
@@ -9,7 +9,7 @@
 
 <div class="flex items-center justify-between mt-4">
     <section class="flex items-center">
-        <div class="items-center" style="{{ $android ? '' : 'display: none' }}" id="pagination-button-container">
+        <div class="items-center" style="{{ $mobile ? '' : 'display: none' }}" id="pagination-button-container">
             <button class="input-label focus:outline-none hover:text-blue-600 transition ease-in-out duration-300"
                 id="previous-page-button" title="Previous page">
                 <svg class="w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -23,14 +23,14 @@
                 </svg>
             </button>
         </div>
-        <span class="text-sm text-gray-700 ml-2 {{ $android ? 'block' : 'hidden' }}">{{ ctrans('texts.page') }}:
+        <span class="text-sm text-gray-700 ml-2 {{ $mobile ? 'block' : 'hidden' }}">{{ ctrans('texts.page') }}:
             <span id="current-page-container"></span>
             <span>{{ strtolower(ctrans('texts.of')) }}</span>
             <span id="total-page-container"></span>
         </span>
     </section>
     <section class="flex items-center space-x-1">
-        <div class="flex items-center mr-4 space-x-1 {{ $android ? 'block' : 'hidden' }}">
+        <div class="flex items-center mr-4 space-x-1 {{ $mobile ? 'block' : 'hidden' }}">
             <span class="text-gray-600 mr-2" id="zoom-level">100%</span>
             <a href="#" id="zoom-in">
                 <svg class="text-gray-400 hover:text-gray-600 focus:outline-none focus:text-gray-600 cursor-pointer"
@@ -81,7 +81,7 @@
     </section>
 </div>
 
-@if($android)
+@if($mobile)
     <div class="flex justify-center">
         <canvas id="pdf-placeholder" class="shadow rounded-lg bg-white mt-4 p-4"></canvas>
     </div>
@@ -90,7 +90,7 @@
 @endif
 
 
-@if($android)
+@if($mobile)
     @push('footer')
         <script src="{{ asset('js/clients/shared/pdf.js') }}" defer></script>
     @endpush


### PR DESCRIPTION
This will use PDF.js as a viewer for Android-based devices, iPhone, iPad & iPod.