### PR TITLE
Improve selfhost app load time

### DIFF
--- a/app/Http/Controllers/SetupController.php
+++ b/app/Http/Controllers/SetupController.php
@@ -43,7 +43,7 @@ class SetupController extends Controller
 
     public function index()
     {
-        $check = SystemHealth::check(false);
+        $check = SystemHealth::check(false, false);
 
         if ($check['system_health'] == true && $check['simple_db_check'] && Schema::hasTable('accounts') && $account = Account::first()) {
             return redirect('/');
@@ -59,7 +59,7 @@ class SetupController extends Controller
     public function doSetup(StoreSetupRequest $request)
     {
         try {
-            $check = SystemHealth::check(false);
+            $check = SystemHealth::check(false, false);
         } catch (Exception $e) {
             nlog(['message' => $e->getMessage(), 'action' => 'SetupController::doSetup()']);
 

--- a/app/Utils/SystemHealth.php
+++ b/app/Utils/SystemHealth.php
@@ -43,7 +43,7 @@ class SystemHealth
      * @param bool $check_database
      * @return     array  Result set of checks
      */
-    public static function check($check_database = true): array
+    public static function check($check_database = true, $check_filesystem = true): array
     {
         $system_health = true;
 
@@ -82,7 +82,7 @@ class SystemHealth
             'pdf_engine' => (string) self::getPdfEngine(),
             'queue' => (string) config('queue.default'),
             'trailing_slash' => (bool) self::checkUrlState(),
-            'file_permissions' => (string) self::checkFileSystem(),
+            'file_permissions' => (string) ($check_filesystem ? self::checkFileSystem() : ''),
             'exchange_rate_api_not_configured' => (bool)self::checkCurrencySanity(),
             'api_version' => (string) config('ninja.app_version'),
             'is_docker' => (bool) config('ninja.is_docker'),

--- a/app/Utils/SystemHealth.php
+++ b/app/Utils/SystemHealth.php
@@ -43,7 +43,7 @@ class SystemHealth
      * @param bool $check_database
      * @return     array  Result set of checks
      */
-    public static function check($check_database = true, $check_filesystem = true): array
+    public static function check($check_database = true, $check_file_system = true): array
     {
         $system_health = true;
 
@@ -82,7 +82,7 @@ class SystemHealth
             'pdf_engine' => (string) self::getPdfEngine(),
             'queue' => (string) config('queue.default'),
             'trailing_slash' => (bool) self::checkUrlState(),
-            'file_permissions' => (string) ($check_filesystem ? self::checkFileSystem() : ''),
+            'file_permissions' => (string) ($check_file_system ? self::checkFileSystem() : ''),
             'exchange_rate_api_not_configured' => (bool)self::checkCurrencySanity(),
             'api_version' => (string) config('ninja.app_version'),
             'is_docker' => (bool) config('ninja.is_docker'),

--- a/app/Utils/Traits/AppSetup.php
+++ b/app/Utils/Traits/AppSetup.php
@@ -25,7 +25,7 @@ trait AppSetup
             return Ninja::isNinja();
         }
 
-        $check = SystemHealth::check();
+        $check = SystemHealth::check(true, false);
 
         return $check['system_health'] == 'true';
     }


### PR DESCRIPTION
On my selfhost instance the /setup screen and app take a long time to load, almost 30 seconds. The slowdown is caused by file permissions check in SystemHealth::check. 

This change disables the file permission check on the / and /setup routes. The result of the file permission check isn't used so it shouldn't have any impact other than speeding things up. 

Note: on the hosted platform this code is skipped so it doesn't have this problem.