### PR TITLE
Improve compatibility with CIUS XRechnung schema

### DIFF
--- a/app/Services/EDocument/Standards/ZugferdEDokument.php
+++ b/app/Services/EDocument/Standards/ZugferdEDokument.php
@@ -76,6 +76,7 @@ class ZugferdEDokument extends AbstractService
             ->setDocumentBuyer($client->present()->name(), $client->number)
             ->setDocumentBuyerAddress($client->address1, "", "", $client->postal_code, $client->city, $client->country->iso_3166_2, $client->state)
             ->setDocumentBuyerContact($client->present()->primary_contact_name(), "", $client->present()->phone(), "", $client->present()->email())
+            ->setDocumentBuyerCommunication("EM", $client->present()->email())
             ->addDocumentPaymentTerm(ctrans("texts.xinvoice_payable", ['payeddue' => date_create($this->document->date ?? now()->format('Y-m-d'))->diff(date_create($this->document->due_date ?? now()->format('Y-m-d')))->format("%d"), 'paydate' => $this->document->due_date]));
 
         if (!empty($this->document->public_notes)) {
@@ -113,9 +114,7 @@ class ZugferdEDokument extends AbstractService
             $this->xdocument->setDocumentBuyerOrderReferencedDocument($this->document->po_number);
         }
         if (empty($client->routing_id)) {
-
-            $this->xdocument->setDocumentBuyerReference(ctrans("texts.xinvoice_no_buyers_reference"))
-                ->setDocumentSellerCommunication("EM", $this->document->user->email);
+            $this->xdocument->setDocumentBuyerReference(ctrans("texts.xinvoice_no_buyers_reference"));
         } else {
             $this->xdocument->setDocumentBuyerReference($client->routing_id)
                  ->setDocumentBuyerCommunication("0204", $client->routing_id);


### PR DESCRIPTION
This patch fixes a schema warning that could occur with _XInvoice 3.0_ invoices in some cases (when `$client->routing_id` is not set).

Schematron rule [PEPPOL-EN16931-R010](https://docs.peppol.eu/poacc/billing/3.0/rules/ubl-peppol/PEPPOL-EN16931-R010/) for, e.g., CIUS XRechnung (CII) (val-sch.2) demands that

>Buyer electronic address MUST be provided

So to ensure that it is always provided I moved the call to `setDocumentBuyerCommunication` out of an if clause and higher up to where related initial setup steps are done. This forces the `<ram:URIUniversalCommunication>` element to always be present, thus avoiding above warning.