### PR TITLE
Fix: Update Nordigen to properly handle small money transfer amounts

### DIFF
--- a/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
@@ -148,7 +148,7 @@ class TransactionTransformer implements BankRevenueInterface
             'description' => $description,
             'participant' => $participant,
             'participant_name' => $participant_name,
-            'base_type' => (int) $transaction["transactionAmount"]["amount"] <= 0 ? 'DEBIT' : 'CREDIT',
+            'base_type' => $amount < 0 ? 'DEBIT' : 'CREDIT',
         ];
 
     }


### PR DESCRIPTION
I've changed the way base_type was defined by using the $amount field that was already defined before and made it use the float value to check below 0, so that small values like 0.01 also work.