### PR TITLE
Fix for issue #11072

### DIFF
--- a/app/PaymentDrivers/Mollie/CreditCard.php
+++ b/app/PaymentDrivers/Mollie/CreditCard.php
@@ -64,6 +64,7 @@ class CreditCard implements LivewireMethodInterface
                 $cgt = ClientGatewayToken::where('token', $request->token)->firstOrFail();
 
                 $payment = $this->mollie->gateway->payments->create([
+                    'method' => 'creditcard',
                     'amount' => [
                         'currency' => $this->mollie->client->currency()->code,
                         'value' => $amount,
@@ -107,6 +108,7 @@ class CreditCard implements LivewireMethodInterface
 
         try {
             $data = [
+                'method' => 'creditcard',
                 'amount' => [
                     'currency' => $this->mollie->client->currency()->code,
                     'value' => $amount,


### PR DESCRIPTION
This is the fix for this issue [#11072](https://github.com/invoiceninja/invoiceninja/issues/11072).

it lacks the "method" => "creditcard" parameter when an "Create Payment" POST API Request for Mollie gets done: 

see Mollie's [Create Payment API Docs](https://docs.mollie.com/reference/create-payment) (search for method  string | null)

`Normally, a payment method screen is shown ...  ... fully integrate the payment method selection into your website.` 