### PR TITLE
Add margin-top to public_notes on clean design

### DIFF
--- a/resources/views/pdf-designs/clean.html
+++ b/resources/views/pdf-designs/clean.html
@@ -240,6 +240,10 @@
         margin-bottom: 0;
     }
 
+    [data-ref="total_table-public_notes"] {
+        margin-top: 1rem;
+    }
+
     [data-ref="statement-totals"] {
         margin-top: 1rem;
         text-align: right;


### PR DESCRIPTION
Adds margin-top to the invoice notes on the "Clean" design template so that the notes are not directly against the product/task rows. This also brings the notes into alignment with the totals on the opposite side.