### PR TITLE
HOTFIX: en_GB language is broken

### DIFF
--- a/lang/en_GB/texts.php
+++ b/lang/en_GB/texts.php
@@ -1,6 +1,6 @@
 <?php
 
-$lang = array(
+$lang = [
     'organization' => 'Organisation',
     'name' => 'Name',
     'website' => 'Website',


### PR DESCRIPTION
```
production.ERROR: Unclosed '(' on line 3 does not match ']' {"userId":1,"exception":"[object] (ParseError(code: 0): Unclosed '(' on line 3 does not match ']' at /var/www/app/lang/en_GB/texts.php:5049)
```

This works in the stable branch, it seems.