### PR TITLE
Fix paymentlink `price` and `promo_price` when using inclusive taxes

### DIFF
--- a/app/Repositories/SubscriptionRepository.php
+++ b/app/Repositories/SubscriptionRepository.php
@@ -69,6 +69,7 @@ class SubscriptionRepository extends BaseRepository
 
         $invoice = InvoiceFactory::create($subscription->company_id, $subscription->user_id);
         $invoice->client_id = $client->id;
+        $invoice->uses_inclusive_taxes = $client->getSetting('inclusive_taxes');
 
         $invoice->save();
 

--- a/app/Services/Subscription/SubscriptionCalculator.php
+++ b/app/Services/Subscription/SubscriptionCalculator.php
@@ -49,6 +49,7 @@ class SubscriptionCalculator
         $invoice->is_proforma = true;
         $invoice->number = "####" . ctrans('texts.subscription') . "_" . now()->format('Y-m-d') . "_" . rand(0, 100000);
         $invoice->line_items = $this->buildItems($context);
+        $invoice->uses_inclusive_taxes = $this->subscription->company->getSetting('inclusive_taxes');
 
         if (isset($context['valid_coupon']) && $context['valid_coupon']) {
             $invoice->discount = $this->subscription->promo_discount;


### PR DESCRIPTION
Code currently always calculates price and promo_price assuming exclusive taxes (ignoring the inclusive_taxes setting).