### PR TITLE
Use `between` rule for `frequency_id` validation, instead of `digits_between`

### DIFF
--- a/app/Http/Requests/RecurringExpense/StoreRecurringExpenseRequest.php
+++ b/app/Http/Requests/RecurringExpense/StoreRecurringExpenseRequest.php
@@ -51,7 +51,7 @@ class StoreRecurringExpenseRequest extends Request
         }
 
         $rules['category_id'] = 'bail|nullable|sometimes|exists:expense_categories,id,company_id,' . $user->company()->id . ',is_deleted,0';
-        $rules['frequency_id'] = 'required|integer|digits_between:1,12';
+        $rules['frequency_id'] = 'required|integer|between:1,12';
         $rules['tax_amount1'] = 'numeric';
         $rules['tax_amount2'] = 'numeric';
         $rules['tax_amount3'] = 'numeric';

--- a/app/Http/Requests/RecurringInvoice/StoreRecurringInvoiceRequest.php
+++ b/app/Http/Requests/RecurringInvoice/StoreRecurringInvoiceRequest.php
@@ -56,7 +56,7 @@ class StoreRecurringInvoiceRequest extends Request
         $rules['invitations'] = 'sometimes|bail|array';
         $rules['invitations.*.client_contact_id'] = 'bail|required|distinct';
 
-        $rules['frequency_id'] = 'required|integer|digits_between:1,12';
+        $rules['frequency_id'] = 'required|integer|between:1,12';
 
         $rules['project_id'] = ['bail', 'sometimes', new ValidProjectForClient($this->all())];
 

--- a/app/Http/Requests/RecurringQuote/StoreRecurringQuoteRequest.php
+++ b/app/Http/Requests/RecurringQuote/StoreRecurringQuoteRequest.php
@@ -52,7 +52,7 @@ class StoreRecurringQuoteRequest extends Request
 
         $rules['invitations.*.client_contact_id'] = 'distinct';
 
-        $rules['frequency_id'] = 'required|integer|digits_between:1,12';
+        $rules['frequency_id'] = 'required|integer|between:1,12';
         $rules['number'] = ['bail', 'nullable', \Illuminate\Validation\Rule::unique('recurring_quotes')->where('company_id', $user->company()->id)];
 
         return $rules;

--- a/app/Http/Requests/TaskScheduler/StoreSchedulerRequest.php
+++ b/app/Http/Requests/TaskScheduler/StoreSchedulerRequest.php
@@ -79,7 +79,7 @@ class StoreSchedulerRequest extends Request
         $rules = [
             'name' => 'bail|sometimes|nullable|string',
             'is_paused' => 'bail|sometimes|boolean',
-            'frequency_id' => 'bail|sometimes|integer|digits_between:1,12',
+            'frequency_id' => 'bail|sometimes|integer|between:1,12',
             'next_run' => 'bail|required|date:Y-m-d|after_or_equal:today',
             'next_run_client' => 'bail|sometimes|date:Y-m-d',
             'template' => 'bail|required|string',

--- a/app/Http/Requests/TaskScheduler/UpdateSchedulerRequest.php
+++ b/app/Http/Requests/TaskScheduler/UpdateSchedulerRequest.php
@@ -76,7 +76,7 @@ class UpdateSchedulerRequest extends Request
         $rules = [
             'name' => 'bail|sometimes|nullable|string',
             'is_paused' => 'bail|sometimes|boolean',
-            'frequency_id' => 'bail|sometimes|integer|digits_between:1,12',
+            'frequency_id' => 'bail|sometimes|integer|between:1,12',
             'next_run' => 'bail|required|date:Y-m-d|after_or_equal:today',
             'next_run_client' => 'bail|sometimes|date:Y-m-d',
             'template' => 'bail|required|string',


### PR DESCRIPTION
Use `between` rule for `frequency_id` validation, instead of `digits_between` since the values of the frequency constants are between 0-13 (exclusive) and we don't want to check the amount of digits, but the actual integer value given.