### PR TITLE
E-invoicing: Fixes for acting validators

### DIFF
--- a/app/Http/Requests/EInvoice/Peppol/UpdateEntityRequest.php
+++ b/app/Http/Requests/EInvoice/Peppol/UpdateEntityRequest.php
@@ -52,4 +52,15 @@ class UpdateEntityRequest extends FormRequest
 
         $this->replace($input);
     }
+
+    public function after(): array
+    {
+        return [
+            function (Validator $validator) {
+                if ($this->input('acts_as_sender') === false && $this->input('acts_as_receiver') === false) {
+                    $validator->errors()->add('acts_as_receiver', ctrans('texts.acts_as_must_be_true'));
+                }
+            }
+        ];
+    }
 }

--- a/app/Http/Requests/EInvoice/Peppol/UpdateEntityRequest.php
+++ b/app/Http/Requests/EInvoice/Peppol/UpdateEntityRequest.php
@@ -16,6 +16,7 @@ use App\Models\Country;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class UpdateEntityRequest extends FormRequest
 {

--- a/lang/en/texts.php
+++ b/lang/en/texts.php
@@ -5470,6 +5470,7 @@ $lang = array(
     'notification_no_credits' => 'Warning! Your credit balance is empty.',
     'notification_no_credits_text' => 'Please add credits to your account to avoid interruption of services.',
     'saved_comment' => 'Comment Saved',
+    'acts_as_must_be_true' => 'Either "Send E-Invoice" or "Receive E-Invoice" (or both) must be selected.'
 );
 
 return $lang;


### PR DESCRIPTION
This adds minimum field validators for the e-invoicing based on Storecove error response:

```
acts_as_receiver or acts_as_sender or both must be true
```

Ref. https://github.com/invoiceninja/admin-module/pull/32
Ref. 2: https://github.com/invoiceninja/ui/pull/2204
