### PR TITLE
Redirect client to dashboard at login if enabled -fix #9417 #9501

### DIFF
--- a/app/Http/Middleware/ContactKeyLogin.php
+++ b/app/Http/Middleware/ContactKeyLogin.php
@@ -161,7 +161,9 @@ class ContactKeyLogin
 
     private function setRedirectPath()
     {
-        if (auth()->guard('contact')->user()->company->enabled_modules & PortalComposer::MODULE_INVOICES) {
+        if (auth()->guard('contact')->user()->client->getSetting('enable_client_portal_dashboard') === true) {
+            return '/client/dashboard';                                                                                              
+        } elseif (auth()->guard('contact')->user()->company->enabled_modules & PortalComposer::MODULE_INVOICES) {
             return '/client/invoices';
         } elseif (auth()->guard('contact')->user()->company->enabled_modules & PortalComposer::MODULE_RECURRING_INVOICES) {
             return '/client/recurring_invoices';


### PR DESCRIPTION
Upon pulling the latest release I discovered that the singular change did not have the desired effect (I admit, I did not test removing the other two items previously). After some testing I found that the change needed was in fact for the `app/Http/Middleware/ContactKeyLogin.php`