### PR TITLE
Flutter OAuth Email support

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -181,7 +181,6 @@ class User extends Authenticatable implements MustVerifyEmail
     ];
 
     protected $casts = [
-        'oauth_user_token' => 'object',
         'settings'         => 'object',
         'updated_at'       => 'timestamp',
         'created_at'       => 'timestamp',


### PR DESCRIPTION
PR allows OAuth connecting email for M365 (and gmail?)~~, includes fixes for M365 mailer headers (no from/sender)~~

Closes #4501 