### PR TITLE
Fixes for PayTrace

### DIFF
--- a/resources/views/portal/ninja2020/gateways/paytrace/pay.blade.php
+++ b/resources/views/portal/ninja2020/gateways/paytrace/pay.blade.php
@@ -50,7 +50,7 @@
     @include('portal.ninja2020.gateways.includes.save_card')
 
     @component('portal.ninja2020.components.general.card-element-single')
-        <div class="w-screen items-center" id="paytrace--credit-card-container">
+        <div class="items-center" id="paytrace--credit-card-container">
             <div id="pt_hpf_form"></div>
         </div>
     @endcomponent

--- a/resources/views/portal/ninja2020/layout/payments.blade.php
+++ b/resources/views/portal/ninja2020/layout/payments.blade.php
@@ -70,9 +70,12 @@
 
         document.addEventListener('DOMContentLoaded', function() {
             let toggleWithToken = document.querySelector('.toggle-payment-with-token');
+            let toggleWithCard = document.querySelector('#toggle-payment-with-credit-card');
 
             if (toggleWithToken) {
                 toggleWithToken.click();
+            } else if (toggleWithCard) {
+                toggleWithCard.click();
             }
         });
     </script>


### PR DESCRIPTION
This fixes PayTrace form widget width. Additionally, it'll focus card input for all gateways, if the token option is not present, double-check.