### PR TITLE
Add new variable client.lang_2

### DIFF
--- a/app/Utils/HtmlEngine.php
+++ b/app/Utils/HtmlEngine.php
@@ -370,6 +370,8 @@ class HtmlEngine
 
         $data['$client.currency'] = ['value' => $this->client->currency()->code, 'label' => ''];
 
+        $data['$client.lang_2'] = ['value' => optional($this->client->language())->locale, 'label' => ''];
+
         $data['$client.balance'] = ['value' => Number::formatMoney($this->client->balance, $this->client), 'label' => ctrans('texts.account_balance')];
         $data['$client_balance'] = ['value' => Number::formatMoney($this->client->balance, $this->client), 'label' => ctrans('texts.account_balance')];
         $data['$paid_to_date'] = ['value' => Number::formatMoney($this->entity->paid_to_date, $this->client), 'label' => ctrans('texts.paid_to_date')];


### PR DESCRIPTION
This PR adds a new variable which can be used in e-mail or invoice templates using `$client.lang_2`. It is a two-letter language code (a.k.a locale).

Example: If a client (customer) has German set as language in the settings, this variable will print `de`.

See also https://forum.invoiceninja.com/t/language-as-variable/10142 for the initial request and discussion. 