### PR TITLE
EPC QR update

### DIFF
--- a/app/Helpers/Epc/EpcQrGenerator.php
+++ b/app/Helpers/Epc/EpcQrGenerator.php
@@ -75,9 +75,9 @@ class EpcQrGenerator
             isset($this->company?->custom_fields?->company1) ? $this->company->settings->custom_value1 : '',
             $this->formatMoney($this->amount),
             $this->sepa['purpose'],
-            substr($this->invoice->number,0,34),
-            substr($this->invoice->public_notes,0,139),
-            ''
+            '',
+            substr($this->invoice->number,0,139),
+            substr($this->invoice->public_notes,0,69)
         )), "\n");
 
     }

--- a/app/Helpers/Epc/EpcQrGenerator.php
+++ b/app/Helpers/Epc/EpcQrGenerator.php
@@ -32,7 +32,8 @@ class EpcQrGenerator
         'identification' => 'SCT',
         'bic' => '',
         'purpose' => '',
-
+        'reference' => '',
+        'additionalInformation' => ''
     ];
 
     public function __construct(protected Company $company, protected Invoice $invoice, protected float $amount){}
@@ -70,14 +71,14 @@ class EpcQrGenerator
             sprintf('%03d', $this->sepa['version']),
             $this->sepa['characterSet'],
             $this->sepa['identification'],
-            isset($this->company?->custom_fields?->company2) ? $this->company->settings->custom_value2 : '',
+            isset($this->company?->custom_fields?->company2) ? $this->company->settings->custom_value2 : $this->sepa['bic'],
             $this->company->present()->name(),
             isset($this->company?->custom_fields?->company1) ? $this->company->settings->custom_value1 : '',
             $this->formatMoney($this->amount),
             $this->sepa['purpose'],
-            '',
+            $this->sepa['reference'],
             substr($this->invoice->number,0,139),
-            substr($this->invoice->public_notes,0,69)
+            $this->sepa['additionalInformation']
         )), "\n");
 
     }


### PR DESCRIPTION
Hi there,

I'm using invoiceninja since several days and decided to go with it (self-hosted, white label) - great work, thanks!

While customizing the invoice template, I recognized that the EPC QR Code is using the invoice number as "reference". According to the specs this line should start with "RF" followed by a 2 digit check. For me the invoice number is more likely plain text (line 11 of 12). I then would move the public note to the last line.

Correct me if I'm wrong, but the currently used "reference" is breaking the compatibility.

Links to the specs:
https://de.wikipedia.org/wiki/EPC-QR-Code
https://en.wikipedia.org/wiki/EPC_QR_code
https://en.wikipedia.org/wiki/Creditor_Reference