### PR TITLE
Update composer.json to use Larastan Org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,7 @@
         "laracasts/cypress": "^3.0",
         "mockery/mockery": "^1.4.4",
         "nunomaduro/collision": "^7.0",
-        "nunomaduro/larastan": "^2.0",
+        "larastan/larastan": "^2.0",
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": "^10.0",
         "spatie/laravel-ignition": "^2.0",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
     - ./vendor/spaze/phpstan-stripe/extension.neon
     - phpstan-baseline.neon
 parameters:


### PR DESCRIPTION
Starting with Larastan 2.7.0, the Larastan repository will now be managed under the Larastan organization. 