### PR TITLE
Increase throttle on login routes

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -103,8 +103,8 @@ Route::group(['middleware' => ['throttle:300,1', 'api_secret_check']], function 
     Route::post('api/v1/oauth_login', [LoginController::class, 'oauthApiLogin']);
 });
 
-Route::group(['middleware' => ['throttle:50,1','api_secret_check','email_db']], function () {
-    Route::post('api/v1/login', [LoginController::class, 'apiLogin'])->name('login.submit')->middleware('throttle:20,1');
+Route::group(['middleware' => ['throttle:1000,1','api_secret_check','email_db']], function () {
+    Route::post('api/v1/login', [LoginController::class, 'apiLogin'])->name('login.submit')->middleware('throttle:1000,1');
     Route::post('api/v1/reset_password', [ForgotPasswordController::class, 'sendResetLinkEmail']);
 });
 


### PR DESCRIPTION
The previous value of `50` was too low and Playwright tests were failing randomly. This increases the throttle value to `1000`.