### PR TITLE
Mollie: Make it possible for users to choose a payment method on the Mollie page

### DIFF
--- a/app/Models/Gateway.php
+++ b/app/Models/Gateway.php
@@ -138,6 +138,7 @@ class Gateway extends StaticModel
                     GatewayType::KBC => ['refund' => false, 'token_billing' => false, 'webhooks' => ['all']],
                     GatewayType::BANCONTACT => ['refund' => false, 'token_billing' => false, 'webhooks' => ['all']],
                     GatewayType::IDEAL => ['refund' => false, 'token_billing' => false, 'webhooks' => ['all']],
+                    GatewayType::HOSTED_PAGE => ['refund' => false, 'token_billing' => false, 'webhooks' => ['all']],
                 ];
             case 15:
                 return [

--- a/app/PaymentDrivers/Mollie/Aio.php
+++ b/app/PaymentDrivers/Mollie/Aio.php
@@ -1,0 +1,246 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2025. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\PaymentDrivers\Mollie;
+
+use App\Exceptions\PaymentFailed;
+use App\Http\Requests\ClientPortal\Payments\PaymentResponseRequest;
+use App\Jobs\Util\SystemLogger;
+use App\Models\GatewayType;
+use App\Models\Payment;
+use App\Models\PaymentType;
+use App\Models\SystemLog;
+use App\PaymentDrivers\Common\LivewireMethodInterface;
+use App\PaymentDrivers\Common\MethodInterface;
+use App\PaymentDrivers\MolliePaymentDriver;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+class Aio implements MethodInterface, LivewireMethodInterface
+{
+    protected MolliePaymentDriver $mollie;
+
+    public function __construct(MolliePaymentDriver $mollie)
+    {
+        $this->mollie = $mollie;
+
+        $this->mollie->init();
+    }
+
+    /**
+     * Show the authorization page for Mollie.
+     *
+     * @param array $data
+     * @return \Illuminate\View\View
+     */
+    public function authorizeView(array $data): View
+    {
+        return render('gateways.mollie.aio.authorize', $data);
+    }
+
+    /**
+     * Handle the authorization for Mollie.
+     *
+     * @param Request $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function authorizeResponse(Request $request): RedirectResponse
+    {
+        return redirect()->route('client.payment_methods.index');
+    }
+
+    /**
+     * Show the payment page for Mollie.
+     *
+     * @param array $data
+     * @return \Illuminate\Http\RedirectResponseor|RedirectResponse
+     */
+    public function paymentView(array $data)
+    {
+        $this->mollie->payment_hash
+            ->withData('gateway_type_id', GatewayType::HOSTED_PAGE)
+            ->withData('client_id', $this->mollie->client->id);
+
+        try {
+            $payment = $this->mollie->gateway->payments->create([
+                'amount' => [
+                    'currency' => $this->mollie->client->currency()->code,
+                    'value' => $this->mollie->convertToMollieAmount((float) $this->mollie->payment_hash->data->amount_with_fee),
+                ],
+                'description' => \sprintf('%s: %s', ctrans('texts.invoices'), \implode(', ', collect($data['invoices'])->pluck('invoice_number')->toArray())),
+                'redirectUrl' => route('client.payments.response', [
+                    'company_gateway_id' => $this->mollie->company_gateway->id,
+                    'payment_hash' => $this->mollie->payment_hash->hash,
+                    'payment_method_id' => GatewayType::HOSTED_PAGE,
+                ]),
+                'webhookUrl' => $this->mollie->company_gateway->webhookUrl(),
+                'metadata' => [
+                    'client_id' => $this->mollie->client->hashed_id,
+                    'hash' => $this->mollie->payment_hash->hash,
+                    'gateway_type_id' => GatewayType::HOSTED_PAGE,
+                    'payment_type_id' => PaymentType::HOSTED_PAGE,
+                ],
+            ]);
+
+            $this->mollie->payment_hash->withData('payment_id', $payment->id);
+
+            return redirect(
+                $payment->getCheckoutUrl()
+            );
+        } catch (\Mollie\Api\Exceptions\ApiException | \Exception $exception) {
+            return $this->processUnsuccessfulPayment($exception);
+        }
+    }
+
+    /**
+     * Handle unsuccessful payment.
+     *
+     * @param Exception $exception
+     * @throws PaymentFailed
+     * @return void
+     */
+    public function processUnsuccessfulPayment(\Exception $exception): void
+    {
+        $this->mollie->sendFailureMail($exception->getMessage());
+
+        SystemLogger::dispatch(
+            $exception->getMessage(),
+            SystemLog::CATEGORY_GATEWAY_RESPONSE,
+            SystemLog::EVENT_GATEWAY_FAILURE,
+            SystemLog::TYPE_MOLLIE,
+            $this->mollie->client,
+            $this->mollie->client->company,
+        );
+
+        throw new PaymentFailed($exception->getMessage(), $exception->getCode());
+    }
+
+    /**
+     * Handle the payments for the Mollie.
+     *
+     * @param PaymentResponseRequest $request
+     * @return mixed
+     */
+    public function paymentResponse(PaymentResponseRequest $request)
+    {
+        if (! \property_exists($this->mollie->payment_hash->data, 'payment_id')) {
+            return $this->processUnsuccessfulPayment(
+                new PaymentFailed('Whoops, something went wrong. Missing required [payment_id] parameter. Please contact administrator. Reference hash: '.$this->mollie->payment_hash->hash)
+            );
+        }
+
+        try {
+            $payment = $this->mollie->gateway->payments->get(
+                $this->mollie->payment_hash->data->payment_id
+            );
+
+            if ($payment->status === 'paid') {
+                return $this->processSuccessfulPayment($payment);
+            }
+
+            if ($payment->status === 'open') {
+                return $this->processOpenPayment($payment);
+            }
+
+            if ($payment->status === 'failed') {
+                return $this->processUnsuccessfulPayment(
+                    new PaymentFailed(ctrans('texts.status_failed'))
+                );
+            }
+
+            return $this->processUnsuccessfulPayment(
+                new PaymentFailed(ctrans('texts.status_voided'))
+            );
+        } catch (\Mollie\Api\Exceptions\ApiException | \Exception $exception) {
+            return $this->processUnsuccessfulPayment($exception);
+        }
+    }
+
+    /**
+     * Handle the successful payment for Mollie.
+     *
+     * @param string $status
+     * @param ResourcesPayment $payment
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function processSuccessfulPayment(\Mollie\Api\Resources\Payment $payment, string $status = 'paid'): RedirectResponse
+    {
+        $p = \App\Models\Payment::query()
+                    ->withTrashed()
+                    ->where('company_id', $this->mollie->client->company_id)
+                    ->where('transaction_reference', $payment->id)
+                    ->first();
+
+        if ($p) {
+            $p->status_id = Payment::STATUS_COMPLETED;
+            $p->save();
+
+            return redirect()->route('client.payments.show', ['payment' => $p->hashed_id]);
+        }
+
+        $data = [
+            'gateway_type_id' => GatewayType::HOSTED_PAGE,
+            'amount' => array_sum(array_column($this->mollie->payment_hash->invoices(), 'amount')) + $this->mollie->payment_hash->fee_total,
+            'payment_type' => PaymentType::HOSTED_PAGE,
+            'transaction_reference' => $payment->id,
+            'idempotency_key' => substr("{$payment->id}{$this->mollie->payment_hash->hash}", 0, 64)
+        ];
+
+        $payment_record = $this->mollie->createPayment(
+            $data,
+            $status === 'paid' ? Payment::STATUS_COMPLETED : Payment::STATUS_PENDING
+        );
+
+        SystemLogger::dispatch(
+            ['response' => $payment, 'data' => $data],
+            SystemLog::CATEGORY_GATEWAY_RESPONSE,
+            SystemLog::EVENT_GATEWAY_SUCCESS,
+            SystemLog::TYPE_MOLLIE,
+            $this->mollie->client,
+            $this->mollie->client->company,
+        );
+
+        return redirect()->route('client.payments.show', ['payment' => $payment_record->hashed_id]);
+    }
+
+    /**
+     * Handle 'open' payment status for Mollie.
+     *
+     * @param ResourcesPayment $payment
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function processOpenPayment(\Mollie\Api\Resources\Payment $payment): RedirectResponse
+    {
+        return $this->processSuccessfulPayment($payment, 'open');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function livewirePaymentView(array $data): string
+    {
+        // Doesn't support, it's offsite payment method.
+
+        return '';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function paymentData(array $data): array
+    {
+        $this->paymentView($data);
+
+        return $data;
+    }
+}

--- a/app/PaymentDrivers/MolliePaymentDriver.php
+++ b/app/PaymentDrivers/MolliePaymentDriver.php
@@ -29,6 +29,7 @@ use App\PaymentDrivers\Mollie\BankTransfer;
 use App\PaymentDrivers\Mollie\CreditCard;
 use App\PaymentDrivers\Mollie\IDEAL;
 use App\PaymentDrivers\Mollie\KBC;
+use App\PaymentDrivers\Mollie\Aio;
 use App\Utils\Traits\MakesHash;
 use Illuminate\Support\Facades\Validator;
 use Mollie\Api\Exceptions\ApiException;
@@ -72,6 +73,7 @@ class MolliePaymentDriver extends BaseDriver
         GatewayType::BANK_TRANSFER => BankTransfer::class,
         GatewayType::KBC => KBC::class,
         GatewayType::IDEAL => IDEAL::class,
+        GatewayType::HOSTED_PAGE => Aio::class,
     ];
 
     public const SYSTEM_LOG_TYPE = SystemLog::TYPE_MOLLIE;
@@ -96,6 +98,7 @@ class MolliePaymentDriver extends BaseDriver
         $types[] = GatewayType::BANK_TRANSFER;
         $types[] = GatewayType::KBC;
         $types[] = GatewayType::IDEAL;
+        $types[] = GatewayType::HOSTED_PAGE;
 
         return $types;
     }
@@ -357,13 +360,13 @@ class MolliePaymentDriver extends BaseDriver
 
             if ($record) {
                 if (in_array($payment->status, ['canceled', 'expired', 'failed'])) {
-                    
+
                     if(property_exists($payment->metadata, 'hash') && $payment->metadata->hash){
                         $payment_hash = PaymentHash::where('hash', $payment->metadata->hash)->first();
                         $this->handlePendingGatewayFeeRemoval($payment_hash);
                     }
 
-                    $record->service()->deletePayment(false); 
+                    $record->service()->deletePayment(false);
 
                 }
 

--- a/resources/views/portal/ninja2020/gateways/mollie/aio/authorize.blade.php
+++ b/resources/views/portal/ninja2020/gateways/mollie/aio/authorize.blade.php
@@ -1,0 +1,8 @@
+@extends('portal.ninja2020.layout.payments', ['gateway_title' => 'KBC/CBC', 'card_title' =>
+'KBC/CBC'])
+
+@section('gateway_content')
+    @component('portal.ninja2020.components.general.card-element-single')
+        {{ __('texts.payment_method_cannot_be_preauthorized') }}
+    @endcomponent
+@endsection

--- a/resources/views/portal/ninja2020/gateways/mollie/aio/authorize.blade.php
+++ b/resources/views/portal/ninja2020/gateways/mollie/aio/authorize.blade.php
@@ -1,5 +1,5 @@
-@extends('portal.ninja2020.layout.payments', ['gateway_title' => 'KBC/CBC', 'card_title' =>
-'KBC/CBC'])
+@extends('portal.ninja2020.layout.payments', ['gateway_title' => 'All-in-one checkout', 'card_title' =>
+'All-in-one checkout'])
 
 @section('gateway_content')
     @component('portal.ninja2020.components.general.card-element-single')


### PR DESCRIPTION
This adds a new "All-in-one" payment method for Mollie, where users choose their payment method at Mollie instead of entering details in Invoice Ninja.

This means that any payment method enabled in Mollie will be available.