### PR TITLE
fix SEPA QR Code recurring invoice

### DIFF
--- a/app/Helpers/Epc/EpcQrGenerator.php
+++ b/app/Helpers/Epc/EpcQrGenerator.php
@@ -13,6 +13,7 @@ namespace App\Helpers\Epc;
 
 use App\Models\Company;
 use App\Models\Invoice;
+use App\Models\RecurringInvoice;
 use App\Utils\Ninja;
 use BaconQrCode\Renderer\ImageRenderer;
 use BaconQrCode\Renderer\Image\SvgImageBackEnd;
@@ -35,7 +36,7 @@ class EpcQrGenerator
 
     ];
 
-    public function __construct(protected Company $company, protected Invoice $invoice, protected float $amount){}
+    public function __construct(protected Company $company, protected Invoice|RecurringInvoice $invoice, protected float $amount){}
 
     public function getQrCode()
     {

--- a/app/Utils/HtmlEngine.php
+++ b/app/Utils/HtmlEngine.php
@@ -596,7 +596,7 @@ class HtmlEngine
             $data['$payments'] = ['value' => $payment_list, 'label' => ctrans('texts.payments')];
         }
 
-        if($this->entity_string == 'invoice' && isset($this->company?->custom_fields?->company1))
+        if(($this->entity_string == 'invoice' || $this->entity_string == 'recurring_invoice') && isset($this->company?->custom_fields?->company1))
         {
             $data['$sepa_qr_code'] = ['value' => (new EpcQrGenerator($this->company, $this->entity,$data['$amount_raw']['value']))->getQrCode(), 'label' => ''];
         }


### PR DESCRIPTION
Hi there,

I use my normal invoice layout for recurring invoices with SEPA QR code on it and it only shows ```$sepa_qr_code``` instead of the QR code image. I think recurring invoices should follow normal invoices in terms of layout.