### PR TITLE
Default to company currency if currency_id is not set

### DIFF
--- a/app/Repositories/PaymentRepository.php
+++ b/app/Repositories/PaymentRepository.php
@@ -107,6 +107,10 @@ class PaymentRepository extends BaseRepository {
         $payment->is_manual = true;
         $payment->status_id = Payment::STATUS_COMPLETED;
 
+        if (! $payment->currency_id) {
+            $payment->currency_id = $client->company->settings->currency_id;
+        }
+
         $payment->save();
 
         /*Save documents*/


### PR DESCRIPTION
This is a follow up of https://github.com/invoiceninja/admin-portal/issues/408

Issue was not fixed after the commit https://github.com/invoiceninja/invoiceninja/pull/7175/commits/c1081f46ce778fb59e3ca7287ebbe4c0ac688124

I realised that `$data` does not contain `currency_id` therefore `$payment->currency_id` is not populated. Maybe the real fix should be populating `$data`?

https://github.com/invoiceninja/invoiceninja/blob/3ad68e264dd856ccb65657102e977bc808c2f93f/app/Repositories/PaymentRepository.php#L106

Referencing to the commit that @turbo124 have made 6 days back, I think this 2 lines are conflicting. Should it be reverted? Looking at the logic, `currency_id` will always default to company currency

https://github.com/invoiceninja/invoiceninja/blob/3ad68e264dd856ccb65657102e977bc808c2f93f/app/Repositories/PaymentRepository.php#L211

https://github.com/invoiceninja/invoiceninja/blob/3ad68e264dd856ccb65657102e977bc808c2f93f/app/Repositories/PaymentRepository.php#L215

This my first pull request in this repo. Do feel free to close this if you think this fix are not appropriate.