### PR TITLE
exclude vendor folder from chmod

### DIFF
--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -59,6 +59,7 @@ jobs:
           rm -rf ui || true
           # Set permissions: directories 755, files 644
           chmod -R a=r,u+w,a+X .
+          chmod +x ./vendor/bin/*
 
       - name: Build project
         run: |

--- a/.github/workflows/react_release.yml
+++ b/.github/workflows/react_release.yml
@@ -58,8 +58,8 @@ jobs:
           rm .env || true
           rm -rf ui || true
           # Set permissions: directories 755, files 644
-          chmod -R a=r,u+w,a+X .
-          chmod +x ./vendor/bin/*
+          find . -path ./vendor -prune -type f -o -exec chmod 644 {} \+
+          find . -path ./vendor -prune -type d -o -exec chmod 755 {} \+
 
       - name: Build project
         run: |


### PR DESCRIPTION
After running composer install, files inside `./vendor/bin` are executable. The executable flag is removed with https://github.com/invoiceninja/invoiceninja/blob/99d2652f89b64c49be3aefe420500e652e50bbaf/.github/workflows/react_release.yml#L61, which sets permissions to the recommended values for a laravel application, but is to restrictive for the `vendor`

Related issue:
https://forum.invoiceninja.com/t/pdf-download-broken-after-an-update/21026/8