### PR TITLE
PEPPOL-EN16931-R053 only allows one TaxTotal

### DIFF
--- a/app/Services/EDocument/Standards/Peppol.php
+++ b/app/Services/EDocument/Standards/Peppol.php
@@ -1507,9 +1507,9 @@ class Peppol extends AbstractService
             $tax_subtotal->TaxCategory = $this->globalTaxCategories[0];
 
             $tax_total->TaxSubtotal[] = $tax_subtotal;
-
-            $this->p_invoice->TaxTotal[] = $tax_total;
         }
+
+        $this->p_invoice->TaxTotal[] = $tax_total;
 
         return $this;
     }


### PR DESCRIPTION
When using multiple tax percentages, the XML creates multiple TaxTotal fields, which results in failing XML files.