### PR TITLE
Add queue stats to the health check stats

### DIFF
--- a/app/Utils/SystemHealth.php
+++ b/app/Utils/SystemHealth.php
@@ -78,9 +78,9 @@ class SystemHealth
             'open_basedir' => (bool) self::checkOpenBaseDir(),
             'mail_mailer' => (string) self::checkMailMailer(),
             'flutter_renderer' => (string) config('ninja.flutter_canvas_kit'),
-            'jobs_pending' => (int) self::checkQueueSize(),
             'pdf_engine' => (string) self::getPdfEngine(),
             'queue' => (string) config('queue.default'),
+            'queue_data' => self::checkQueueData(),
             'trailing_slash' => (bool) self::checkUrlState(),
             'file_permissions' => (string) ($check_file_system ? self::checkFileSystem() : ''),
             'exchange_rate_api_not_configured' => (bool)self::checkCurrencySanity(),
@@ -117,16 +117,28 @@ class SystemHealth
         return false;
     }
 
-    private static function checkQueueSize()
+    private static function checkQueueData()
     {
-        $count = 0;
+        $pending = 0;
+        $failed = 0;
+        $last_error = '';
 
         try {
-            $count = Queue::size();
+            $pending = DB::table('jobs')->count();
+            $failed = DB::table('failed_jobs')->count();
+
+            if ($failed > 0) {
+                $failed_job = DB::table('failed_jobs')->latest('failed_at')->first();
+                $last_error = $failed_job->exception;
+            }
         } catch (\Exception $e) {
         }
 
-        return $count;
+        return [
+            'failed' => $failed,
+            'pending' => $pending,
+            'last_error' => $last_error,
+        ];
     }
 
     public static function checkFileSystem()

--- a/app/Utils/SystemHealth.php
+++ b/app/Utils/SystemHealth.php
@@ -11,6 +11,8 @@
 
 namespace App\Utils;
 
+use LimitIterator;
+use SplFileObject;
 use App\Libraries\MultiDB;
 use App\Mail\TestMailServer;
 use Exception;
@@ -337,11 +339,12 @@ class SystemHealth
 
     public static function lastError()
     {
-        $filepath = storage_path('logs/laravel.log');
-        $file = escapeshellarg($filepath);
-        $end_of_file = `tail -n 500 $file`;
+        $log_file = new SplFileObject(sprintf('%s/laravel.log', base_path('storage/logs')));
+        $log_file->seek(PHP_INT_MAX);
+        $last_line = $log_file->key();
 
-        $lines = explode("\n", $end_of_file);
+        $lines = new LimitIterator($log_file, max(0, $last_line - 500), $last_line);
+        $log_lines = iterator_to_array($lines);
         $last_error = '';
 
         foreach ($lines as $line) {


### PR DESCRIPTION
This PR replaces the `jobs_pending` property in the health check response with `queue_data` which includes the number of pending/failed jobs as well as the last error if one exists.

Note: the implementation assumes the database queue is being used, in my experience this seems much more common for selfhoster than using Redis. I'll handle adding this to the Flutter app but it will also need to be added to the React app.

The PR also includes a refactor of the code to retrieve the last error from storage/logs to match existing code. 