### PR TITLE
RFF validation errors on invoice show page

### DIFF
--- a/resources/views/portal/ninja2020/invoices/show.blade.php
+++ b/resources/views/portal/ninja2020/invoices/show.blade.php
@@ -10,6 +10,16 @@
 
 @endpush
 
+@section('header')
+    @if($errors->any())
+        <div class="alert alert-failure mb-4">
+            @foreach($errors->all() as $error)
+            <p>{{ $error }}</p>
+            @endforeach
+        </div>
+    @endif
+@endsection
+
 @section('body')
 
     @if($invoice->isPayable() && $client->getSetting('custom_message_unpaid_invoice'))


### PR DESCRIPTION
This adds matching RFF errors on the invoice show page.

![image](https://github.com/invoiceninja/invoiceninja/assets/13711415/45963995-839a-4e12-891c-7b5667b8cb43)
