### PR TITLE
Drop the requirement for sending product_key on the product create page

### DIFF
--- a/app/Http/Requests/Product/CreateProductRequest.php
+++ b/app/Http/Requests/Product/CreateProductRequest.php
@@ -28,8 +28,6 @@ class CreateProductRequest extends Request
 
     public function rules() : array
     {
-        return [
-            'product_key' => 'required',
-        ];
+        return [];
     }
 }


### PR DESCRIPTION
At the moment, `product_key` is required when hitting `/api/v1/products/create`. This fixes it.