### PR TITLE
Stripe webhook secret implimentation

### DIFF
--- a/app/PaymentDrivers/StripePaymentDriver.php
+++ b/app/PaymentDrivers/StripePaymentDriver.php
@@ -85,8 +85,6 @@ class StripePaymentDriver extends BaseDriver implements SupportsHeadlessInterfac
 
     public $stripe_connect_auth = [];
 
-    public $webhook_secret = "";
-
     public static $methods = [
         GatewayType::CREDIT_CARD => CreditCard::class,
         GatewayType::BANK_TRANSFER => ACH::class,
@@ -124,7 +122,6 @@ class StripePaymentDriver extends BaseDriver implements SupportsHeadlessInterfac
                 throw new StripeConnectFailure('Stripe Connect has not been configured');
             }
         } else {
-            $this->webhook_secret = $this->company_gateway->getConfigField('webhookSecret');
             
             $this->stripe = new StripeClient(
                 $this->company_gateway->getConfigField('apiKey')

--- a/app/PaymentDrivers/StripePaymentDriver.php
+++ b/app/PaymentDrivers/StripePaymentDriver.php
@@ -711,6 +711,7 @@ class StripePaymentDriver extends BaseDriver implements SupportsHeadlessInterfac
                 nlog("Stripe webhook signature verification failed: No signature header");
                 return response()->json(['error' => 'No signature header'], 403);
             }
+        }
             try {
                 \Stripe\Webhook::constructEvent(
                     $request->getContent(),

--- a/app/PaymentDrivers/StripePaymentDriver.php
+++ b/app/PaymentDrivers/StripePaymentDriver.php
@@ -133,7 +133,6 @@ class StripePaymentDriver extends BaseDriver implements SupportsHeadlessInterfac
             Stripe::setApiKey($this->company_gateway->getConfigField('apiKey'));
             Stripe::setAPiVersion('2023-10-16');
         }
-            $this->webhook_secret = $this->company_gateway->getConfigField('webhookSecret');
 
         return $this;
     }
@@ -717,12 +716,11 @@ class StripePaymentDriver extends BaseDriver implements SupportsHeadlessInterfac
                     $request->getContent(),
                     $sig_header,
                     $webhook_secret
-        };
+        );
         } catch (\Stripe\Exception\SignatureVerificationException $e) {
             nlog("Stripe webhook signature verification failed: " . $e->getMessage());
             return response()->json(['error' => 'Invalid signature'], 403);
         }
-    }
         
         if ($request->type === 'customer.source.updated') {
             $ach = new ACH($this);

--- a/app/PaymentDrivers/StripePaymentDriver.php
+++ b/app/PaymentDrivers/StripePaymentDriver.php
@@ -711,16 +711,16 @@ class StripePaymentDriver extends BaseDriver implements SupportsHeadlessInterfac
                 nlog("Stripe webhook signature verification failed: No signature header");
                 return response()->json(['error' => 'No signature header'], 403);
             }
-        }
             try {
                 \Stripe\Webhook::constructEvent(
                     $request->getContent(),
                     $sig_header,
                     $webhook_secret
-        );
-        } catch (\Stripe\Exception\SignatureVerificationException $e) {
-            nlog("Stripe webhook signature verification failed: " . $e->getMessage());
-            return response()->json(['error' => 'Invalid signature'], 403);
+                );
+            } catch (\Stripe\Exception\SignatureVerificationException $e) {
+                nlog("Stripe webhook signature verification failed: " . $e->getMessage());
+                return response()->json(['error' => 'Invalid signature'], 403);
+            }
         }
         
         if ($request->type === 'customer.source.updated') {

--- a/app/PaymentDrivers/StripePaymentDriver.php
+++ b/app/PaymentDrivers/StripePaymentDriver.php
@@ -717,8 +717,13 @@ class StripePaymentDriver extends BaseDriver implements SupportsHeadlessInterfac
                     $request->getContent(),
                     $sig_header,
                     $webhook_secret
+        };
+        } catch (\Stripe\Exception\SignatureVerificationException $e) {
+            nlog("Stripe webhook signature verification failed: " . $e->getMessage());
+            return response()->json(['error' => 'Invalid signature'], 403);
         }
-
+    }
+        
         if ($request->type === 'customer.source.updated') {
             $ach = new ACH($this);
             $ach->updateBankAccount($request->all());

--- a/app/PaymentDrivers/StripePaymentDriver.php
+++ b/app/PaymentDrivers/StripePaymentDriver.php
@@ -702,6 +702,15 @@ class StripePaymentDriver extends BaseDriver implements SupportsHeadlessInterfac
 
     public function processWebhookRequest(PaymentWebhookRequest $request)
     {
+            // Initialize to load webhook_secret and other config
+        try {
+            $this->init();
+        } catch (\Exception $e) {
+            nlog("Stripe webhook init failed: " . $e->getMessage());
+            // Continue without webhook secret verification if init fails
+        }
+
+
           // Validate webhook signature if webhook_secret is configured
         if ($this->webhook_secret) {
             $sig_header = $_SERVER["HTTP_STRIPE_SIGNATURE"] ?? $request->header('Stripe-Signature');

--- a/database/seeders/PaymentLibrariesSeeder.php
+++ b/database/seeders/PaymentLibrariesSeeder.php
@@ -47,7 +47,7 @@ class PaymentLibrariesSeeder extends Seeder
             ['id' => 17, 'name' => 'Pin', 'provider' => 'Pin', 'key' => '0749cb92a6b36c88bd9ff8aabd2efcab', 'fields' => '{"secretKey":"","testMode":false}'],
             ['id' => 18, 'name' => 'SagePay Direct', 'provider' => 'SagePay_Direct', 'key' => '4c8f4e5d0f353a122045eb9a60cc0f2d', 'fields' => '{"vendor":"","testMode":false,"referrerId":""}'],
             ['id' => 19, 'name' => 'SecurePay DirectPost', 'provider' => 'SecurePay_DirectPost', 'key' => '8036a5aadb2bdaafb23502da8790b6a2', 'fields' => '{"merchantId":"","transactionPassword":"","testMode":false,"enable_ach":"","enable_sofort":"","enable_apple_pay":"","enable_alipay":""}'],
-            ['id' => 20, 'name' => 'Stripe', 'provider' => 'Stripe', 'sort_order' => 1, 'key' => 'd14dd26a37cecc30fdd65700bfb55b23', 'fields' => '{"publishableKey":"","apiKey":"","appleDomainVerification":""}'],
+            ['id' => 20, 'name' => 'Stripe', 'provider' => 'Stripe', 'sort_order' => 1, 'key' => 'd14dd26a37cecc30fdd65700bfb55b23', 'fields' => '{"publishableKey":"","apiKey":"","webhookSecret":"","appleDomainVerification":""}'],
             ['id' => 21, 'name' => 'TargetPay Direct eBanking', 'provider' => 'TargetPay_Directebanking', 'key' => 'd14dd26a37cdcc30fdd65700bfb55b23', 'fields' => '{"subAccountId":""}'],
             ['id' => 22, 'name' => 'TargetPay Ideal', 'provider' => 'TargetPay_Ideal', 'key' => 'ea3b328bd72d381387281c3bd83bd97c', 'fields' => '{"subAccountId":""}'],
             ['id' => 23, 'name' => 'TargetPay Mr Cash', 'provider' => 'TargetPay_Mrcash', 'key' => 'a0035fc0d87c4950fb82c73e2fcb825a', 'fields' => '{"subAccountId":""}'],


### PR DESCRIPTION
Summary

This PR adds optional Stripe Webhook signature verification to ensure improved security and full compatibility with existing Invoice Ninja installations.

Background

Stripe recommends verifying the Webhook Signing Secret for all webhook events.
However, many existing Invoice Ninja installations do not have this configured, and enabling verification without backward compatibility would immediately break webhook processing.

What This PR Does

Adds Stripe webhook signature verification

Fully backward compatible with all current systems

Verification occurs only if a Webhook Secret is defined in the admin portal

If the field is left blank, the webhook will be processed without verification (current behavior preserved)

Implementation Logic

Admin UI allows the Webhook Secret to remain empty

When empty → skip verification

When populated → verify using Stripe’s recommended signature method

Why This is Needed

Stripe explicitly recommends validating webhook signatures for security and fraud prevention.
This implementation brings Invoice Ninja closer to Stripe best practice while ensuring existing installations do not break.

Important Note for Administrators

When adding a new Stripe payment gateway, you must:

Leave the “Webhook Secret” field blank when creating the gateway

Save and retrieve the generated webhook URL

Add this URL in the Stripe Dashboard and generate the Webhook Secret

Return to Invoice Ninja and paste the Webhook Secret into the gateway settings

This is required because Stripe does not provide the webhook secret until after their endpoint is created.