### PR TITLE
Fix inbound issues

### DIFF
--- a/app/Http/Controllers/MailgunController.php
+++ b/app/Http/Controllers/MailgunController.php
@@ -139,10 +139,13 @@ class MailgunController extends BaseController
         }
 
         // Spam protection
-        if (new InboundMailEngine()->isInvalidOrBlocked($input["sender"], $input["recipient"])) {
+        $inboundEngine = new InboundMailEngine();
+
+        if ($inboundEngine->isInvalidOrBlocked($input["sender"], $input["recipient"])) {
             return;
         }
 
+        // Dispatch Job for processing
         ProcessMailgunInboundWebhook::dispatch($input["sender"], $input["recipient"], $input["message-url"])->delay(rand(2, 10));
 
         return response()->json(['message' => 'Success.'], 200);

--- a/app/Http/Controllers/MailgunController.php
+++ b/app/Http/Controllers/MailgunController.php
@@ -138,9 +138,9 @@ class MailgunController extends BaseController
             return response()->json(['message' => 'Failed. Missing Parameters. Use store and notify!'], 400);
         }
 
-        // Spam protection
         $inboundEngine = new InboundMailEngine();
 
+        // Spam protection
         if ($inboundEngine->isInvalidOrBlocked($input["sender"], $input["recipient"])) {
             return;
         }

--- a/app/Http/Controllers/MailgunController.php
+++ b/app/Http/Controllers/MailgunController.php
@@ -11,6 +11,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Services\InboundMail\InboundMailEngine;
 use App\Utils\Ninja;
 use App\Models\Company;
 use App\Libraries\MultiDB;
@@ -137,14 +138,12 @@ class MailgunController extends BaseController
             return response()->json(['message' => 'Failed. Missing Parameters. Use store and notify!'], 400);
         }
 
-        /** @var \App\Models\Company $company */
-        $company = MultiDB::findAndSetDbByExpenseMailbox($input["recipient"]);
+        // Spam protection
+        if (new InboundMailEngine()->isInvalidOrBlocked($input["sender"], $input["recipient"])) {
+            return;
+        }
 
-        if (!$company) {
-            return response()->json(['message' => 'Ok'], 200);
-        }  // Fail gracefully
-
-        ProcessMailgunInboundWebhook::dispatch($input["sender"], $input["recipient"], $input["message-url"], $company)->delay(rand(2, 10));
+        ProcessMailgunInboundWebhook::dispatch($input["sender"], $input["recipient"], $input["message-url"])->delay(rand(2, 10));
 
         return response()->json(['message' => 'Success.'], 200);
     }

--- a/app/Jobs/Brevo/ProcessBrevoInboundWebhook.php
+++ b/app/Jobs/Brevo/ProcessBrevoInboundWebhook.php
@@ -115,6 +115,7 @@ class ProcessBrevoInboundWebhook implements ShouldQueue
      */
     public function __construct(private array $input)
     {
+        $this->engine = new InboundMailEngine();
     }
 
     /**
@@ -143,7 +144,7 @@ class ProcessBrevoInboundWebhook implements ShouldQueue
                 continue;
             }
 
-            $this->engine = new InboundMailEngine($company);
+            $this->engine->setCompany($company);
 
             $foundOneRecipient = true;
 
@@ -240,7 +241,7 @@ class ProcessBrevoInboundWebhook implements ShouldQueue
 
     public function failed($exception)
     {
-        nlog("BREVO:: Ingest Exception:: => ".$exception->getMessage());
+        nlog("BREVO:: Ingest Exception:: => " . $exception->getMessage());
         config(['queue.failed.driver' => null]);
     }
 


### PR DESCRIPTION
This PR fixes the following:
- fixes error while running brevo webhook (trying to access $engine property before initializing)
- enable inbound engine to perform stateless methods (no company), to allow checking for blocked recipients before hitting the db to get current company => better to avoid DOS when spam is incomming