### PR TITLE
Return correct identifier for reports

### DIFF
--- a/app/Export/CSV/ActivityExport.php
+++ b/app/Export/CSV/ActivityExport.php
@@ -54,7 +54,7 @@ class ActivityExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
             

--- a/app/Export/CSV/ClientExport.php
+++ b/app/Export/CSV/ClientExport.php
@@ -93,7 +93,7 @@ class ClientExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/ContactExport.php
+++ b/app/Export/CSV/ContactExport.php
@@ -89,7 +89,7 @@ class ContactExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/CreditExport.php
+++ b/app/Export/CSV/CreditExport.php
@@ -44,7 +44,7 @@ class CreditExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/DocumentExport.php
+++ b/app/Export/CSV/DocumentExport.php
@@ -50,7 +50,7 @@ class DocumentExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/ExpenseExport.php
+++ b/app/Export/CSV/ExpenseExport.php
@@ -44,7 +44,7 @@ class ExpenseExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/InvoiceExport.php
+++ b/app/Export/CSV/InvoiceExport.php
@@ -73,7 +73,7 @@ class InvoiceExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/InvoiceItemExport.php
+++ b/app/Export/CSV/InvoiceItemExport.php
@@ -81,7 +81,7 @@ class InvoiceItemExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
 

--- a/app/Export/CSV/PaymentExport.php
+++ b/app/Export/CSV/PaymentExport.php
@@ -66,7 +66,7 @@ class PaymentExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use ($headerdisplay) {
-            return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+            return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
         })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/ProductExport.php
+++ b/app/Export/CSV/ProductExport.php
@@ -42,7 +42,7 @@ class ProductExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/PurchaseOrderExport.php
+++ b/app/Export/CSV/PurchaseOrderExport.php
@@ -114,7 +114,7 @@ class PurchaseOrderExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/PurchaseOrderItemExport.php
+++ b/app/Export/CSV/PurchaseOrderItemExport.php
@@ -73,7 +73,7 @@ class PurchaseOrderItemExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $query->cursor()

--- a/app/Export/CSV/QuoteExport.php
+++ b/app/Export/CSV/QuoteExport.php
@@ -75,7 +75,7 @@ class QuoteExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use ($headerdisplay) {
-            return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+            return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
         })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/QuoteItemExport.php
+++ b/app/Export/CSV/QuoteItemExport.php
@@ -75,7 +75,7 @@ class QuoteItemExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
             $query->cursor()

--- a/app/Export/CSV/RecurringInvoiceExport.php
+++ b/app/Export/CSV/RecurringInvoiceExport.php
@@ -87,7 +87,7 @@ class RecurringInvoiceExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()

--- a/app/Export/CSV/TaskExport.php
+++ b/app/Export/CSV/TaskExport.php
@@ -100,7 +100,7 @@ class TaskExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $query->cursor()

--- a/app/Export/CSV/VendorExport.php
+++ b/app/Export/CSV/VendorExport.php
@@ -74,7 +74,7 @@ class VendorExport extends BaseExport
         $headerdisplay = $this->buildHeader();
 
         $header = collect($this->input['report_keys'])->map(function ($key, $value) use($headerdisplay){
-                return ['identifier' => $value, 'display_value' => $headerdisplay[$value]];
+                return ['identifier' => $key, 'display_value' => $headerdisplay[$value]];
             })->toArray();
 
         $report = $query->cursor()


### PR DESCRIPTION
This fixes identifier return for report previews.

Previous:

```
{ identifier: 0, display_value: "Client Name" },
{ identifier: 1, display_value: "Invoice Invoice Number" }
```

Now:

```
{ identifier: "client.name", display_value: "Client Name" },
{ identifier: "invoice.number", display_value: "Invoice Invoice Number" }
```