### PR TITLE
fix: processReservedKeywords should be aware of recurring invoice date

### DIFF
--- a/app/Factory/RecurringInvoiceToInvoiceFactory.php
+++ b/app/Factory/RecurringInvoiceToInvoiceFactory.php
@@ -15,6 +15,7 @@ use App\Models\Client;
 use App\Models\Invoice;
 use App\Models\RecurringInvoice;
 use App\Utils\Helpers;
+use Carbon\Carbon;
 
 class RecurringInvoiceToInvoiceFactory
 {
@@ -70,11 +71,16 @@ class RecurringInvoiceToInvoiceFactory
 
     private static function transformItems($recurring_invoice, $client)
     {
+        $currentDateTime = null;
         $line_items = $recurring_invoice->line_items;
+
+        if (isset($recurring_invoice->next_send_date)) {
+            $currentDateTime = Carbon::parse($recurring_invoice->next_send_date)->timezone($client->timezone()->name);
+        }
 
         foreach ($line_items as $key => $item) {
             if (property_exists($line_items[$key], 'notes')) {
-                $line_items[$key]->notes = Helpers::processReservedKeywords($item->notes, $client);
+                $line_items[$key]->notes = Helpers::processReservedKeywords($item->notes, $client, $currentDateTime);
             }
         }
 

--- a/tests/Feature/RecurringInvoiceTest.php
+++ b/tests/Feature/RecurringInvoiceTest.php
@@ -17,6 +17,7 @@ use App\Factory\RecurringInvoiceToInvoiceFactory;
 use App\Models\Client;
 use App\Models\ClientContact;
 use App\Models\RecurringInvoice;
+use App\Utils\Helpers;
 use App\Utils\Traits\MakesHash;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -302,6 +303,35 @@ class RecurringInvoiceTest extends TestCase
         $invoice = RecurringInvoiceToInvoiceFactory::create($recurring_invoice, $this->client);
 
         $this->assertEquals(10, $invoice->subscription_id);
+    }
+
+    public function testRecurringDatePassesToInvoice()
+    {
+        $noteText = "Hello this is for :MONTH_AFTER";
+        $recurringDate = \Carbon\Carbon::now()->subDays(10);
+
+        $item = InvoiceItemFactory::create();
+        $item->cost = 10;
+        $item->notes = $noteText;
+
+        $recurring_invoice = InvoiceToRecurringInvoiceFactory::create($this->invoice);
+        $recurring_invoice->user_id = $this->user->id;
+        $recurring_invoice->next_send_date = $recurringDate;
+        $recurring_invoice->status_id = RecurringInvoice::STATUS_ACTIVE;
+        $recurring_invoice->remaining_cycles = 2;
+        $recurring_invoice->next_send_date = $recurringDate;
+        $recurring_invoice->line_items = [$item];
+        $recurring_invoice->save();
+
+        $recurring_invoice->number = $this->getNextRecurringInvoiceNumber($this->invoice->client, $this->invoice);
+        $recurring_invoice->subscription_id = 10;
+        $recurring_invoice->save();
+
+        $invoice = RecurringInvoiceToInvoiceFactory::create($recurring_invoice, $this->invoice->client);
+
+        $expectedNote = Helpers::processReservedKeywords($noteText, $this->invoice->client, $recurringDate);
+
+        $this->assertEquals($expectedNote, $invoice->line_items[0]->notes);
     }
 
     public function testSubscriptionIdPassesToInvoiceIfNull()


### PR DESCRIPTION
This is an addition to the earlier PR which made processReservedKeywords aware of the recurring invoice send date.

The recurring invoice factory needs to know the intended send date not the current date otherwise the date ranges in the line item are incorrect when a recurring invoice is created via the api with a date in the past.

For example:

A monthly start date of 2022-11-20 will on each cron run create an overdue invoice until we reach the current month.
At present the line items on each month will show the date range for MONTH_AFTER being 2023-01-20 rather than 2022-11-20, 2022-12-20, 2023-01-20

