### PR TITLE
Remove `client` include from tasks

### DIFF
--- a/app/Transformers/TaskTransformer.php
+++ b/app/Transformers/TaskTransformer.php
@@ -14,7 +14,6 @@ namespace App\Transformers;
 use App\Models\Document;
 use App\Models\Task;
 use App\Utils\Traits\MakesHash;
-use League\Fractal\Resource\Item;
 
 /**
  * class TaskTransformer.
@@ -30,22 +29,13 @@ class TaskTransformer extends EntityTransformer
     /**
      * @var array
      */
-    protected $availableIncludes = [
-        'client',
-    ];
+    protected $availableIncludes = [];
 
     public function includeDocuments(Task $task)
     {
         $transformer = new DocumentTransformer($this->serializer);
 
         return $this->includeCollection($task->documents, $transformer, Document::class);
-    }
-
-    public function includeClient(Task $task): Item
-    {
-        $transformer = new ClientTransformer($this->serializer);
-
-        return $this->includeItem($task->client, $transformer, Client::class);
     }
 
     public function transform(Task $task)


### PR DESCRIPTION
As it turns out not all tasks need to have client, which makes this often return 500 error.

```
{
    "message": "App\\Transformers\\ClientTransformer::transform(): Argument #1 ($client) must be of type App\\Models\\Client, null given, called in /var/www/html/vendor/league/fractal/src/Scope.php on line 407",
    "exception": "TypeError",
    "file": "/var/www/html/app/Transformers/ClientTransformer.php",
    "line": 105,
    "trace": []
}
```

We may need to find alternative solution for this if we want to display client name for the tasks table in the React app.