### PR TITLE
Improve IAP InitialPurchaseRequest.php as Hillel requested

### DIFF
--- a/database/migrations/2022_08_19_000131_change_plan_type_in_accounts_table.php
+++ b/database/migrations/2022_08_19_000131_change_plan_type_in_accounts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangePlanTypeInAccountsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            $table->string('plan')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('accounts', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
Change plan type in the database so we can store values as in example:

pro_plan
enterprise_plan
enterprise_plan_5
enterprise_plan_10
enterprise_plan_20
pro_plan_annual
enterprise_plan_annual
enterprise_plan_annual_5
enterprise_plan_annual_10
enterprise_plan_annual_20

instead of a hardcoded enum which was (pro,whitelabel..)