### PR TITLE
Fix SEPA payments blocked by Stripe Radar due to missing billing country

### DIFF
--- a/resources/js/clients/payments/stripe-sepa.js
+++ b/resources/js/clients/payments/stripe-sepa.js
@@ -112,7 +112,7 @@ class ProcessSEPA {
 
                 this.stripe
                     .confirmSepaDebitPayment(
-                        document.querySelector('meta[name=pi-client-secret')
+                        document.querySelector('meta[name="pi-client-secret"]')
                             .content,
                         {
                             payment_method:
@@ -169,7 +169,7 @@ class ProcessSEPA {
 
                 this.stripe
                     .confirmSepaDebitPayment(
-                        document.querySelector('meta[name=pi-client-secret')
+                        document.querySelector('meta[name="pi-client-secret"]')
                             .content,
                         {
                             payment_method: {
@@ -180,6 +180,11 @@ class ProcessSEPA {
                                     email: document.getElementById(
                                         'sepa-email-address'
                                     ).value,
+                                    address: {
+                                        country: document.querySelector(
+                                            'meta[name="country"]'
+                                        ).content,
+                                    },
                                 },
                             },
                         }


### PR DESCRIPTION
## Problem

SEPA Direct Debit payments are flagged with `risk_level: "elevated"` by Stripe Radar because `billing_details.address.country` is not provided when creating the PaymentMethod via `confirmSepaDebitPayment`.

The Stripe charge object shows the result:

```json
"billing_details": {
  "address": { "country": null }
},
"outcome": {
  "risk_level": "elevated"
}
```

Stripe extracts the country from the IBAN itself (`payment_method_details.sepa_debit.country: "DE"`), but Radar evaluates risk based on `billing_details.address.country`, which is `null`. This causes legitimate payments to be blocked or held for review.

## Root cause

In `resources/js/clients/payments/stripe-sepa.js`, the `confirmSepaDebitPayment` call for new bank accounts passes `billing_details` with `name` and `email`, but no `address.country`. The country value is already available on the page in `<meta name="country">` (populated server-side from `$client->country->iso_3166_2` in `app/PaymentDrivers/Stripe/SEPA.php`) — it just was never wired into the Stripe API call.

Note: the server-side code in `SEPA.php` has a commented-out block (added in commit 59bcd30) with a TODO about injecting billing details — this confirms the gap was known but not yet addressed on the client side.

## Fix

- Add `address: { country }` to `billing_details` in the `confirmSepaDebitPayment` call for new bank accounts, reading the value from the existing `<meta name="country">` tag
- Fix two malformed `querySelector` selectors for `pi-client-secret` that were missing the closing `]` bracket (e.g. `meta[name=pi-client-secret` → `meta[name="pi-client-secret"]`)

Only the source file is modified. Built assets (`public/js/`, `public/build/assets/`) need to be regenerated.

## Testing

1. Initiate a SEPA Direct Debit payment with a new bank account (not a saved token)
2. Verify in Stripe Dashboard that the resulting charge has `billing_details.address.country` populated (e.g. `"DE"`)
3. Verify `outcome.risk_level` is no longer `"elevated"` for otherwise clean payments
4. Verify paying with a saved SEPA token still works (that path is unchanged)