### PR TITLE
`Client` include in TaskTransformer

### DIFF
--- a/app/Transformers/TaskTransformer.php
+++ b/app/Transformers/TaskTransformer.php
@@ -14,6 +14,7 @@ namespace App\Transformers;
 use App\Models\Document;
 use App\Models\Task;
 use App\Utils\Traits\MakesHash;
+use League\Fractal\Resource\Item;
 
 /**
  * class TaskTransformer.
@@ -30,6 +31,7 @@ class TaskTransformer extends EntityTransformer
      * @var array
      */
     protected $availableIncludes = [
+        'client',
     ];
 
     public function includeDocuments(Task $task)
@@ -37,6 +39,13 @@ class TaskTransformer extends EntityTransformer
         $transformer = new DocumentTransformer($this->serializer);
 
         return $this->includeCollection($task->documents, $transformer, Document::class);
+    }
+
+    public function includeClient(Task $task): Item
+    {
+        $transformer = new ClientTransformer($this->serializer);
+
+        return $this->includeItem($task->client, $transformer, Client::class);
     }
 
     public function transform(Task $task)


### PR DESCRIPTION
This implements `client` relationship in the TaskTransformer required for the React app.