### PR TITLE
Change to the correct thousand separator for Slovakia

### DIFF
--- a/database/migrations/2024_02_08_234429_change_thousand_separator_for_slovakia.php
+++ b/database/migrations/2024_02_08_234429_change_thousand_separator_for_slovakia.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $sk = \App\Models\Country::find(703);
+
+        if($sk) {
+            $sk->thousand_separator = ' ';
+            $sk->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+};

--- a/database/seeders/CountriesSeeder.php
+++ b/database/seeders/CountriesSeeder.php
@@ -177,6 +177,7 @@ class CountriesSeeder extends Seeder
             ],
             'SK' => [ // Slovakia
                 'swap_currency_symbol' => true,
+                'thousand_separator' => ' ',
             ],
             'US' => [
                 'thousand_separator' => ',',


### PR DESCRIPTION
I'd like to perform this change for thousand separator for Slovakia.

Possible proofs of the fact that this is the correct format:
https://www.unicode.org/cldr/cldr-aux/charts/29/verify/numbers/sk.html
https://publications.europa.eu/code/sk/sk-4100200.htm

Or what would be used in Windows:
![image](https://github.com/invoiceninja/invoiceninja/assets/9124099/53cfcc3c-5164-4839-9c05-38e5977e18f7)


Decimal separator and others were already correct but let's make sure we don't get overrides.

