### PR TITLE
Ensure tax amount sent when 0

### DIFF
--- a/app/PaymentDrivers/Authorize/ChargePaymentProfile.php
+++ b/app/PaymentDrivers/Authorize/ChargePaymentProfile.php
@@ -76,7 +76,7 @@ class ChargePaymentProfile
         
         $tax = new ExtendedAmountType();
         $tax->setName('tax');
-        $tax->setAmount($taxAmount);
+        $tax->setAmount((float) $taxAmount);
 
         $transactionRequestType = new TransactionRequestType();
         $transactionRequestType->setTransactionType('authCaptureTransaction');


### PR DESCRIPTION
Tax exempt transactions are being sent without
tax information due to NULL interpretation.