### PR TITLE
2025 05 01 verifactu soap service

### DIFF
--- a/app/Services/EDocument/Standards/Verifactu.php
+++ b/app/Services/EDocument/Standards/Verifactu.php
@@ -3,6 +3,7 @@
 namespace App\Services\EDocument\Standards;
 
 use App\Services\AbstractService;
+use App\Services\EDocument\Standards\Verifactu\InvoiceninjaToVerifactuMapper;
 use App\Services\EDocument\Standards\Verifactu\VerifactuClient;
 
 class Verifactu extends AbstractService
@@ -12,7 +13,10 @@ class Verifactu extends AbstractService
     {
 
         $client = new VerifactuClient(VerifactuClient::MODE_PROD);
-        $response = $client->sendRegistroFactura('<sum:RegFactuSistemaFacturacion xmlns:sum="https://...">...</sum:RegFactuSistemaFacturacion>');
+        $mapper = new InvoiceninjaToVerifactuMapper();
+        $invoice = null; //TODO fetch actual invoice
+        $regFacAlta = $mapper->mapRegistroFacturacionAlta($invoice);
+        $response = $client->sendRegistroAlta($regFacAlta);
         var_dump($response);
 
     }

--- a/app/Services/EDocument/Standards/Verifactu.php
+++ b/app/Services/EDocument/Standards/Verifactu.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\EDocument\Standards;
+
+use App\Services\AbstractService;
+use App\Services\EDocument\Standards\Verifactu\VerifactuClient;
+
+class Verifactu extends AbstractService
+{
+
+    public function run()
+    {
+
+        $client = new VerifactuClient(VerifactuClient::MODE_PROD);
+        $response = $client->sendRegistroFactura('<sum:RegFactuSistemaFacturacion xmlns:sum="https://...">...</sum:RegFactuSistemaFacturacion>');
+        var_dump($response);
+
+    }
+}

--- a/app/Services/EDocument/Standards/Verifactu/InvoiceninjaToVerifactuMapper.php
+++ b/app/Services/EDocument/Standards/Verifactu/InvoiceninjaToVerifactuMapper.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\EDocument\Standards\Verifactu;
+
+use App\Models\Invoice;
+use App\Services\EDocument\Standards\Verifactu\Types\Desglose;
+use App\Services\EDocument\Standards\Verifactu\Types\Destinatarios;
+use App\Services\EDocument\Standards\Verifactu\Types\Detalle;
+use App\Services\EDocument\Standards\Verifactu\Types\IDFacturaExpedida;
+use App\Services\EDocument\Standards\Verifactu\Types\PersonaFisicaJuridica;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAlta;
+use Carbon\Carbon;
+
+class InvoiceninjaToVerifactuMapper
+{
+    public function mapRegistroFacturacionAlta(Invoice $invoice): RegistroFacturacionAlta
+    {
+        $registroFacturacionAlta = new RegistroFacturacionAlta();
+
+        // Set version
+        $registroFacturacionAlta->setIDVersion('');
+
+        // Set invoice ID
+        $idFactura = new IDFacturaExpedida();
+        $idFactura->setIDEmisorFactura($invoice->company->vat_number);
+        $idFactura->setNumSerieFactura($invoice->number);
+        $idFactura->setFechaExpedicionFactura($invoice->date->format('d-m-Y'));
+        $registroFacturacionAlta->setIDFactura($idFactura);
+
+        // Set external reference
+        $registroFacturacionAlta->setRefExterna($invoice->number);
+
+        // Set issuer name
+        $registroFacturacionAlta->setNombreRazonEmisor($invoice->company->name);
+
+        // Set subsanacion and rechazo previo
+        $registroFacturacionAlta->setSubsanacion('Subsanacion::VALUE_N');
+        $registroFacturacionAlta->setRechazoPrevio('RechazoPrevio::VALUE_N');
+
+        // Set invoice type
+        $registroFacturacionAlta->setTipoFactura(ClaveTipoFactura::VALUE_F_1);
+
+        // Set operation date and description
+        $registroFacturacionAlta->setFechaOperacion($invoice->date->format('d-m-Y'));
+        $registroFacturacionAlta->setDescripcionOperacion($invoice->public_notes);
+
+        // Set recipients
+        $destinatarios = new Destinatarios();
+        $destinatario = new PersonaFisicaJuridica();
+        $destinatario->setNombreRazon($invoice->client->name);
+
+        if ($invoice->client->vat_number) {
+            $destinatario->setNIF($invoice->client->vat_number);
+        } else {
+            $idOtro = new IDOtro();
+            $idOtro->setID('07'); // No censado
+            $idOtro->setID($invoice->client->id_number);
+            $destinatario->setIDOtro($idOtro);
+        }
+
+        $destinatarios->addToIDDestinatario($destinatario);
+        $registroFacturacionAlta->setDestinatarios($destinatarios);
+
+        // Set breakdown
+        $desglose = new Desglose();
+        $detalle = new Detalle();
+        $detalle->setImpuesto(''); // IVA
+        $detalle->setTipoImpositivo($invoice->tax_rate);
+        $detalle->setBaseImponibleOimporteNoSujeto($invoice->amount);
+        $detalle->setCuotaRepercutida($invoice->tax_amount);
+        $desglose->addToDetalleDesglose($detalle);
+        $registroFacturacionAlta->setDesglose($desglose);
+
+        // Set total amounts
+        $registroFacturacionAlta->setCuotaTotal((string)$invoice->tax_amount);
+        $registroFacturacionAlta->setImporteTotal((string)$invoice->total);
+
+        // Set fingerprint type and value
+        $registroFacturacionAlta->setTipoHuella('');
+        $registroFacturacionAlta->setHuella(hash('sha256', $invoice->number));
+
+        // Set generation date
+        $registroFacturacionAlta->setFechaHoraHusoGenRegistro(Carbon::now()->format('Y-m-d\TH:i:s'));
+
+        return $registroFacturacionAlta;
+    }
+}

--- a/app/Services/EDocument/Standards/Verifactu/VerifactuClient.php
+++ b/app/Services/EDocument/Standards/Verifactu/VerifactuClient.php
@@ -13,6 +13,28 @@ use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAlta;
 use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAnulacion;
 use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionSubsanacion;
 use App\Services\EDocument\Standards\Verifactu\Types\Subsanacion;
+use App\Services\EDocument\Standards\Verifactu\Types\ImporteSgn14_2;
+use App\Services\EDocument\Standards\Verifactu\Types\Incidencia;
+use App\Services\EDocument\Standards\Verifactu\Types\ObligadoEmision;
+use App\Services\EDocument\Standards\Verifactu\Types\OperacionExenta;
+use App\Services\EDocument\Standards\Verifactu\Types\PersonaFisicaJuridica;
+use App\Services\EDocument\Standards\Verifactu\Types\PersonaFisicaJuridicaES;
+use App\Services\EDocument\Standards\Verifactu\Types\RechazoPrevio;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroAlta;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroAnterior;
+use App\Services\EDocument\Standards\Verifactu\Types\SistemaInformatico;
+use App\Services\EDocument\Standards\Verifactu\Types\Cabecera;
+use App\Services\EDocument\Standards\Verifactu\Types\Desglose;
+use App\Services\EDocument\Standards\Verifactu\Types\DesgloseRectificacion;
+use App\Services\EDocument\Standards\Verifactu\Types\Destinatarios;
+use App\Services\EDocument\Standards\Verifactu\Types\Detalle;
+use App\Services\EDocument\Standards\Verifactu\Types\DetalleDesglose;
+use App\Services\EDocument\Standards\Verifactu\Types\Encadenamiento;
+use App\Services\EDocument\Standards\Verifactu\Types\IDDestinatario;
+use App\Services\EDocument\Standards\Verifactu\Types\IDFactura;
+use App\Services\EDocument\Standards\Verifactu\Types\IDFacturaAR;
+use App\Services\EDocument\Standards\Verifactu\Types\IDFacturaExpedida;
+use App\Services\EDocument\Standards\Verifactu\Types\IDOtro;
 
 
 class VerifactuClient
@@ -56,12 +78,33 @@ class VerifactuClient
             'location'     => $endpoint,
             'soap_version' => SOAP_1_1,
             'classmap'     => [
+                'Cabecera'                       => Cabecera::class,
+                'Desglose'                       => Desglose::class,
+                'DesgloseRectificacion'          => DesgloseRectificacion::class,
+                'Destinatarios'                  => Destinatarios::class,
+                'Detalle'                        => Detalle::class,
+                'DetalleDesglose'                => DetalleDesglose::class,
+                'Encadenamiento'                 => Encadenamiento::class,
+                'IDDestinatario'                 => IDDestinatario::class,
+                'IDFactura'                      => IDFactura::class,
+                'IDFacturaAR'                    => IDFacturaAR::class,
+                'IDFacturaExpedida'              => IDFacturaExpedida::class,
+                'IDOtro'                         => IDOtro::class,
+                'ImporteSgn14_2'                 => ImporteSgn14_2::class,
+                'Incidencia'                     => Incidencia::class,
+                'ObligadoEmision'                => ObligadoEmision::class,
+                'OperacionExenta'                => OperacionExenta::class,
+                'PersonaFisicaJuridica'          => PersonaFisicaJuridica::class,
+                'PersonaFisicaJuridicaES'        => PersonaFisicaJuridicaES::class,
+                'RechazoPrevio'                  => RechazoPrevio::class,
                 'RegFactuSistemaFacturacion'     => RegFactuSistemaFacturacion::class,
+                'RegistroAlta'                   => RegistroAlta::class,
+                'RegistroAnterior'               => RegistroAnterior::class,
                 'RegistroFactura'                => RegistroFactura::class,
                 'RegistroFacturacionAlta'        => RegistroFacturacionAlta::class,
                 'RegistroFacturacionAnulacion'   => RegistroFacturacionAnulacion::class,
                 'RegistroFacturacionSubsanacion' => Subsanacion::class,
-                // Add additional types here as needed
+                'SistemaInformatico'             => SistemaInformatico::class,
             ],
         ];
 

--- a/app/Services/EDocument/Standards/Verifactu/VerifactuClient.php
+++ b/app/Services/EDocument/Standards/Verifactu/VerifactuClient.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * VerifactuClient.php
+ *
+ * SOAP client for sending invoices (facturas) to AEAT Verifactu service.
+ * Supports production and test endpoints via a mode switch.
+ */
+namespace App\Services\EDocument\Standards\Verifactu;
+
+use App\Services\EDocument\Standards\Verifactu\Types\RegFactuSistemaFacturacion;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroFactura;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAlta;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAnulacion;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionSubsanacion;
+use App\Services\EDocument\Standards\Verifactu\Types\Subsanacion;
+
+
+class VerifactuClient
+{
+    const MODE_PROD = 'prod';
+    const MODE_TEST = 'test';
+
+    /**
+     * @var array<string,string>
+     */
+    private static array $endpoints = [
+        self::MODE_PROD => 'https://www1.agenciatributaria.gob.es/wlpl/TIKE-CONT/ws/SistemaFacturacion/VerifactuSOAP',
+        self::MODE_TEST => 'https://prewww1.aeat.es/wlpl/TIKE-CONT/ws/SistemaFacturacion/VerifactuSOAP',
+    ];
+
+    private \SoapClient $client;
+    private string $mode;
+
+    /**
+     * @param string      $mode    One of VerifactuClient::MODE_PROD or MODE_TEST
+     * @param string|null $wsdl    Path to the WSDL file; defaults to xsd/SistemaFacturacion.wsdl
+     * @param array       $options Additional SoapClient options
+     *
+     * @throws \InvalidArgumentException
+     * @throws \SoapFault
+     */
+    public function __construct(string $mode = self::MODE_TEST, string $wsdl = null, array $options = [])
+    {
+        if (!isset(self::$endpoints[$mode])) {
+            throw new \InvalidArgumentException("Invalid mode '{$mode}', must be 'prod' or 'test'.");
+        }
+        $this->mode = $mode;
+        $endpoint    = self::$endpoints[$mode];
+        $wsdlPath    = $wsdl ?: __DIR__ . '/xsd/SistemaFacturacion.wsdl';
+
+        // Default SOAP client options with classmap for generated Types
+        $defaultOpts = [
+            'trace'        => true,
+            'exceptions'   => true,
+            'cache_wsdl'   => WSDL_CACHE_NONE,
+            'location'     => $endpoint,
+            'soap_version' => SOAP_1_1,
+            'classmap'     => [
+                'RegFactuSistemaFacturacion'     => RegFactuSistemaFacturacion::class,
+                'RegistroFactura'                => RegistroFactura::class,
+                'RegistroFacturacionAlta'        => RegistroFacturacionAlta::class,
+                'RegistroFacturacionAnulacion'   => RegistroFacturacionAnulacion::class,
+                'RegistroFacturacionSubsanacion' => Subsanacion::class,
+                // Add additional types here as needed
+            ],
+        ];
+
+        $opts = array_merge($defaultOpts, $options);
+
+        $this->client = new \SoapClient($wsdlPath, $opts);
+    }
+
+    /**
+     * Send an invoice registration (alta) request
+     *
+     * @param RegistroFacturacionAlta $registro
+     * @return mixed The SOAP response
+     * @throws \SoapFault
+     */
+    public function sendRegistroAlta(RegistroFacturacionAlta $registro)
+    {
+        $factura = new RegistroFactura();
+        $factura->setRegistroAlta($registro);
+
+        $wrapper = new RegFactuSistemaFacturacion();
+        $wrapper->addRegistroFactura($factura);
+
+        return $this->sendRegistroFactura($wrapper);
+    }
+
+    /**
+     * Send an invoice cancellation (anulación) request
+     *
+     * @param RegistroFacturacionAnulacion $registro
+     * @return mixed The SOAP response
+     * @throws \SoapFault
+     */
+    public function sendRegistroAnulacion(RegistroFacturacionAnulacion $registro)
+    {
+        $factura = new RegistroFactura();
+        $factura->setRegistroAnulacion($registro);
+
+        $wrapper = new RegFactuSistemaFacturacion();
+        $wrapper->addRegistroFactura($factura);
+
+        return $this->sendRegistroFactura($wrapper);
+    }
+
+    /**
+     * Low-level send: SoapClient marshals the object per classmap
+     *
+     * @param RegFactuSistemaFacturacion $wrapper
+     * @return mixed                     The SOAP response
+     * @throws \SoapFault
+     */
+    public function sendRegistroFactura(RegFactuSistemaFacturacion $wrapper)
+    {
+        return $this->client->__soapCall(
+            'RegFactuSistemaFacturacion',
+            ['RegFactuSistemaFacturacion' => $wrapper]
+        );
+    }
+
+
+    /**
+     * Get the last raw request XML
+     *
+     * @return string
+     */
+    public function getLastRequest(): string
+    {
+        return $this->client->__getLastRequest();
+    }
+
+    /**
+     * Get the last raw response XML
+     *
+     * @return string
+     */
+    public function getLastResponse(): string
+    {
+        return $this->client->__getLastResponse();
+    }
+}

--- a/app/Services/EDocument/Standards/Verifactu/VerifactuClient.php
+++ b/app/Services/EDocument/Standards/Verifactu/VerifactuClient.php
@@ -7,22 +7,8 @@
  */
 namespace App\Services\EDocument\Standards\Verifactu;
 
-use App\Services\EDocument\Standards\Verifactu\Types\RegFactuSistemaFacturacion;
-use App\Services\EDocument\Standards\Verifactu\Types\RegistroFactura;
-use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAlta;
-use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAnulacion;
-use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionSubsanacion;
-use App\Services\EDocument\Standards\Verifactu\Types\Subsanacion;
-use App\Services\EDocument\Standards\Verifactu\Types\ImporteSgn14_2;
-use App\Services\EDocument\Standards\Verifactu\Types\Incidencia;
-use App\Services\EDocument\Standards\Verifactu\Types\ObligadoEmision;
-use App\Services\EDocument\Standards\Verifactu\Types\OperacionExenta;
-use App\Services\EDocument\Standards\Verifactu\Types\PersonaFisicaJuridica;
-use App\Services\EDocument\Standards\Verifactu\Types\PersonaFisicaJuridicaES;
-use App\Services\EDocument\Standards\Verifactu\Types\RechazoPrevio;
-use App\Services\EDocument\Standards\Verifactu\Types\RegistroAlta;
-use App\Services\EDocument\Standards\Verifactu\Types\RegistroAnterior;
-use App\Services\EDocument\Standards\Verifactu\Types\SistemaInformatico;
+
+
 use App\Services\EDocument\Standards\Verifactu\Types\Cabecera;
 use App\Services\EDocument\Standards\Verifactu\Types\Desglose;
 use App\Services\EDocument\Standards\Verifactu\Types\DesgloseRectificacion;
@@ -35,7 +21,21 @@ use App\Services\EDocument\Standards\Verifactu\Types\IDFactura;
 use App\Services\EDocument\Standards\Verifactu\Types\IDFacturaAR;
 use App\Services\EDocument\Standards\Verifactu\Types\IDFacturaExpedida;
 use App\Services\EDocument\Standards\Verifactu\Types\IDOtro;
-
+use App\Services\EDocument\Standards\Verifactu\Types\ImporteSgn14_2;
+use App\Services\EDocument\Standards\Verifactu\Types\Incidencia;
+use App\Services\EDocument\Standards\Verifactu\Types\ObligadoEmision;
+use App\Services\EDocument\Standards\Verifactu\Types\OperacionExenta;
+use App\Services\EDocument\Standards\Verifactu\Types\PersonaFisicaJuridica;
+use App\Services\EDocument\Standards\Verifactu\Types\PersonaFisicaJuridicaES;
+use App\Services\EDocument\Standards\Verifactu\Types\RechazoPrevio;
+use App\Services\EDocument\Standards\Verifactu\Types\RegFactuSistemaFacturacion;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroAlta;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroAnterior;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroFactura;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAlta;
+use App\Services\EDocument\Standards\Verifactu\Types\RegistroFacturacionAnulacion;
+use App\Services\EDocument\Standards\Verifactu\Types\SistemaInformatico;
+use App\Services\EDocument\Standards\Verifactu\Types\Subsanacion;
 
 class VerifactuClient
 {
@@ -70,7 +70,7 @@ class VerifactuClient
         $endpoint    = self::$endpoints[$mode];
         $wsdlPath    = $wsdl ?: __DIR__ . '/xsd/SistemaFacturacion.wsdl';
 
-        // Default SOAP client options with classmap for generated Types
+        // Default SOAP client options with classmap for generated s
         $defaultOpts = [
             'trace'        => true,
             'exceptions'   => true,
@@ -126,7 +126,7 @@ class VerifactuClient
         $factura->setRegistroAlta($registro);
 
         $wrapper = new RegFactuSistemaFacturacion();
-        $wrapper->addRegistroFactura($factura);
+        $wrapper->addToRegistroFactura($factura);
 
         return $this->sendRegistroFactura($wrapper);
     }
@@ -144,7 +144,7 @@ class VerifactuClient
         $factura->setRegistroAnulacion($registro);
 
         $wrapper = new RegFactuSistemaFacturacion();
-        $wrapper->addRegistroFactura($factura);
+        $wrapper->addToRegistroFactura($factura);
 
         return $this->sendRegistroFactura($wrapper);
     }


### PR DESCRIPTION
So in the classes you generated there were loads of getters and setters missing.
I went ahead and regenereated the classes with https://github.com/WsdlToPhp/PackageGenerator
which seems to be the only wsdl to php generated that is maintained as far as I was able to find things.

used this command:
./wsdltophp-php7.phar generate:package  --urlorpath="invoiceninja/app/Services/EDocument/Standards/Verifactu/xsd/SistemaFacturacion.wsdl"   --destination="./output"   --composer-name="dummy/dummy" --namespace="App\\Services\\EDocument\\Standards\\Verifactu\\Types"  --force

and copied the classes from ./output over to their correct location.

We would need some additional dependencies to make this work, not sure how you stand on that.
For example https://github.com/WsdlToPhp/PackageBase would be needed for my generate to work. Also my IDE shows me some missing util classes.

Sadly there does not seem to be an option to alter the naming convention of the generator and it adds a Type postfix quite consistently which I am not very fond of, but in my experience its better to stick with the generate as closely as possible in case one needs to regenerate for a newer wsdl version.

Anyway the generator gave me way more classes than the previous generate and they seem to now have validation aswell as a complete set of getters and setters. (I noticed the missing ones when I tried implementing the mapper for the first time and then decided to regenerate).

If there was something I missed or a particular reason you didnt generate everything feel free to decline this and text me on slack again.

I added the VerifactuClient aswell as the Verifactu class with a general outline of how I imagine things to work together.
You can check this and we can take it from there.
This should work with a few changes with either generate.