### PR TITLE
Reserved keywords are aware of date in recurring invoice PDF preview

### DIFF
--- a/app/Utils/Helpers.php
+++ b/app/Utils/Helpers.php
@@ -106,9 +106,10 @@ class Helpers
      *
      * @param string $value
      * @param Client|Company $entity
+     * @param null|Carbon $currentDateTime
      * @return null|string
      */
-    public static function processReservedKeywords(?string $value, $entity): ?string
+    public static function processReservedKeywords(?string $value, $entity, $currentDateTime = null): ?string
     {
         if (! $value) {
             return '';
@@ -132,71 +133,75 @@ class Helpers
 
         Carbon::setLocale($entity->locale());
 
+        if (!$currentDateTime) {
+            $currentDateTime = Carbon::now();
+        }
+
         $replacements = [
             'literal' => [
                 ':MONTH_BEFORE' => \sprintf(
                     '%s %s %s',
-                    Carbon::now()->subMonth(1)->translatedFormat($entity->date_format()),
+                    $currentDateTime->copy()->subMonth(1)->translatedFormat($entity->date_format()),
                     ctrans('texts.to'),
-                    Carbon::now()->subDay(1)->translatedFormat($entity->date_format()),
+                    $currentDateTime->copy()->subDay(1)->translatedFormat($entity->date_format()),
                 ),
                 ':YEAR_BEFORE' => \sprintf(
                     '%s %s %s',
-                    Carbon::now()->subYear(1)->translatedFormat($entity->date_format()),
+                    $currentDateTime->copy()->subYear(1)->translatedFormat($entity->date_format()),
                     ctrans('texts.to'),
-                    Carbon::now()->subDay(1)->translatedFormat($entity->date_format()),
+                    $currentDateTime->copy()->subDay(1)->translatedFormat($entity->date_format()),
                 ),
                 ':MONTH_AFTER' => \sprintf(
                     '%s %s %s',
-                    Carbon::now()->translatedFormat($entity->date_format()),
+                    $currentDateTime->translatedFormat($entity->date_format()),
                     ctrans('texts.to'),
-                    Carbon::now()->addMonth(1)->subDay(1)->translatedFormat($entity->date_format()),
+                    $currentDateTime->copy()->addMonth(1)->subDay(1)->translatedFormat($entity->date_format()),
                 ),
                 ':YEAR_AFTER' => \sprintf(
                     '%s %s %s',
-                    Carbon::now()->translatedFormat($entity->date_format()),
+                    $currentDateTime->translatedFormat($entity->date_format()),
                     ctrans('texts.to'),
-                    Carbon::now()->addYear(1)->subDay(1)->translatedFormat($entity->date_format()),
+                    $currentDateTime->copy()->addYear(1)->subDay(1)->translatedFormat($entity->date_format()),
                 ),
                 ':MONTHYEAR' => \sprintf(
                     '%s %s',
-                    Carbon::createFromDate(now()->month)->translatedFormat('F'),
-                    now()->year,
+                    Carbon::createFromDate($currentDateTime->month)->translatedFormat('F'),
+                    $currentDateTime->year,
                 ),
-                ':MONTH' => Carbon::createFromDate(now()->year, now()->month)->translatedFormat('F'),
-                ':YEAR' => now()->year,
-                ':QUARTER' => 'Q'.now()->quarter,
+                ':MONTH' => Carbon::createFromDate($currentDateTime->year, $currentDateTime->month)->translatedFormat('F'),
+                ':YEAR' => $currentDateTime->year,
+                ':QUARTER' => 'Q'.$currentDateTime->quarter,
                 ':WEEK_BEFORE' => \sprintf(
                     '%s %s %s',
-                    Carbon::now()->subDays(7)->translatedFormat($entity->date_format()),
+                    $currentDateTime->copy()->subDays(7)->translatedFormat($entity->date_format()),
                     ctrans('texts.to'),
-                    Carbon::now()->subDays(1)->translatedFormat($entity->date_format())
+                    $currentDateTime->copy()->subDays(1)->translatedFormat($entity->date_format())
                 ),
                 ':WEEK_AHEAD' => \sprintf(
                     '%s %s %s',
-                    Carbon::now()->addDays(7)->translatedFormat($entity->date_format()),
+                    $currentDateTime->copy()->addDays(7)->translatedFormat($entity->date_format()),
                     ctrans('texts.to'),
-                    Carbon::now()->addDays(13)->translatedFormat($entity->date_format())
+                    $currentDateTime->copy()->addDays(13)->translatedFormat($entity->date_format())
                 ),
                 ':WEEK' => \sprintf(
                     '%s %s %s',
-                    Carbon::now()->translatedFormat($entity->date_format()),
+                    $currentDateTime->translatedFormat($entity->date_format()),
                     ctrans('texts.to'),
-                    Carbon::now()->addDays(6)->translatedFormat($entity->date_format())
+                    $currentDateTime->copy()->addDays(6)->translatedFormat($entity->date_format())
                 ),
             ],
             'raw' => [
-                ':MONTHYEAR' => now()->month,
-                ':MONTH' => now()->month,
-                ':YEAR' => now()->year,
-                ':QUARTER' => now()->quarter,
+                ':MONTHYEAR' => $currentDateTime->month,
+                ':MONTH' => $currentDateTime->month,
+                ':YEAR' => $currentDateTime->year,
+                ':QUARTER' => $currentDateTime->quarter,
             ],
             'ranges' => [
-                'MONTHYEAR' => Carbon::createFromDate(now()->year, now()->month),
+                'MONTHYEAR' => Carbon::createFromDate($currentDateTime->year, $currentDateTime->month),
             ],
             'ranges_raw' => [
-                'MONTH' => now()->month,
-                'YEAR' => now()->year,
+                'MONTH' => $currentDateTime->month,
+                'YEAR' => $currentDateTime->year,
             ],
         ];
 
@@ -221,12 +226,12 @@ class Helpers
                     continue;
                 }
 
-                $_left = Carbon::createFromDate(now()->year, now()->month)->translatedFormat('F Y');
+                $_left = Carbon::createFromDate($currentDateTime->year, $currentDateTime->month)->translatedFormat('F Y');
                 $_right = '';
 
                 // If right side doesn't have any calculations, replace with raw ranges keyword.
                 if (! Str::contains($right, ['-', '+', '/', '*'])) {
-                    $_right = Carbon::createFromDate(now()->year, now()->month)->translatedFormat('F Y');
+                    $_right = Carbon::createFromDate($currentDateTime->year, $currentDateTime->month)->translatedFormat('F Y');
                 }
 
                 // If right side contains one of math operations, calculate.
@@ -237,7 +242,7 @@ class Helpers
 
                     $_value = explode($_operation, $right); // [MONTHYEAR, 4]
 
-                    $_right = Carbon::createFromDate(now()->year, now()->month)->addMonths($_value[1])->translatedFormat('F Y');
+                    $_right = Carbon::createFromDate($currentDateTime->year, $currentDateTime->month)->addMonths($_value[1])->translatedFormat('F Y');
                 }
 
                 $replacement = sprintf('%s to %s', $_left, $_right);
@@ -304,7 +309,7 @@ class Helpers
                 }
 
                 if ($matches->keys()->first() == ':MONTHYEAR') {
-                    $final_date = now()->addMonths($output - now()->month);
+                    $final_date = $currentDateTime->copy()->addMonths($output - $currentDateTime->month);
 
                     $output = \sprintf(
                             '%s %s',

--- a/app/Utils/Traits/MakesInvoiceValues.php
+++ b/app/Utils/Traits/MakesInvoiceValues.php
@@ -295,8 +295,13 @@ trait MakesInvoiceValues
             $data[$key][$table_type.'.item'] = is_null(optional($item)->item) ? $item->product_key : $item->item;
             $data[$key][$table_type.'.service'] = is_null(optional($item)->service) ? $item->product_key : $item->service;
 
-            $data[$key][$table_type.'.notes'] = Helpers::processReservedKeywords($item->notes, $entity);
-            $data[$key][$table_type.'.description'] = Helpers::processReservedKeywords($item->notes, $entity);
+            $currentDateTime = null;
+            if (isset($this->entity->next_send_date)) {
+                $currentDateTime = Carbon::parse($this->entity->next_send_date);
+            }
+
+            $data[$key][$table_type.'.notes'] = Helpers::processReservedKeywords($item->notes, $entity, $currentDateTime);
+            $data[$key][$table_type.'.description'] = Helpers::processReservedKeywords($item->notes, $entity, $currentDateTime);
 
             $data[$key][$table_type.".{$_table_type}1"] = strlen($item->custom_value1) >= 1 ? $helpers->formatCustomFieldValue($this->company->custom_fields, "{$_table_type}1", $item->custom_value1, $entity) : '';
             $data[$key][$table_type.".{$_table_type}2"] = strlen($item->custom_value2) >= 1 ? $helpers->formatCustomFieldValue($this->company->custom_fields, "{$_table_type}2", $item->custom_value2, $entity) : '';


### PR DESCRIPTION
Hi,

As recurring invoice is always for a future date, it didn't make sense for the PDF preview to only show reserved keyword examples for the current date, makes it'quite confusing for users.

This amendment makes processReservedKeywords aware of timeframe so the recurring invoice PDF preview is more understandable.  

Kind Regards