### PR TITLE
Only apply credit numbering for Peppol if the invoice amount is negative.

### DIFF
--- a/app/Services/Invoice/ApplyNumber.php
+++ b/app/Services/Invoice/ApplyNumber.php
@@ -74,14 +74,14 @@ class ApplyNumber extends AbstractService
 
         do {
             try {
-                
-                if($peppol_enabled && strlen(trim($this->client->getSetting('credit_number_pattern'))) > 0) {
+
+                if($peppol_enabled && strlen(trim($this->client->getSetting('credit_number_pattern'))) > 0 && $this->invoice->amount < 0) {
                     $this->invoice->number = $this->getPeppolCreditNumber($this->client, $this->invoice);
                 }
                 else {
                     $this->invoice->number = $this->getNextInvoiceNumber($this->client, $this->invoice, $this->invoice->recurring_id);
                 }
-                
+
                 $this->invoice->saveQuietly();
 
                 $this->completed = false;


### PR DESCRIPTION
Only apply credit numbering for Peppol if the invoice amount is negative.
This should fix invoice numbering.