### PR TITLE
Replace copyable link with pushState in client portal

### DIFF
--- a/resources/views/portal/ninja2020/credits/show.blade.php
+++ b/resources/views/portal/ninja2020/credits/show.blade.php
@@ -9,16 +9,6 @@
                     <h3 class="text-lg leading-6 font-medium text-gray-900">
                         {{ ctrans('texts.entity_number_placeholder', ['entity' => ctrans('texts.credit'), 'entity_number' => $credit->number]) }}
                     </h3>
-
-                    @if($key)
-                    <div class="btn hidden md:block" data-clipboard-text="{{url("client/credit/{$key}")}}" aria-label="Copied!">
-                        <div class="flex text-sm leading-6 font-medium text-gray-500">
-                            <p class="mr-2">{{url("client/credit/{$key}")}}</p>
-                            <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                        </div>
-                    </div>
-                    @endif
-
                 </div>
             </div>
         </div>
@@ -30,11 +20,16 @@
 @endsection
 
 @section('footer')
-    <script src="{{ asset('vendor/clipboard.min.js') }}"></script>
 
     <script type="text/javascript">
 
-        var clipboard = new ClipboardJS('.btn');
+        document.addEventListener('DOMContentLoaded', () => {
+
+            @if($key)
+                window.history.pushState({}, "", "{{ url("client/credit/{$key}") }}");
+            @endif
+
+        });
 
     </script>
 @endsection

--- a/resources/views/portal/ninja2020/invoices/show.blade.php
+++ b/resources/views/portal/ninja2020/invoices/show.blade.php
@@ -56,17 +56,6 @@
                                 {{ ctrans('texts.invoice_number_placeholder', ['invoice' => $invoice->number])}}
                                 - {{ ctrans('texts.unpaid') }}
                             </h3>
-
-                            @if($key)
-                            <div class="btn hidden md:block" data-clipboard-text="{{url("client/invoice/{$key}")}}" aria-label="Copied!">
-                                <div class="flex text-sm leading-6 font-medium text-gray-500">
-                                    <p class="mr-2">{{url("client/invoice/{$key}")}}</p>
-                                    <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                                </div>
-                            </div>
-                            @endif
-
-
                         </div>
                         <div class="mt-5 sm:mt-0 sm:ml-6 flex justify-end">
                             <div class="inline-flex rounded-md shadow-sm">
@@ -93,15 +82,6 @@
                             {{ ctrans('texts.invoice_number_placeholder', ['invoice' => $invoice->number])}}
                             - {{ \App\Models\Invoice::stringStatus($invoice->status_id) }}
                         </h3>
-
-                            @if($key)
-                            <div class="btn hidden md:block" data-clipboard-text="{{url("client/invoice/{$key}")}}" aria-label="Copied!">
-                                <div class="flex text-sm leading-6 font-medium text-gray-500">
-                                    <p class="pr-10">{{url("client/invoice/{$key}")}}</p>
-                                    <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                                </div>
-                            </div>
-                            @endif
                     </div>
                 </div>
             </div>
@@ -121,15 +101,16 @@
 
 @push('head')
     @vite('resources/js/clients/invoices/payment.js')
-    <script src="{{ asset('vendor/clipboard.min.js') }}" defer></script>
 
     <script type="text/javascript">
 
-    document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', () => {
 
-        var clipboard = new ClipboardJS('.btn');
+            @if($key)
+                window.history.pushState({}, "", "{{ url("client/invoice/{$key}") }}");
+            @endif
 
-    });
+        });
 
     </script>
 @endpush

--- a/resources/views/portal/ninja2020/purchase_orders/includes/actions.blade.php
+++ b/resources/views/portal/ninja2020/purchase_orders/includes/actions.blade.php
@@ -10,18 +10,9 @@
     <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-start sm:justify-between">
             <div>
-            
                 <h3 class="text-lg leading-6 font-medium text-gray-900">
                     {{ ctrans('texts.approve') }}
                 </h3>
-                
-                <div class="btn hidden md:block" data-clipboard-text="{{url("vendor/purchase_order/{$key}")}}" aria-label="Copied!">
-                    <div class="flex text-sm leading-6 font-medium text-gray-500">
-                        <p class="mr-2">{{url("vendor/purchase_order/{$key}")}}</p>
-                        <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                    </div>
-                </div>
-            
             </div>
 
             <div class="mt-5 sm:mt-0 sm:ml-6 sm:flex-shrink-0 sm:flex sm:items-center">

--- a/resources/views/portal/ninja2020/purchase_orders/show.blade.php
+++ b/resources/views/portal/ninja2020/purchase_orders/show.blade.php
@@ -30,15 +30,6 @@
                             {{ ctrans('texts.purchase_order_number_placeholder', ['purchase_order' => $purchase_order->number])}}
                             - {{ \App\Models\PurchaseOrder::stringStatus($purchase_order->status_id) }}
                         </h3>
-
-                            @if($key)
-                            <div class="btn hidden md:block" data-clipboard-text="{{url("vendor/purchase_order/{$key}")}}" aria-label="Copied!">
-                                <div class="flex text-sm leading-6 font-medium text-gray-500">
-                                    <p class="pr-10">{{url("vendor/purchase_order/{$key}")}}</p>
-                                    <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                                </div>
-                            </div>
-                            @endif
                     </div>
                 </div>
             </div>
@@ -57,13 +48,14 @@
 
 @push('head')
     @vite('resources/js/clients/purchase_orders/accept.js')
-    <script src="{{ asset('vendor/clipboard.min.js') }}"  defer></script>
 
     <script type="text/javascript">
 
         document.addEventListener('DOMContentLoaded', () => {
 
-            var clipboard = new ClipboardJS('.btn');
+            @if($key)
+                window.history.pushState({}, "", "{{ url("vendor/purchase_order/{$key}") }}");
+            @endif
 
         });
 

--- a/resources/views/portal/ninja2020/quotes/includes/actions.blade.php
+++ b/resources/views/portal/ninja2020/quotes/includes/actions.blade.php
@@ -11,17 +11,9 @@
     <div class="px-4 py-5 sm:p-6">
         <div class="sm:flex sm:items-start sm:justify-between">
             <div>
-
                 <h3 class="text-lg leading-6 font-medium text-gray-900">
                     {{ ctrans('texts.approve') }}
                 </h3>
-
-                <div class="btn hidden md:block" data-clipboard-text="{{url("client/quote/{$key}")}}" aria-label="Copied!">
-                    <div class="flex text-sm leading-6 font-medium text-gray-500">
-                        <p class="mr-2">{{url("client/quote/{$key}")}}</p>
-                        <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                    </div>
-                </div>
             </div>
 
             <div class="mt-5 sm:mt-0 sm:ml-6 sm:flex-shrink-0 sm:flex sm:items-center">

--- a/resources/views/portal/ninja2020/quotes/show.blade.php
+++ b/resources/views/portal/ninja2020/quotes/show.blade.php
@@ -29,16 +29,6 @@
                         <h3 class="text-lg leading-6 font-medium text-gray-900">
                             {{ ctrans('texts.approved') }}
                         </h3>
-
-                            @if($key)
-                            <div class="btn hidden md:block" data-clipboard-text="{{url("client/quote/{$key}")}}" aria-label="Copied!">
-                                <div class="flex text-sm leading-6 font-medium text-gray-500">
-                                    <p class="mr-2">{{url("client/quote/{$key}")}}</p>
-                                    <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                                </div>
-                            </div>
-                            @endif
-
                     </div>
 
                                 @if($quote->invoice()->exists())
@@ -61,15 +51,6 @@
                         <h3 class="text-lg leading-6 font-medium text-gray-900">
                             {{ ctrans('texts.approved') }}
                         </h3>
-
-                            @if($key)
-                            <div class="btn hidden md:block" data-clipboard-text="{{url("client/quote/{$key}")}}" aria-label="Copied!">
-                                <div class="flex text-sm leading-6 font-medium text-gray-500">
-                                    <p class="mr-2">{{url("client/quote/{$key}")}}</p>
-                                    <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                                </div>
-                            </div>
-                            @endif
                     </div>
                 </div>
             </div>
@@ -84,15 +65,6 @@
                         <h3 class="text-lg leading-6 font-medium text-gray-900">
                             {{ ctrans('texts.expired') }}
                         </h3>
-
-                            @if($key)
-                            <div class="btn hidden md:block" data-clipboard-text="{{url("client/quote/{$key}")}}" aria-label="Copied!">
-                                <div class="flex text-sm leading-6 font-medium text-gray-500">
-                                    <p class="mr-2">{{url("client/quote/{$key}")}}</p>
-                                    <p><img class="h-5 w-5" src="{{ asset('assets/clippy.svg') }}" alt="Copy to clipboard"></p>
-                                </div>
-                            </div>
-                            @endif
                     </div>
                 </div>
             </div>
@@ -112,13 +84,14 @@
 
 @push('head')
     @vite('resources/js/clients/quotes/approve.js')
-    <script src="{{ asset('vendor/clipboard.min.js') }}" defer></script>
 
     <script type="text/javascript" defer>
 
     document.addEventListener('DOMContentLoaded', () => {
 
-        var clipboard = new ClipboardJS('.btn');
+        @if($key)
+            window.history.pushState({}, "", "{{ url("client/quote/{$key}") }}");
+        @endif
 
     });
 


### PR DESCRIPTION
This PR uses the pushState method to update the browser's URL when viewing an invoice, quote, credit or purchase order in the client portal.

This change enables us to remove the copyable link shown at the top of the screen since the browser URL can now be copied instead. 