### PR TITLE
Added pending database migrations to the health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ We offer a $30 per year white-label license to remove the Invoice Ninja branding
 git clone --single-branch --branch v5-stable https://github.com/invoiceninja/invoiceninja.git
 cp .env.example .env
 composer i -o --no-dev
-php artisan key:generate
 ```
 
 Please Note: 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -152,7 +152,7 @@ class Handler extends ExceptionHandler
         parent::report($exception);
 
         if (Ninja::isSelfHost() && $exception instanceof MissingAppKeyException) {
-            info('To setup the app run "cp .env.example .env" followed by "php artisan key:generate"');
+            info('To setup the app run: cp .env.example .env');
         }
     }
 

--- a/app/Utils/SystemHealth.php
+++ b/app/Utils/SystemHealth.php
@@ -89,6 +89,7 @@ class SystemHealth
             'exchange_rate_api_not_configured' => (bool)self::checkCurrencySanity(),
             'api_version' => (string) config('ninja.app_version'),
             'is_docker' => (bool) config('ninja.is_docker'),
+            'pending_migrations' => self::checkPendingMigrations(),
         ];
     }
 
@@ -170,6 +171,17 @@ class SystemHealth
         }
 
         return false;
+    }
+
+    public static function checkPendingMigrations()
+    {
+        $run_count = DB::table('migrations')->count();
+
+        $directory = base_path('database/migrations');
+        $iterator = new \FilesystemIterator($directory);
+        $total_count = iterator_count($iterator) - 1;
+
+        return $run_count != $total_count;
     }
 
     public static function getPdfEngine()


### PR DESCRIPTION
- Added pending database migrations to the health check by comparing the number of rows in the migrations table to the number of files in the migrations folder
- Removed obsolete references to `key:generate`