### PR TITLE
Update RotessaPaymentDriver.php

### DIFF
--- a/app/PaymentDrivers/RotessaPaymentDriver.php
+++ b/app/PaymentDrivers/RotessaPaymentDriver.php
@@ -265,7 +265,7 @@ class RotessaPaymentDriver extends BaseDriver
 
     public function gatewayRequest($verb, $uri, $payload = [])
     {
-        $r = Http::withToken($this->company_gateway->getConfigField('apiKey'))
+        $r = Http::withHeaders(['Authorization' => 'Token token=' . $this->company_gateway->getConfigField('apiKey'))
                 ->{$verb}($this->getUrl().$uri, $payload);
 
         nlog($r->body());

--- a/app/PaymentDrivers/RotessaPaymentDriver.php
+++ b/app/PaymentDrivers/RotessaPaymentDriver.php
@@ -265,7 +265,7 @@ class RotessaPaymentDriver extends BaseDriver
 
     public function gatewayRequest($verb, $uri, $payload = [])
     {
-        $r = Http::withHeaders(['Authorization' => 'Token token=' . $this->company_gateway->getConfigField('apiKey'))
+        $r = Http::withToken($this->company_gateway->getConfigField('apiKey'),'Token token=')
                 ->{$verb}($this->getUrl().$uri, $payload);
 
         nlog($r->body());


### PR DESCRIPTION
Api Key should be passed in authorization header in format specified by API docs https://rotessa.com/docs/#authentication

Fixes [issue #10043 ](https://github.com/invoiceninja/invoiceninja/issues/10043)