### PR TITLE
Remove empty section and fix dead URL's in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ The self-host zip includes all third party libraries whereas downloading the cod
 * [Support Forum](https://www.invoiceninja.com/forums/forum/support/)
 * [StackOverflow](https://stackoverflow.com/tags/invoice-ninja/)
 
-## Referral Program
-
 ## Mobile App
-* [iPhone](https://itunes.apple.com/us/app/invoice-ninja/id1435514417?ls=1&mt=8)
-* [Android](https://play.google.com/store/apps/details?id=com.invoiceninja.flutter)
-* [Source Code](https://github.com/invoiceninja/flutter-mobile)
+* [iPhone](https://apps.apple.com/us/app/invoice-ninja-v5/id1503970375#?platform=iphone)
+* [Android](https://play.google.com/store/apps/details?id=com.invoiceninja.app)
+* [Linux](https://github.com/invoiceninja/flutter-mobile)
+
+## Desktop App
+* [MacOS](https://apps.apple.com/app/id1503970375)
+* [Windows](https://microsoft.com/en-us/p/invoice-ninja/9n3f2bbcfdr6)
+* [MacOS Desktop](https://snapcraft.io/invoiceninja)
 
 ## Installation Options
 * [Ansible](https://github.com/invoiceninja/ansible-installer)


### PR DESCRIPTION
https://github.com/invoiceninja/invoiceninja/commit/03a1c2be8ab4e840c9b9ca0103f9fef4fcc5c563

Commit above simply removed the content of the section but not the section heading. The referral program seems to have stopped (at least all URL's are dead and it's not mentioned anymore on the website).

The IOS and Android links were pointing to the old version which no longer are online, updated those to the new version. Also added the links to the desktop applications.