### PR TITLE
fix: Date check changes format for where clause

### DIFF
--- a/app/Filters/QueryFilters.php
+++ b/app/Filters/QueryFilters.php
@@ -180,12 +180,8 @@ abstract class QueryFilters
         $created_at = date('Y-m-d H:i:s', $value);
 
         if(is_string($created_at)){
-
-            $created_at = strtotime(str_replace("/","-",$created_at));
-
-            if(!$created_at)
+            if(!strtotime(str_replace("/","-",$created_at)))
                 return $this->builder;
-
         }
 
         return $this->builder->where('created_at', '>=', $created_at);


### PR DESCRIPTION
The query filter for created_at has a check to test the date is valid.  The check changes the format of $created_at so it no longer works in the query builder.