### PR TITLE
Throttle failed responses for routes using invitation keys

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -165,7 +165,8 @@ class Kernel extends HttpKernel
         'document_db' => SetDocumentDb::class,
         'session_domain' => SessionDomains::class,
         'valid_json' => \App\Http\Middleware\ValidJson::class,
-        //we dyanamically add the throttle middleware in RouteServiceProvider
+        'throttle.failed_response' => \App\Http\Middleware\ThrottleFailedResponse::class,
+        // Throttle middleware is inserted in RouteServiceProvider
     ];
 
     protected $middlewarePriority = [

--- a/app/Http/Middleware/ThrottleFailedResponse.php
+++ b/app/Http/Middleware/ThrottleFailedResponse.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2025. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
+use Symfony\Component\HttpFoundation\Response;
+
+class ThrottleFailedResponse
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  int  $maxAttempts
+     * @param  int  $decayMinutes
+     * @return mixed
+     * @todo When using laravel v12, this middleware can be removed and
+     * replaced with the following throttler code in RouteServiceProvider.php:
+     * ```
+     * // Rate limiter for failed responses to prevent brute force attacks
+     * // Allows 3 failed attempts per hour
+     * RateLimiter::for('failed_response', function (Request $request) {
+     * return Limit::perHour(3)
+     * ->by($request->ip())
+     * ->response(function () {
+     * return response()->json([
+     * 'message' => 'Too many failed attempts. Please try again later.'
+     * ], 429);
+     * })
+     * ->after(function (\Symfony\Component\HttpFoundation\Response $response) {
+     * // Only count failed responses
+     * return $response->getStatusCode() >= 400;
+     * });
+     * });
+     * ```
+     */
+    public function handle(Request $request, Closure $next, $maxAttempts = 3, $decayMinutes = 60)
+    {
+        $key = 'failed_response:' . $request->ip() . '|' . $request->path();
+
+        // If we've already hit the rate limit, block the request
+        if (RateLimiter::tooManyAttempts($key, $maxAttempts)) {
+            return response()->json([
+                'message' => 'Too many failed attempts. Please try again later.'
+            ], 429);
+        }
+
+        // Handle the request
+        $response = $next($request);
+
+        // Only count the attempt if the response status is 400 or higher
+        if ($response->status() >= 400) {
+            RateLimiter::hit($key, $decayMinutes * 60);
+        }
+
+        return $response;
+    }
+}

--- a/routes/client.php
+++ b/routes/client.php
@@ -57,7 +57,7 @@ Route::group(['middleware' => ['auth:contact', 'locale', 'domain_db','check_clie
     Route::get('invoices/payment', [App\Http\Controllers\ClientPortal\InvoiceController::class, 'catch_bulk'])->name('invoices.catch_bulk');
     Route::post('invoices/download', [App\Http\Controllers\ClientPortal\InvoiceController::class, 'download'])->name('invoices.download');
     Route::get('invoices/{invoice}/{hash?}', [App\Http\Controllers\ClientPortal\InvoiceController::class, 'show'])->name('invoice.show');
-    Route::get('invoices/{invoice_invitation}', [App\Http\Controllers\ClientPortal\InvoiceController::class, 'show'])->name('invoice.show_invitation');
+    Route::get('invoices/{invoice_invitation}', [App\Http\Controllers\ClientPortal\InvoiceController::class, 'show'])->name('invoice.show_invitation')->middleware('throttle.failed_response');
 
     Route::get('recurring_invoices', [App\Http\Controllers\ClientPortal\RecurringInvoiceController::class, 'index'])->name('recurring_invoices.index')->middleware('portal_enabled');
     Route::get('recurring_invoices/{recurring_invoice}', [App\Http\Controllers\ClientPortal\RecurringInvoiceController::class, 'show'])->name('recurring_invoice.show');
@@ -88,13 +88,13 @@ Route::group(['middleware' => ['auth:contact', 'locale', 'domain_db','check_clie
     Route::match(['GET', 'POST'], 'quotes/approve', [App\Http\Controllers\ClientPortal\QuoteController::class, 'bulk'])->name('quotes.bulk');
     Route::get('quotes', [App\Http\Controllers\ClientPortal\QuoteController::class, 'index'])->name('quotes.index')->middleware('portal_enabled');
     Route::get('quotes/{quote}', [App\Http\Controllers\ClientPortal\QuoteController::class, 'show'])->name('quote.show');
-    Route::get('quotes/{quote_invitation}', [App\Http\Controllers\ClientPortal\QuoteController::class, 'show'])->name('quote.show_invitation');
+    Route::get('quotes/{quote_invitation}', [App\Http\Controllers\ClientPortal\QuoteController::class, 'show'])->name('quote.show_invitation')->middleware('throttle.failed_response');
     Route::post('quotes/download', [App\Http\Controllers\ClientPortal\QuoteController::class, 'download'])->name('quotes.download');
 
     Route::get('credits', [App\Http\Controllers\ClientPortal\CreditController::class, 'index'])->name('credits.index');
     Route::get('credits/{credit}', [App\Http\Controllers\ClientPortal\CreditController::class, 'show'])->name('credit.show');
 
-    Route::get('credits/{credit_invitation}', [App\Http\Controllers\ClientPortal\CreditController::class,'show'])->name('credits.show_invitation');
+    Route::get('credits/{credit_invitation}', [App\Http\Controllers\ClientPortal\CreditController::class,'show'])->name('credits.show_invitation')->middleware('throttle.failed_response');
 
     Route::get('client/switch_company/{contact}', App\Http\Controllers\ClientPortal\SwitchCompanyController::class)->name('switch_company');
 
@@ -123,7 +123,7 @@ Route::get('client/subscriptions/{subscription}/purchase', [App\Http\Controllers
 Route::get('client/subscriptions/{subscription}/purchase/v2', [App\Http\Controllers\ClientPortal\SubscriptionPurchaseController::class, 'upgrade'])->name('client.subscription.upgrade')->middleware('domain_db');
 Route::get('client/subscriptions/{subscription}/purchase/v3', [App\Http\Controllers\ClientPortal\SubscriptionPurchaseController::class, 'v3'])->name('client.subscription.v3')->middleware('domain_db');
 
-Route::group(['middleware' => ['invite_db'], 'prefix' => 'client', 'as' => 'client.'], function () {
+Route::group(['middleware' => ['invite_db','throttle.failed_response'], 'prefix' => 'client', 'as' => 'client.'], function () {
     /*Invitation catches*/
     Route::get('recurring_invoice/{invitation_key}', [App\Http\Controllers\ClientPortal\InvitationController::class, 'recurringRouter']);
     Route::get('invoice/{invitation_key}', [App\Http\Controllers\ClientPortal\InvitationController::class, 'invoiceRouter']);


### PR DESCRIPTION
Throttle failed responses for routes using invitation keys to prevent bruteforce attacks.

I've added a piece of code to the `@todo` comment for the preferred way in laravel v12. Laravel v12 supports `->after()` so it can be created as throttler in RouteServiceProvider.php instead of a separate middleware. In Laravel v11 however, this is not yet possible.