### PR TITLE
Add migration to update Blockonomics site URL

### DIFF
--- a/database/migrations/2025_07_20_044138_update_blockonomics_site_url.php
+++ b/database/migrations/2025_07_20_044138_update_blockonomics_site_url.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if($g = \App\Models\Gateway::find(65))
+        {
+            $g->site_url = 'https://help.blockonomics.co/solutions/articles/33000291849';
+            $g->save();
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
`https://help.blockonomics.co/a/solutions/articles/33000291849` -> `https://help.blockonomics.co/solutions/articles/33000291849`

the `/a/` is meant for agents, who write and maintain the article. This PR updates the URL to point the public article. 