### PR TITLE
BaseDriver: Make `payment_hash` nullable by default

### DIFF
--- a/app/PaymentDrivers/BaseDriver.php
+++ b/app/PaymentDrivers/BaseDriver.php
@@ -71,7 +71,7 @@ class BaseDriver extends AbstractPaymentDriver
     public $payment_method;
 
     /* PaymentHash */
-    public PaymentHash $payment_hash;
+    public ?PaymentHash $payment_hash = null;
 
     /* Array of payment methods */
     public static $methods = [];

--- a/app/PaymentDrivers/BaseDriver.php
+++ b/app/PaymentDrivers/BaseDriver.php
@@ -70,8 +70,8 @@ class BaseDriver extends AbstractPaymentDriver
     /* The initialized gateway driver class*/
     public $payment_method;
 
-    /* PaymentHash */
-    public ?PaymentHash $payment_hash = null;
+    /* @var \App\Models\PaymentHash|null */
+    public $payment_hash;
 
     /* Array of payment methods */
     public static $methods = [];


### PR DESCRIPTION
Ref: sentry-13445