### PR TITLE
Account management: Stripe in headless

### DIFF
--- a/app/PaymentDrivers/Stripe/CreditCard.php
+++ b/app/PaymentDrivers/Stripe/CreditCard.php
@@ -38,6 +38,10 @@ class CreditCard implements LivewireMethodInterface
     {
         $intent['intent'] = $this->stripe->getSetupIntent();
 
+        if ($this->stripe->headless) {
+            return array_merge($data, $intent);
+        }
+
         return render('gateways.stripe.credit_card.authorize', array_merge($data, $intent));
     }
 
@@ -54,6 +58,10 @@ class CreditCard implements LivewireMethodInterface
         $stripe_method = $this->stripe->getStripePaymentMethod($stripe_response->payment_method);
 
         $this->storePaymentMethod($stripe_method, $request->payment_method_id, $customer);
+
+        if ($this->stripe->headless) {
+            return true;
+        }
 
         return redirect()->route('client.payment_methods.index');
     }

--- a/app/PaymentDrivers/StripePaymentDriver.php
+++ b/app/PaymentDrivers/StripePaymentDriver.php
@@ -107,6 +107,13 @@ class StripePaymentDriver extends BaseDriver
     public const SYSTEM_LOG_TYPE = SystemLog::TYPE_STRIPE;
 
     /**
+     * Indicates if returning responses should be headless or classic redirect.
+     * 
+     * @var bool
+     */
+    public bool $headless = false;
+
+    /**
      * Initializes the Stripe API.
      * @return self
      */


### PR DESCRIPTION
This configures Stripe to return headless responses instead of views.

We can leave this open until PR is fully done on all 3 sides.