### PR TITLE
Readme git clone improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ We offer a $30 per year white-label license to remove the Invoice Ninja branding
 
 ```sh
 git clone --single-branch --branch v5-stable https://github.com/invoiceninja/invoiceninja.git
-git checkout v5-stable
 cp .env.example .env
 composer i -o --no-dev
 php artisan key:generate

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We offer a $30 per year white-label license to remove the Invoice Ninja branding
 ## Quick Hosting Setup
 
 ```sh
-git clone https://github.com/invoiceninja/invoiceninja.git
+git clone --single-branch --branch v5-stable https://github.com/invoiceninja/invoiceninja.git
 git checkout v5-stable
 cp .env.example .env
 composer i -o --no-dev


### PR DESCRIPTION
Checking out the entire invoiceninja repository takes up around ~3.6Gb of disk space. Checking out v5-stable takes around 3.3Gb. As software grows, this will increase. It makes sense for those who only want to host stable versions to pick out just the one branch.