### PR TITLE
Provide missing translations

### DIFF
--- a/lang/en/texts.php
+++ b/lang/en/texts.php
@@ -4767,6 +4767,7 @@ $LANG = array(
     'bulk_email_invoices' => 'Email Invoices',
     'bulk_email_quotes' => 'Email Quotes',
     'bulk_email_credits' => 'Email Credits',
+    'expense_tax_rates' => 'Expense Tax Rates',
 );
 
 return $LANG;


### PR DESCRIPTION
This provides missing translations for the expenses.

![image](https://user-images.githubusercontent.com/13711415/185359589-7f3ce05c-6eca-4e8f-a509-02799d2d0215.png)
