### PR TITLE
Add `client` relationship to CreditTransformer

### DIFF
--- a/app/Transformers/CreditTransformer.php
+++ b/app/Transformers/CreditTransformer.php
@@ -18,6 +18,7 @@ use App\Models\CreditInvitation;
 use App\Models\Document;
 use App\Transformers\ActivityTransformer;
 use App\Utils\Traits\MakesHash;
+use League\Fractal\Resource\Item;
 
 class CreditTransformer extends EntityTransformer
 {
@@ -30,6 +31,7 @@ class CreditTransformer extends EntityTransformer
 
     protected $availableIncludes = [
         'activities',
+        'client',
     ];
 
     public function includeActivities(Credit $credit)
@@ -53,28 +55,13 @@ class CreditTransformer extends EntityTransformer
         return $this->includeCollection($credit->invitations, $transformer, CreditInvitation::class);
     }
 
-    /*
-        public function includePayments(quote $credit)
-        {
-            $transformer = new PaymentTransformer($this->account, $this->serializer, $credit);
+    public function includeClient(Credit $credit): Item
+    {
+        $transformer = new ClientTransformer($this->serializer);
 
-            return $this->includeCollection($credit->payments, $transformer, ENTITY_PAYMENT);
-        }
+        return $this->includeItem($credit->client, $transformer, Client::class);
+    }
 
-        public function includeClient(quote $credit)
-        {
-            $transformer = new ClientTransformer($this->account, $this->serializer);
-
-            return $this->includeItem($credit->client, $transformer, ENTITY_CLIENT);
-        }
-
-        public function includeExpenses(quote $credit)
-        {
-            $transformer = new ExpenseTransformer($this->account, $this->serializer);
-
-            return $this->includeCollection($credit->expenses, $transformer, ENTITY_EXPENSE);
-        }
-*/
     public function includeDocuments(Credit $credit)
     {
         $transformer = new DocumentTransformer($this->serializer);


### PR DESCRIPTION
This adds `client` relationship include for credits (required for credits module in the React app).