### PR TITLE
Import Company Model and Hash in usersTableSeeder.php

### DIFF
--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -18,6 +18,8 @@ use App\Models\ClientContact;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Seeder;
+use App\Models\Company;
+use Illuminate\Support\Facades\Hash;
 
 class UsersTableSeeder extends Seeder
 {


### PR DESCRIPTION
`UsersTableSeeder.php` takes use of company models here but it has not imported it:  ` $company = Company::factory()->create([....` 

Also it takes use of password hashing here but it has not imported it:  `'password' => Hash::make(config('ninja.testvars.password')),`