### PR TITLE
Fix for accesing `response_summary` on payment object

### DIFF
--- a/app/PaymentDrivers/CheckoutCom/Utilities.php
+++ b/app/PaymentDrivers/CheckoutCom/Utilities.php
@@ -84,8 +84,7 @@ trait Utilities
 
     public function processUnsuccessfulPayment(Payment $_payment, $throw_exception = true)
     {
-
-        $this->getParent()->sendFailureMail($_payment->status . " " . $_payment->response_summary);
+        $this->getParent()->sendFailureMail($_payment->status . " " . optional($_payment)->response_summary);
 
         $message = [
             'server_response' => $_payment,
@@ -102,7 +101,7 @@ trait Utilities
         );
 
         if ($throw_exception) {
-            throw new PaymentFailed($_payment->status . " " . $_payment->response_summary, $_payment->http_code);
+            throw new PaymentFailed($_payment->status . " " . optional($_payment)->response_summary, $_payment->http_code);
         }
     }
 

--- a/app/PaymentDrivers/CheckoutComPaymentDriver.php
+++ b/app/PaymentDrivers/CheckoutComPaymentDriver.php
@@ -338,7 +338,9 @@ class CheckoutComPaymentDriver extends BaseDriver
         $this->setPaymentHash($request->getPaymentHash());
 
         try {
-            $payment = $this->gateway->payments()->details($request->query('cko-session-id'));
+            $payment = $this->gateway->payments()->details(
+                $request->query('cko-session-id')
+            );
 
             if ($payment->approved) {
                 return $this->processSuccessfulPayment($payment);


### PR DESCRIPTION
Fixes for exception issues after Checkout.com 3DS payments.