### PR TITLE
Improvement: Invoicely import (payment dates)

### DIFF
--- a/app/Import/Transformer/Invoicely/InvoiceTransformer.php
+++ b/app/Import/Transformer/Invoicely/InvoiceTransformer.php
@@ -50,7 +50,7 @@ class InvoiceTransformer extends BaseTransformer
         if (strtolower($data['Status']) === 'paid') {
             $transformed['payments'] = [
                 [
-                    'date'   => date('Y-m-d'),
+                    'date'   => isset($data['Date']) ? $this->parseDate($data['Date']) : date('Y-m-d'),
                     'amount' => $amount,
                 ],
             ];


### PR DESCRIPTION
Hi there,

I have just installed InvoiceNinja for personal use. After completing data migration from Invoicely I found all payments were set to date of import. With 100s of paid invoices this resulted in way to many payment dates to correct through UI.  

A quick look at the code and there is a one line change for significant improvement, so I figured I would push this to pull request - and save others from having to deal with the same issue.

**The Problem**
When importing invoice data from Invoicely the import process will detect paid invoices and automatically add a payment record for the value of the invoice.  Unfortunately the date set on these payments is the _date of import_!

**The Improvement**
Instead of using the date of import payments should be set to date of invoice. 

**Not Ideal But Better**
Whilst assuming a payment date is not ideal, having payment dates that align with the invoice date maintains a useful report. In my case I was OK with leaving older invoices as `payment date` = `invoice date`, and only chose to manually update payments in the current financial year.


