### PR TITLE
Fix edge cases to ensure /setup loads

### DIFF
--- a/resources/views/setup/clean_setup.blade.php
+++ b/resources/views/setup/clean_setup.blade.php
@@ -42,13 +42,7 @@
         @endif
 
         <!-- Title -->
-        @auth('contact')
-            <title>@yield('meta_title', '') — {{ auth()->guard('contact')->user()->user->account->isPaid() ? auth()->guard('contact')->user()->company->present()->name() : 'Invoice Ninja' }}</title>
-        @endauth
-
-        @guest
-            <title>@yield('meta_title', '') — {{ config('app.name') }}</title>
-        @endguest
+        <title>@yield('meta_title', '') — {{ config('app.name') }}</title>
 
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -86,10 +80,6 @@
             <link href="{{ str_replace("setup", "", Request::url())}}css/app.css" rel="stylesheet">
         @endif
 
-        @if(auth()->guard('contact')->user() && !auth()->guard('contact')->user()->user->account->isPaid())
-        {{-- <link href="{{ mix('favicon.png') }}" rel="shortcut icon" type="image/png"> --}}
-        @endif
-
         <link rel="canonical" href="{{ config('ninja.app_url') }}/{{ request()->path() }}"/>
 
         {{-- Feel free to push anything to header using @push('header') --}}
@@ -101,8 +91,6 @@
 
         <link rel="stylesheet" type="text/css" href="{{ asset('vendor/cookieconsent@3/cookieconsent.min.css') }}" />
     </head>
-
-    @include('portal.ninja2020.components.primary-color')
 
     <body class="antialiased {{ $custom_body_class ?? '' }}">
         @if(session()->has('message'))

--- a/resources/views/setup/index.blade.php
+++ b/resources/views/setup/index.blade.php
@@ -1,4 +1,4 @@
-@extends('portal.ninja2020.layout.clean_setup')
+@extends('setup.clean_setup')
 @section('meta_title', ctrans('texts.setup'))
 
 @section('body')


### PR DESCRIPTION
I've noticed a number of edge cases when trying to load the /setup screen related to the database due to using the auth() methods, this will throw user/contacts table don't exist errors. I believe I've tracked it down to two issues:

- The setup/index blade file extends "portal.ninja2020.layout.clean_setup", since the clean_setup file is under the "portal.*" namespace I believe the ComposerServiceProvider class is automatically trying to instantiate an instance of the PortalComposer class. I believe the fix here would be to simply move clean_setup file to views/setup
- The setup/index blade file uses auth methods. I believe the instances can be removed.
