### PR TITLE
Fixes for Square idempotency

### DIFF
--- a/app/PaymentDrivers/Square/CreditCard.php
+++ b/app/PaymentDrivers/Square/CreditCard.php
@@ -105,7 +105,7 @@ class CreditCard implements MethodInterface
         $amount_money->setAmount($amount);
         $amount_money->setCurrency($this->square_driver->client->currency()->code);
 
-        $body = new \Square\Models\CreatePaymentRequest($token, Str::random(32), $amount_money);
+        $body = new \Square\Models\CreatePaymentRequest($token, $request->idempotencyKey, $amount_money);
 
         $body->setAutocomplete(true);
         $body->setLocationId($this->square_driver->company_gateway->getConfigField('locationId'));

--- a/resources/views/portal/ninja2020/gateways/square/credit_card/pay.blade.php
+++ b/resources/views/portal/ninja2020/gateways/square/credit_card/pay.blade.php
@@ -22,6 +22,7 @@
         <input type="hidden" name="token">
         <input type="hidden" name="sourceId" id="sourceId">
         <input type="hidden" name="verificationToken" id="verificationToken">
+        <input type="hidden" name="idempotencyKey" value="{{ \Illuminate\Support\Str::uuid() }}">
     </form>
 
     <div class="alert alert-failure mb-4" hidden id="errors"></div>


### PR DESCRIPTION
We now generate UUID on the frontend and use it for the idempotency key. This prevents double sumbissions.