### PR TITLE
Reset counter enhancements

### DIFF
--- a/app/Utils/Traits/GeneratesCounter.php
+++ b/app/Utils/Traits/GeneratesCounter.php
@@ -606,42 +606,42 @@ trait GeneratesCounter
 
         switch ($company->reset_counter_frequency_id) {
             case RecurringInvoice::FREQUENCY_DAILY:
-                $reset_date->addDay();
+                $new_reset_date = $reset_date->addDay();
                 break;
             case RecurringInvoice::FREQUENCY_WEEKLY:
-                $reset_date->addWeek();
+                $new_reset_date = $reset_date->addWeek();
                 break;
             case RecurringInvoice::FREQUENCY_TWO_WEEKS:
-                $reset_date->addWeeks(2);
+                $new_reset_date = $reset_date->addWeeks(2);
                 break;
             case RecurringInvoice::FREQUENCY_FOUR_WEEKS:
-                $reset_date->addWeeks(4);
+                $new_reset_date = $reset_date->addWeeks(4);
                 break;
             case RecurringInvoice::FREQUENCY_MONTHLY:
-                $reset_date->addMonth();
+                $new_reset_date = $reset_date->addMonth();
                 break;
             case RecurringInvoice::FREQUENCY_TWO_MONTHS:
-                $reset_date->addMonths(2);
+                $new_reset_date = $reset_date->addMonths(2);
                 break;
             case RecurringInvoice::FREQUENCY_THREE_MONTHS:
-                $reset_date->addMonths(3);
+                $new_reset_date = $reset_date->addMonths(3);
                 break;
             case RecurringInvoice::FREQUENCY_FOUR_MONTHS:
-                $reset_date->addMonths(4);
+                $new_reset_date = $reset_date->addMonths(4);
                 break;
             case RecurringInvoice::FREQUENCY_SIX_MONTHS:
-                $reset_date->addMonths(6);
+                $new_reset_date = $reset_date->addMonths(6);
                 break;
             case RecurringInvoice::FREQUENCY_ANNUALLY:
-                $reset_date->addYear();
+                $new_reset_date = $reset_date->addYear();
                 break;
             case RecurringInvoice::FREQUENCY_TWO_YEARS:
-                $reset_date->addYears(2);
+                $new_reset_date = $reset_date->addYears(2);
                 break;
         }
 
         $settings = $company->settings;
-        $settings->reset_counter_date = $reset_date->format('Y-m-d');
+        $settings->reset_counter_date = $new_reset_date->format('Y-m-d');
         $settings->invoice_number_counter = 1;
         $settings->quote_number_counter = 1;
         $settings->credit_number_counter = 1;
@@ -657,7 +657,7 @@ trait GeneratesCounter
         $company->settings = $settings;
         $company->save();
 
-        if ($reset_date->lte(now())) {
+        if ($new_reset_date->lte(now())) {
             return $this->resetCompanyCounters($company);
         }
     }

--- a/app/Utils/Traits/GeneratesCounter.php
+++ b/app/Utils/Traits/GeneratesCounter.php
@@ -125,7 +125,7 @@ trait GeneratesCounter
         switch ($entity) {
             case Invoice::class:
                 return 'invoice_number_counter';
-                
+
             case Quote::class:
 
                 if ($this->hasSharedCounter($client, 'quote')) {
@@ -133,29 +133,29 @@ trait GeneratesCounter
                 }
 
                 return 'quote_number_counter';
-                
+
             case RecurringInvoice::class:
                 return 'recurring_invoice_number_counter';
-                
+
             case RecurringQuote::class:
                 return 'recurring_quote_number_counter';
-                
+
             case RecurringExpense::class:
                 return 'recurring_expense_number_counter';
-                
+
             case Payment::class:
                 return 'payment_number_counter';
-                
+
             case Credit::class:
                 if ($this->hasSharedCounter($client, 'credit')) {
                     return 'invoice_number_counter';
                 }
 
                 return 'credit_number_counter';
-                
+
             case Project::class:
                 return 'project_number_counter';
-                
+
             case PurchaseOrder::class:
                 return 'purchase_order_number_counter';
 
@@ -400,7 +400,7 @@ trait GeneratesCounter
         }
 
         //credit
-        return (bool) $client->getSetting('shared_invoice_credit_counter');    
+        return (bool) $client->getSetting('shared_invoice_credit_counter');
     }
 
     /**
@@ -421,7 +421,7 @@ trait GeneratesCounter
         $check_counter = 1;
 
         do {
-            
+
             $number = $this->padCounter($counter, $padding);
 
             $number = $this->applyNumberPattern($entity, $number, $pattern);
@@ -434,7 +434,7 @@ trait GeneratesCounter
             $check_counter++;
 
             if ($check_counter > 100) {
-                
+
                 $this->update_counter = $counter--;
 
                 return $number.'_'.Str::random(5);
@@ -525,7 +525,7 @@ trait GeneratesCounter
                     $settings->reset_counter_date = "";
                     $client->company->settings = $settings;
                     $client->company->save();
-                    
+
                 }
 
             return;
@@ -588,6 +588,10 @@ trait GeneratesCounter
 
         $client->company->settings = $settings;
         $client->company->save();
+
+        if ($new_reset_date->lte(now())) {
+            return $this->resetCounters($client);
+        }
     }
 
     private function resetCompanyCounters($company)
@@ -652,6 +656,10 @@ trait GeneratesCounter
 
         $company->settings = $settings;
         $company->save();
+
+        if ($reset_date->lte(now())) {
+            return $this->resetCompanyCounters($company);
+        }
     }
 
     /**


### PR DESCRIPTION
- Enhancement: reset counter date to next possible date instead date in past (recursive call)
- Fix: resetCompanyCounters not saving new reset date

See also:
https://github.com/invoiceninja/dockerfiles/issues/486

Still known bug:
Currently resetCounter is not triggered while creating new customers. So creating just new customers over days leads to problems (not resetting). I haven't found, where to hook this functions yet :/