### PR TITLE
Trim regional locales to two-letter country codes

### DIFF
--- a/app/Http/Controllers/Bank/NordigenController.php
+++ b/app/Http/Controllers/Bank/NordigenController.php
@@ -35,7 +35,7 @@ class NordigenController extends BaseController
         /** @var array $context */
         $context = $request->getTokenContent();
         $company = $request->getCompany();
-        $lang = $company->locale();
+        $lang = substr($company->locale(), 0, 2);
         $context["lang"] = $lang;
 
         if (!$context) {
@@ -143,7 +143,7 @@ class NordigenController extends BaseController
         $data = $request->all();
         $company = $request->getCompany();
         $account = $company->account;
-        $lang = $company->locale();
+        $lang = substr($company->locale(), 0, 2);
 
         /** @var array $context */
         $context = $request->getTokenContent();


### PR DESCRIPTION
@turbo124 One PR, as requested!

---

For anyone else:

GoCardless' Bank Account Data API requires two-letter ISO 639-1 country codes. IN passes the full locale such as *en_GB* or *pt_BR*, which causes an "unknown error" when selecting banks in Connect Accounts.

Note: Norwegian will use the Bokmål (`nb`) form over Nynorsk (`nn`).

Fixes #9566