### PR TITLE
feat: Add YunoHost to self-hosted options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ All Pro and Enterprise features from the hosted app are included in the open-sou
 * [Docker File](https://hub.docker.com/r/invoiceninja/invoiceninja/)
 * [Cloudron](https://www.cloudron.io/store/com.invoiceninja.cloudronapp2.html)
 * [Softaculous](https://www.softaculous.com/apps/ecommerce/Invoice_Ninja)
+* [YunoHost](https://apps.yunohost.org/app/invoiceninja5)
  
 ### Recommended Providers
 * [Stripe](https://stripe.com/)


### PR DESCRIPTION
This PR adds YunoHost to self-hosted options. Added the link to YunoHost's app store: https://apps.yunohost.org/app/invoiceninja5