### PR TITLE
Nordigen fixes

### DIFF
--- a/app/Helpers/Bank/Nordigen/Nordigen.php
+++ b/app/Helpers/Bank/Nordigen/Nordigen.php
@@ -61,13 +61,13 @@ class Nordigen
     }
 
     // requisition-section
-    public function createRequisition(string $redirect, string $initutionId, string $reference, string $userLanguage)
+    public function createRequisition(string $redirect, string $institutionId, string $reference, string $userLanguage)
     {
-        if ($this->test_mode && $initutionId != $this->sandbox_institutionId) {
+        if ($this->test_mode && $institutionId != $this->sandbox_institutionId) {
             throw new \Exception('invalid institutionId while in test-mode');
         }
 
-        return $this->client->requisition->createRequisition($redirect, $initutionId, null, $reference, $userLanguage);
+        return $this->client->requisition->createRequisition($redirect, $institutionId, null, $reference, $userLanguage);
     }
 
     public function getRequisition(string $requisitionId)

--- a/app/Http/Controllers/Bank/NordigenController.php
+++ b/app/Http/Controllers/Bank/NordigenController.php
@@ -218,7 +218,7 @@ class NordigenController extends BaseController
 
             $nordigen_account = $nordigen->getAccount($nordigenAccountId);
 
-            if (!$nordigen_account) {
+            if (isset($nordigen_account['error'])) {
                 continue;
             }
 

--- a/app/Http/Controllers/Bank/NordigenController.php
+++ b/app/Http/Controllers/Bank/NordigenController.php
@@ -252,8 +252,8 @@ class NordigenController extends BaseController
             } else {
 
                 // resetting metadata for account status
-                $existing_bank_integration->balance = $account['current_balance'];
-                $existing_bank_integration->bank_account_status = $account['account_status'];
+                $existing_bank_integration->balance = $nordigen_account['current_balance'];
+                $existing_bank_integration->bank_account_status = $nordigen_account['account_status'];
                 $existing_bank_integration->disabled_upstream = false;
                 $existing_bank_integration->auto_sync = true;
                 $existing_bank_integration->from_date = now()->subDays(90); // default max-fetch interval of nordigen is 90 days


### PR DESCRIPTION
Mostly minor fixes for the Nordigen controller/helper classes.

The controller patch on line 221 should fix #10396 where somebody hit a 500 error. Previously `getAccount()` could return `false`, but now it's always an array so the `continue` couldn't trip.
