### PR TITLE
Tax rule for Poland (PL)

### DIFF
--- a/app/DataMapper/Tax/PL/Rule.php
+++ b/app/DataMapper/Tax/PL/Rule.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2024. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\DataMapper\Tax\PL;
+
+use App\DataMapper\Tax\DE\Rule as DERule;
+
+class Rule extends DERule
+{
+    /** @var string $seller_region */
+    public string $seller_region = 'EU';
+
+    /** @var bool $consumer_tax_exempt */
+    public bool $consumer_tax_exempt = false;
+
+    /** @var bool $business_tax_exempt */
+    public bool $business_tax_exempt = false;
+
+    /** @var bool $eu_business_tax_exempt */
+    public bool $eu_business_tax_exempt = true;
+
+    /** @var bool $foreign_business_tax_exempt */
+    public bool $foreign_business_tax_exempt = false;
+
+    /** @var bool $foreign_consumer_tax_exempt */
+    public bool $foreign_consumer_tax_exempt = false;
+
+    /** @var float $tax_rate */
+    public float $tax_rate = 0;
+
+    /** @var float $reduced_tax_rate */
+    public float $reduced_tax_rate = 0;
+
+    public string $tax_name1 = 'VAT';
+
+}

--- a/app/DataMapper/Tax/TaxModel.php
+++ b/app/DataMapper/Tax/TaxModel.php
@@ -474,6 +474,12 @@ class TaxModel
         $this->regions->EU->subregions->NL->reduced_tax_rate = 9;
         $this->regions->EU->subregions->NL->apply_tax = false;
 
+        $this->regions->EU->subregions->PL = new \stdClass();
+        $this->regions->EU->subregions->PL->tax_rate = 23;
+        $this->regions->EU->subregions->PL->tax_name = 'VAT';
+        $this->regions->EU->subregions->PL->reduced_tax_rate = 8;
+        $this->regions->EU->subregions->PL->apply_tax = false;
+
         $this->regions->EU->subregions->PT = new \stdClass();
         $this->regions->EU->subregions->PT->tax_rate = 23;
         $this->regions->EU->subregions->PT->tax_name = 'IVA';

--- a/app/DataMapper/Tax/tax_model.yaml
+++ b/app/DataMapper/Tax/tax_model.yaml
@@ -197,6 +197,10 @@ region:
         vat: 21
         reduced_vat: 9
         apply_tax: false
+      PL:
+        vat: 23
+        reduced_vat: 8
+        apply_tax: false
       PT:
         vat: 23
         reduced_vat: 6


### PR DESCRIPTION
## Implement Tax rule for Poland (PL)

### Problem
When deploying Invoice Ninja with Poland as the business' home country, the application throws an error due to missing tax rule handling for Poland.

### Error Details
The following error is encountered:
[2024-07-29 16:53:48] production.ERROR: Class "App\DataMapper\Tax\PL\Rule" not found {"userId":1,"exception":"[object] (Error(code: 0): Class "App\DataMapper\Tax\PL\Rule" not found at /var/www/app/app/Helpers/Invoice/InvoiceItemSum.php:185)
[stacktrace]
...

### Solution
I have implemented the missing tax rule class for Poland. This addition allows the application to correctly handle tax calculations for businesses based in Poland.

### Changes Made
- Created a new file `app/DataMapper/Tax/PL/Rule.php`
- Modified `app/Services/Tax/TaxModel.php` & `app/Services/Tax/tax_model.yaml`
  - Added logic to use the new rule for Poland with appropriate tax rates (23% and 8%)

### Testing
- Verified that the application no longer throws an error when Poland is set as the home country
- Tested tax calculations on invoices issued to businesses and non-businesses in Poland, the EU, and outside of the EU.
