### PR TITLE
Fix for setup error introduced with migration check

### DIFF
--- a/app/Utils/SystemHealth.php
+++ b/app/Utils/SystemHealth.php
@@ -89,7 +89,7 @@ class SystemHealth
             'exchange_rate_api_not_configured' => (bool)self::checkCurrencySanity(),
             'api_version' => (string) config('ninja.app_version'),
             'is_docker' => (bool) config('ninja.is_docker'),
-            'pending_migrations' => self::checkPendingMigrations(),
+            'pending_migrations' => (bool) ($check_file_system ? self::checkPendingMigrations() : ''),
         ];
     }
 

--- a/app/Utils/SystemHealth.php
+++ b/app/Utils/SystemHealth.php
@@ -89,7 +89,7 @@ class SystemHealth
             'exchange_rate_api_not_configured' => (bool)self::checkCurrencySanity(),
             'api_version' => (string) config('ninja.app_version'),
             'is_docker' => (bool) config('ninja.is_docker'),
-            'pending_migrations' => (bool) ($check_file_system ? self::checkPendingMigrations() : ''),
+            'pending_migrations' => (bool) ($check_file_system ? self::checkPendingMigrations() : false),
         ];
     }
 


### PR DESCRIPTION
This resolves the error by only checking for pending migrations when the app is already setup 