### PR TITLE
Add `vendor` & `expense` includes for purchase orders

### DIFF
--- a/app/Transformers/PurchaseOrderTransformer.php
+++ b/app/Transformers/PurchaseOrderTransformer.php
@@ -14,6 +14,7 @@ namespace App\Transformers;
 
 use App\Models\PurchaseOrder;
 use App\Models\PurchaseOrderInvitation;
+use App\Models\Vendor;
 use App\Transformers\DocumentTransformer;
 use App\Utils\Traits\MakesHash;
 
@@ -27,7 +28,8 @@ class PurchaseOrderTransformer extends EntityTransformer
     ];
 
     protected $availableIncludes = [
-        'expense'
+        'expense',
+        'vendor',
     ];
 
     public function includeInvitations(PurchaseOrder $purchase_order)
@@ -49,7 +51,22 @@ class PurchaseOrderTransformer extends EntityTransformer
     {
         $transformer = new ExpenseTransformer($this->serializer);
 
-        return $this->includeItem($purchase_order->expense, $transformer, Document::class);
+        if (!$purchase_order->expense) {
+            return null;
+        }
+
+        return $this->includeItem($purchase_order->expense, $transformer, Expense::class);
+    }
+
+    public function includeVendor(PurchaseOrder $purchase_order)
+    {
+        $transformer = new VendorTransformer($this->serializer);
+
+        if (!$purchase_order->vendor) {
+            return null;
+        }
+
+        return $this->includeItem($purchase_order->vendor, $transformer, Vendor::class);
     }
 
     public function transform(PurchaseOrder $purchase_order)

--- a/lang/en/texts.php
+++ b/lang/en/texts.php
@@ -4767,6 +4767,9 @@ $LANG = array(
     'bulk_email_invoices' => 'Email Invoices',
     'bulk_email_quotes' => 'Email Quotes',
     'bulk_email_credits' => 'Email Credits',
+    'archive_purchase_order' => 'Archive Purchase Order',
+    'restore_purchase_order' => 'Restore Purchase Order',
+    'delete_purchase_order' => 'Delete Purchase Order',
 );
 
 return $LANG;


### PR DESCRIPTION
Changes:
- Adds missing includes for expense & vendors with nullable versions.
- Adds missing translations for resourceful actions.