### PR TITLE
fix: issue when email body is empty

### DIFF
--- a/app/Services/InboundMail/InboundMail.php
+++ b/app/Services/InboundMail/InboundMail.php
@@ -29,7 +29,7 @@ class InboundMail
 
     public ?UploadedFile $body_document = null;
 
-    public ?string $text_body;
+    public ?string $text_body = null;
 
     /** @var array $documents */
     public array $documents = [];

--- a/app/Services/InboundMail/InboundMail.php
+++ b/app/Services/InboundMail/InboundMail.php
@@ -29,7 +29,7 @@ class InboundMail
 
     public ?UploadedFile $body_document = null;
 
-    public string $text_body;
+    public ?string $text_body;
 
     /** @var array $documents */
     public array $documents = [];


### PR DESCRIPTION
some email providers like brevo send empty text_bodies when the user has not provided a text. in order to not fail the job, the parameter should be optional.