### PR TITLE
Prevent 500 error without logs

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -152,7 +152,7 @@ class Handler extends ExceptionHandler
         parent::report($exception);
 
         if (Ninja::isSelfHost() && $exception instanceof MissingAppKeyException) {
-            \Log::error('To setup the app run "cp .env.example .env" followed by "php artisan key:generate"');
+            info('To setup the app run "cp .env.example .env" followed by "php artisan key:generate"');
         }
     }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -18,6 +18,7 @@ use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException as ModelNotFoundException;
 use Illuminate\Database\Eloquent\RelationNotFoundException;
+use Illuminate\Encryption\MissingAppKeyException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Http\Request;
@@ -149,6 +150,10 @@ class Handler extends ExceptionHandler
         }
 
         parent::report($exception);
+
+        if (Ninja::isSelfHost() && $exception instanceof MissingAppKeyException) {
+            \Log::error('To setup the app run "cp .env.example .env" followed by "php artisan key:generate"');
+        }
     }
 
     private function validException($exception)

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -94,11 +94,6 @@ class Handler extends ExceptionHandler
      */
     public function report(Throwable $exception)
     {
-        if (! Schema::hasTable('accounts')) {
-            info('account table not found');
-            return;
-        }
-
         if (Ninja::isHosted()) {
 
             // if($exception instanceof ThrottleRequestsException && class_exists(\Modules\Admin\Events\ThrottledExceptionRaised::class)) {

--- a/resources/views/portal/ninja2020/layout/error.blade.php
+++ b/resources/views/portal/ninja2020/layout/error.blade.php
@@ -10,10 +10,16 @@
         </div>
 
         <div class="col-span-2 h-screen flex">
-            <div class="m-auto md:w-1/2 lg:w-1/4 flex flex-col items-center">
+            <div class="m-auto md:w-1/2 lg:w-1/3 flex flex-col items-center">
                 <span class="flex items-center text-2xl">
                     @yield('code') — @yield('message')
                 </span>
+
+                @if (\App\Utils\Ninja::isSelfHost())
+                    <span class="flex items-center text-1xl">
+                        Check storage/logs for more details
+                    </span>
+                @endif
 
                 <a class="button-link text-sm mt-2" href="{{ url(request()->getSchemeAndHttpHost() . '/client') }}">
                     {{ ctrans('texts.back_to', ['url' => parse_url(request()->getHttpHost())['host'] ?? request()->getHttpHost()]) }}


### PR DESCRIPTION
When helping new users setup the app people sometimes say they see a 500 error in the app but there's nothing in the logs. I'm able to replicate this problem by setting up the app and trying to access /setup without first copying the .env.example file. 

Since the .env file doesn't exist it triggers a MissingAppKeyException error, however that error isn't logged because the account table check triggers its own error since the database credentials haven't been set yet.

Note: I plan to submit separate changes to help people understand what do when setting up the app. 