### PR TITLE
Hide client name on small devices

### DIFF
--- a/resources/views/portal/ninja2020/components/general/sidebar/header.blade.php
+++ b/resources/views/portal/ninja2020/components/general/sidebar/header.blade.php
@@ -38,7 +38,7 @@
                     <button data-ref="client-profile-dropdown" @click="open = !open"
                             class="max-w-xs flex items-center text-sm rounded-full focus:outline-none focus:shadow-outline">
                         <img class="h-8 w-8 rounded-full" src="{{ auth('contact')->user()->avatar() }}" alt=""/>
-                        <span class="ml-2">{{ auth('contact')->user()->present()->name() }}</span>
+                        <span class="ml-2 hidden sm:block">{{ auth('contact')->user()->present()->name() }}</span>
                     </button>
                 </div>
                 <div x-show="open" style="display:none;" x-transition:enter="transition ease-out duration-100"


### PR DESCRIPTION
This improves navigation bar handling on smaller devices, by hiding the client name.

![image](https://user-images.githubusercontent.com/13711415/139096752-374e9af9-3524-402f-b1cc-80128314fb37.png)
