### PR TITLE
Integrate octane in preload.php

### DIFF
--- a/preload.php
+++ b/preload.php
@@ -56,7 +56,7 @@ class Preloader
 
         $count = self::$count;
 
-        echo "[Preloader] Preloaded {$count} classes" . PHP_EOL;
+        // echo "[Preloader] Preloaded {$count} classes" . PHP_EOL;
     }
 
     private function loadPath(string $path): void

--- a/preload.php
+++ b/preload.php
@@ -144,12 +144,12 @@ class Preloader
         __DIR__ . '/vendor/laravel/framework/src/Illuminate/Http/Testing',
         __DIR__ . '/vendor/laravel/framework/src/Illuminate/Testing',
         __DIR__ . '/vendor/laravel/framework/src/Illuminate/Foundation/Testing',
+        __DIR__ . '/vendor/laravel/octane/src/Testing',
     ])
     ->ignore(
-        \Illuminate\Filesystem\Cache::class,
-        \Illuminate\Log\LogManager::class,
-        \Illuminate\Http\Testing\File::class,
-        \Illuminate\Http\UploadedFile::class,
-        \Illuminate\Support\Carbon::class,
+        \Illuminate\Console\View\Components\Choice::class,
+        \Laravel\Octane\Tables\OpenSwooleTable::class,
+        \Laravel\Octane\Tables\SwooleTable::class,        
+        \Laravel\Octane\WorkerExceptionInspector::class,
     )
     ->load();

--- a/preload.php
+++ b/preload.php
@@ -147,6 +147,16 @@ class Preloader
         __DIR__ . '/vendor/laravel/octane/src/Testing',
     ])
     ->ignore(
+        ->ignore(
+        \Illuminate\Filesystem\Cache::class,
+        \Illuminate\Http\UploadedFile::class,
+        \Illuminate\Log\LogManager::class,       
+        \Illuminate\Support\Carbon::class,
+        \Illuminate\Console\View\Components\Choice::class,
+        \Laravel\Octane\Tables\OpenSwooleTable::class,
+        \Laravel\Octane\Tables\SwooleTable::class,        
+        \Laravel\Octane\WorkerExceptionInspector::class,
+    )
         \Illuminate\Console\View\Components\Choice::class,
         \Laravel\Octane\Tables\OpenSwooleTable::class,
         \Laravel\Octane\Tables\SwooleTable::class,        


### PR DESCRIPTION
- preload.php was missing octane and therefore was out of order

Open issue:
alpine, debian and octane fail to initialize the database, if opcache.preload is activated. 

Removed non-sense. Initialization works with https://github.com/invoiceninja/invoiceninja/pull/10517#issuecomment-2585497936


