### PR TITLE
Feature: Nordigen better flow language

### DIFF
--- a/app/Helpers/Bank/Nordigen/Nordigen.php
+++ b/app/Helpers/Bank/Nordigen/Nordigen.php
@@ -52,12 +52,12 @@ class Nordigen
     }
 
     // requisition-section
-    public function createRequisition(string $redirect, string $initutionId, string $reference)
+    public function createRequisition(string $redirect, string $initutionId, string $reference, string $userLanguage)
     {
         if ($this->test_mode && $initutionId != $this->sandbox_institutionId)
             throw new \Exception('invalid institutionId while in test-mode');
 
-        return $this->client->requisition->createRequisition($redirect, $initutionId, null, $reference);
+        return $this->client->requisition->createRequisition($redirect, $initutionId, null, $reference, $userLanguage);
     }
 
     public function getRequisition(string $requisitionId)

--- a/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
@@ -114,7 +114,7 @@ class TransactionTransformer implements BankRevenueInterface
             'amount' => abs((int) $transaction["transactionAmount"]["amount"]),
             'currency_id' => $this->convertCurrency($transaction["transactionAmount"]["currency"]),
             'category_id' => null, // nordigen has no categories
-            'category_type' => array_key_exists('additionalInformation', $transaction) ? $transaction["additionalInformation"] : null, // TODO: institution specific keys like: GUTSCHRIFT, ABSCHLUSS, MONATSABSCHLUSS etc
+            'category_type' => array_key_exists('additionalInformation', $transaction) ? $transaction["additionalInformation"] : '', // TODO: institution specific keys like: GUTSCHRIFT, ABSCHLUSS, MONATSABSCHLUSS etc
             'date' => $transaction["bookingDate"],
             'description' => $description,
             'participant' => $participant,


### PR DESCRIPTION
as mentioned via slack, this implementation adds the following things:
- flow language is loaded by default from the company entity of the context
- connect flow get redirected, to company language, when this is not present as query-parmaeter (bank_ui needs this to work properly)
- language is passed to requisition, to use the same selected language at nordigen