### PR TITLE
GoCardless: Force sandbox for specific company

### DIFF
--- a/app/Http/Controllers/Gateways/GoCardlessOAuthController.php
+++ b/app/Http/Controllers/Gateways/GoCardlessOAuthController.php
@@ -44,6 +44,9 @@ class GoCardlessOAuthController extends Controller
             ? 'https://connect.gocardless.com/oauth/authorize?%s'
             : 'https://connect-sandbox.gocardless.com/oauth/authorize?%s';
 
+        if (config('services.gocardless.testing_company') == $company->id) {
+            $url = 'https://connect-sandbox.gocardless.com/oauth/authorize?%s';
+        }
 
         return redirect()->to(
             sprintf($url, http_build_query($params))
@@ -55,12 +58,13 @@ class GoCardlessOAuthController extends Controller
         /** @var \App\Models\Company $company */
         $company = $request->getCompany();
 
-        // LBo0v_561xgFGnFUae6uEQEfrWoSEMnZ&state=5O2O85C8dPv1Gp1UPVq0xs4FVTZdq5dO
-        // https://invoicing.co/gocardless/oauth/connect/confirm?code=sH55_xb-2s1JtuEw-j7W0hT0Z1sFkM7l
-
         $url = config('services.gocardless.environment') === 'production'
             ? 'https://connect.gocardless.com/oauth/access_token'
             : 'https://connect-sandbox.gocardless.com/oauth/access_token';
+
+        if (config('services.gocardless.testing_company') == $company->id) {
+            $url = 'https://connect-sandbox.gocardless.com/oauth/access_token';
+        }
 
         $response = Http::post($url, [
             'client_id' => config('services.gocardless.client_id'),

--- a/config/services.php
+++ b/config/services.php
@@ -136,6 +136,7 @@ return [
         'client_secret' => env('GOCARDLESS_CLIENT_SECRET', null),
         'environment' => env('GOCARDLESS_ENVIRONMENT', 'production'),
         'redirect_uri' => env('GOCARDLESS_REDIRECT_URI', 'https://invoicing.co/gocardless/oauth/connect/confirm'),
+        'testing_company' => env('GOCARDLESS_TESTING_COMPANY', null),
     ],
     'quickbooks' => [
         'client_id' => env('QUICKBOOKS_CLIENT_ID', false),


### PR DESCRIPTION
This will force sandbox endpoints to test GoCardless OAuth2 integration. The value is compared to $company->id, make sure not to provide a hashed id.

```
GOCARDLESS_TESTING_COMPANY=
```

Note: This forces sandbox only on connecting flow and it doesn't include payments.