### PR TITLE
Run AutoBill before emailing invoice

### DIFF
--- a/app/Jobs/RecurringInvoice/SendRecurring.php
+++ b/app/Jobs/RecurringInvoice/SendRecurring.php
@@ -131,7 +131,26 @@ class SendRecurring implements ShouldQueue
 
         event('eloquent.created: App\Models\Invoice', $invoice);
 
-        if($invoice->client->getSetting('auto_email_invoice'))
+        //Attempt to autobill before sending invoice        
+        if ($invoice->client->getSetting('auto_bill_date') == 'on_send_date' && $invoice->auto_bill_enabled) {
+            nlog("attempting to autobill {$invoice->number}");
+            $invoice->service()->autoBill();
+
+        }
+        elseif($invoice->client->getSetting('auto_bill_date') == 'on_due_date' && $invoice->auto_bill_enabled) {
+
+            if($invoice->due_date && Carbon::parse($invoice->due_date)->startOfDay()->lte(now()->startOfDay())) {
+            
+                nlog("attempting to autobill {$invoice->number}");
+                $invoice->service()->autoBill();
+            
+            }
+
+        }
+        
+        //Only send invoice if auto_email_invoice, and invoice is still payable after AutoBill
+        $invoice = $invoice->fresh();
+        if($invoice->client->getSetting('auto_email_invoice') && ((float)$invoice->balance != 0))
         {
             //Admin notification for recurring invoice sent. 
             if ($invoice->invitations->count() >= 1 ) {
@@ -154,23 +173,6 @@ class SendRecurring implements ShouldQueue
                 }
             });
         }
-        
-        if ($invoice->client->getSetting('auto_bill_date') == 'on_send_date' && $invoice->auto_bill_enabled) {
-            nlog("attempting to autobill {$invoice->number}");
-            $invoice->service()->autoBill();
-
-        }
-        elseif($invoice->client->getSetting('auto_bill_date') == 'on_due_date' && $invoice->auto_bill_enabled) {
-
-            if($invoice->due_date && Carbon::parse($invoice->due_date)->startOfDay()->lte(now()->startOfDay())) {
-            
-                nlog("attempting to autobill {$invoice->number}");
-                $invoice->service()->autoBill();
-            
-            }
-
-        }
-
     }
 
     /**


### PR DESCRIPTION
The existing code will send an invoice, attempt to autobill, and follow up
by sending an receipt email that the invoice is already paid.  This seems
to be backwards.
This commit changes the order to first attempt to autobill, and
if successful will not email the invoice but rather a receipt.  Only if configured
to send the email, and the invoice still has a balance, will the invoice be
emailed.