### PR TITLE
Fix: XInvoice showing seller email as buyer email

### DIFF
--- a/app/Services/EDocument/Standards/ZugferdEDokument.php
+++ b/app/Services/EDocument/Standards/ZugferdEDokument.php
@@ -113,7 +113,7 @@ class ZugferdEDokument extends AbstractService
         if (empty($client->routing_id)) {
 
             $this->xdocument->setDocumentBuyerReference(ctrans("texts.xinvoice_no_buyers_reference"))
-                ->setDocumentSellerCommunication("EM", $client->present()->email());
+                ->setDocumentBuyerCommunication("EM", $client->present()->email());
         } else {
             $this->xdocument->setDocumentBuyerReference($client->routing_id)
                  ->setDocumentBuyerCommunication("0204", $client->routing_id);


### PR DESCRIPTION
This fixes the issue that _XInvoice_ invoices put the seller's email under the buyer's contact details in some cases (when there is no routing_id defined for the client). 