### PR TITLE
Add :MONTHYEAR keyword to recurring expenses

### DIFF
--- a/app/Factory/RecurringExpenseToExpenseFactory.php
+++ b/app/Factory/RecurringExpenseToExpenseFactory.php
@@ -95,6 +95,11 @@ class RecurringExpenseToExpenseFactory
 
         $replacements = [
             'literal' => [
+                ':MONTHYEAR' => \sprintf(
+                    '%s %s',
+                    Carbon::createFromDate(now()->year, now()->month)->translatedFormat('F'),
+                    now()->year,
+                ),
                 ':MONTH' => Carbon::createFromDate(now()->year, now()->month)->translatedFormat('F'),
                 ':YEAR' => now()->year,
                 ':QUARTER' => 'Q'.now()->quarter,
@@ -238,6 +243,17 @@ class RecurringExpenseToExpenseFactory
 
                 if ($matches->keys()->first() == ':MONTH') {
                     $output = \Carbon\Carbon::create()->month($output)->translatedFormat('F');
+                }
+
+                if ($matches->keys()->first() == ':MONTHYEAR') {
+
+                    $final_date = now()->addMonths($output-now()->month);
+
+                    $output =    \sprintf(
+                            '%s %s',
+                            $final_date->translatedFormat('F'),
+                            $final_date->year,
+                        );
                 }
 
                 $value = preg_replace(


### PR DESCRIPTION
Hello,

I tried using :MONTHYEAR in a recurring expense Public Notes and it did not work. I ended up getting a JuneYEAR instead of "June 2023".

I tested this patch and it worked fine on my self-hosted instance.