### PR TITLE
Add support for multiple Blockonomics' stores

### DIFF
--- a/app/PaymentDrivers/Blockonomics/Blockonomics.php
+++ b/app/PaymentDrivers/Blockonomics/Blockonomics.php
@@ -54,13 +54,13 @@ class Blockonomics implements LivewireMethodInterface
     public function getBTCAddress(): array
     {
         $api_key = $this->blockonomics->company_gateway->getConfigField('apiKey');
+        $company_key = $this->blockonomics->company_gateway->company->company_key;
 
         if (!$api_key) {
             return ['success' => false, 'message' => 'Please enter a valid API key'];
         }
 
-        $domain = request()->getHost();
-        $url = 'https://www.blockonomics.co/api/new_address?match_callback=' . $domain;
+        $url = 'https://www.blockonomics.co/api/new_address?match_callback=' . $company_key;
 
         $response = Http::withToken($api_key)
                         ->post($url, []);

--- a/app/PaymentDrivers/Blockonomics/Blockonomics.php
+++ b/app/PaymentDrivers/Blockonomics/Blockonomics.php
@@ -59,8 +59,8 @@ class Blockonomics implements LivewireMethodInterface
             return ['success' => false, 'message' => 'Please enter a valid API key'];
         }
 
-        // $params = config('ninja.environment') == 'development' ? '?reset=1' : '';
-        $url = 'https://www.blockonomics.co/api/new_address';
+        $domain = request()->getHost();
+        $url = 'https://www.blockonomics.co/api/new_address?match_callback=' . $domain;
 
         $response = Http::withToken($api_key)
                         ->post($url, []);


### PR DESCRIPTION
Even with multiple stores:
<img width="2013" height="382" alt="image" src="https://github.com/user-attachments/assets/26f0cff7-3122-46cc-aa69-060701456e6d" />

We are now able to correctly fetch an address for the correct store
<img width="1070" height="380" alt="image" src="https://github.com/user-attachments/assets/01016b69-0f25-4273-9062-29e8fbca014e" />
