### PR TITLE
Nordigen API fix: iban should be treated as optional

### DIFF
--- a/app/Helpers/Bank/Nordigen/Transformer/AccountTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/AccountTransformer.php
@@ -104,7 +104,7 @@ class AccountTransformer implements AccountTransformerInterface
         return [
             'id' => $nordigen_account->metadata["id"],
             'account_type' => "bank",
-            'account_name' => $nordigen_account->data["iban"],
+            'account_name' => isset($nordigen_account->data["iban"]) ? $nordigen_account->data["iban"] : '',
             'account_status' => $nordigen_account->metadata["status"],
             'account_number' => '**** ' . substr($nordigen_account->data["iban"], -7),
             'provider_account_id' => $nordigen_account->metadata["id"],

--- a/app/Helpers/Bank/Nordigen/Transformer/AccountTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/AccountTransformer.php
@@ -106,7 +106,7 @@ class AccountTransformer implements AccountTransformerInterface
             'account_type' => "bank",
             'account_name' => isset($nordigen_account->data["iban"]) ? $nordigen_account->data["iban"] : '',
             'account_status' => $nordigen_account->metadata["status"],
-            'account_number' => '**** ' . substr($nordigen_account->data["iban"], -7),
+            'account_number' => isset($nordigen_account->data["iban"]) ? '**** ' . substr($nordigen_account->data["iban"], -7) : '',
             'provider_account_id' => $nordigen_account->metadata["id"],
             'provider_id' => $nordigen_account->institution["id"],
             'provider_name' => $nordigen_account->institution["name"],


### PR DESCRIPTION
As described in this forum thread: https://forum.invoiceninja.com/t/use-of-nordigen-bank-api/15006/18

As noted on the API page of GoCardless (https://developer.gocardless.com/bank-account-data/account-details), iban is an optional field.