### PR TITLE
FIX: Nordigen Import Error, when missing transactionId from instituition

### DIFF
--- a/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
@@ -87,8 +87,10 @@ class TransactionTransformer implements BankRevenueInterface
             $transactionId = $transaction["transactionId"];
         else if (array_key_exists('internalTransactionId', $transaction))
             $transactionId = $transaction["internalTransactionId"];
-        else
+        else {
+            nlog(`Invalid Input for nordigen transaction transformer: ` . $transaction);
             throw new \Exception('invalid dataset: missing transactionId - Please report this error to the developer');
+        }
 
         $amount = (float) $transaction["transactionAmount"]["amount"];
 

--- a/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
@@ -81,15 +81,14 @@ class TransactionTransformer implements BankRevenueInterface
 
     public function transformTransaction($transaction)
     {
-
-        if ((!array_key_exists('transactionId', $transaction) && !array_key_exists('internalTransactionId', $transaction)) || !array_key_exists('transactionAmount', $transaction))
-            throw new \Exception('invalid dataset');
-
+        // depending on institution, the result can be different, so we load the first available unique id
         $transactionId = '';
         if (array_key_exists('transactionId', $transaction))
             $transactionId = $transaction["transactionId"];
         else if (array_key_exists('internalTransactionId', $transaction))
             $transactionId = $transaction["internalTransactionId"];
+        else
+            throw new \Exception('invalid dataset: missing transactionId - Please report this error to the developer');
 
         $amount = (float) $transaction["transactionAmount"]["amount"];
 

--- a/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
@@ -82,8 +82,14 @@ class TransactionTransformer implements BankRevenueInterface
     public function transformTransaction($transaction)
     {
 
-        if (!array_key_exists('transactionId', $transaction) || !array_key_exists('transactionAmount', $transaction))
+        if ((!array_key_exists('transactionId', $transaction) && !array_key_exists('internalTransactionId', $transaction)) || !array_key_exists('transactionAmount', $transaction))
             throw new \Exception('invalid dataset');
+
+        $transactionId = '';
+        if (array_key_exists('transactionId', $transaction))
+            $transactionId = $transaction["transactionId"];
+        else if (array_key_exists('internalTransactionId', $transaction))
+            $transactionId = $transaction["internalTransactionId"];
 
         $amount = (float) $transaction["transactionAmount"]["amount"];
 
@@ -119,7 +125,7 @@ class TransactionTransformer implements BankRevenueInterface
 
         return [
             'transaction_id' => 0,
-            'nordigen_transaction_id' => $transaction["transactionId"],
+            'nordigen_transaction_id' => $transactionId,
             'amount' => $amount,
             'currency_id' => $this->convertCurrency($transaction["transactionAmount"]["currency"]),
             'category_id' => null,


### PR DESCRIPTION
closes https://github.com/invoiceninja/invoiceninja/issues/9198

both fields are optional, so this error could still be present in other cases.
The new import behavior is:
1. Use transactionId (if available)
2. Use internalTransactionId (if available)
3. Throw an error (in this case, we should look into it again :) )

Using transactionId as primary is required to dont result in duplicate transactions, because of changed nordigen_transaction_id for existing transactions.

Note: I also removed the check for amount, because it is a mandatory field from nordigen.