### PR TITLE
Reference customer when paying with Checkout.com

### DIFF
--- a/app/PaymentDrivers/CheckoutCom/CreditCard.php
+++ b/app/PaymentDrivers/CheckoutCom/CreditCard.php
@@ -112,7 +112,7 @@ class CreditCard implements MethodInterface
         $data['currency'] = $this->checkout->client->getCurrencyCode();
         $data['value'] = $this->checkout->convertToCheckoutAmount($data['total']['amount_with_fee'], $this->checkout->client->getCurrencyCode());
         $data['raw_value'] = $data['total']['amount_with_fee'];
-        $data['customer_email'] = $this->checkout->client->present()->email;
+        $data['customer_email'] = $this->checkout->client->present()->email();
 
         return render('gateways.checkout.credit_card.pay', $data);
     }
@@ -173,6 +173,10 @@ class CreditCard implements MethodInterface
         $payment = new Payment($method, $this->checkout->payment_hash->data->currency);
         $payment->amount = $this->checkout->payment_hash->data->value;
         $payment->reference = $this->checkout->getDescription();
+        $payment->customer = [
+            'name' => $this->checkout->client->present()->name() ,
+            'email' => $this->checkout->client->present()->email(),
+        ];
 
         $this->checkout->payment_hash->data = array_merge((array)$this->checkout->payment_hash->data, ['checkout_payment_ref' => $payment]);
         $this->checkout->payment_hash->save();


### PR DESCRIPTION
From now on, users will be able to group payments in the Checkout.com dashboard by customer.

![image](https://user-images.githubusercontent.com/13711415/138710734-9c590730-1175-4e82-b063-0d139dfd1117.png)
