### PR TITLE
Add `client` include for quotes

### DIFF
--- a/app/Transformers/QuoteTransformer.php
+++ b/app/Transformers/QuoteTransformer.php
@@ -78,11 +78,11 @@ class QuoteTransformer extends EntityTransformer
         return $this->includeCollection($quote->documents, $transformer, Document::class);
     }
 
-    public function includeClient(Quote $invoice): Item
+    public function includeClient(Quote $quote): Item
     {
         $transformer = new ClientTransformer($this->serializer);
 
-        return $this->includeItem($invoice->client, $transformer, Client::class);
+        return $this->includeItem($quote->client, $transformer, Client::class);
     }
 
     public function transform(Quote $quote)

--- a/app/Transformers/QuoteTransformer.php
+++ b/app/Transformers/QuoteTransformer.php
@@ -18,6 +18,7 @@ use App\Models\Quote;
 use App\Models\QuoteInvitation;
 use App\Transformers\ActivityTransformer;
 use App\Utils\Traits\MakesHash;
+use League\Fractal\Resource\Item;
 
 class QuoteTransformer extends EntityTransformer
 {
@@ -30,6 +31,7 @@ class QuoteTransformer extends EntityTransformer
 
     protected $availableIncludes = [
         'activities',
+        'client',
     ];
 
     public function includeActivities(Quote $quote)
@@ -61,13 +63,6 @@ class QuoteTransformer extends EntityTransformer
             return $this->includeCollection($quote->payments, $transformer, ENTITY_PAYMENT);
         }
 
-        public function includeClient(quote $quote)
-        {
-            $transformer = new ClientTransformer($this->account, $this->serializer);
-
-            return $this->includeItem($quote->client, $transformer, ENTITY_CLIENT);
-        }
-
         public function includeExpenses(quote $quote)
         {
             $transformer = new ExpenseTransformer($this->account, $this->serializer);
@@ -81,6 +76,13 @@ class QuoteTransformer extends EntityTransformer
         $transformer = new DocumentTransformer($this->serializer);
 
         return $this->includeCollection($quote->documents, $transformer, Document::class);
+    }
+
+    public function includeClient(Quote $invoice): Item
+    {
+        $transformer = new ClientTransformer($this->serializer);
+
+        return $this->includeItem($invoice->client, $transformer, Client::class);
     }
 
     public function transform(Quote $quote)


### PR DESCRIPTION
This is needed for quotes table in the React application. 

In the React app we resolve client using child relationship. This is [same convention as with invoices](https://github.com/invoiceninja/ui/blob/main/src/pages/invoices/index/Invoices.tsx#L53).