### PR TITLE
Improve Nordigen transaction description handling

### DIFF
--- a/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
@@ -107,12 +107,17 @@ class TransactionTransformer implements BankRevenueInterface
         $amount = (float) $transaction["transactionAmount"]["amount"];
         $base_type = $amount < 0 ? 'DEBIT' : 'CREDIT';
 
-        // description could be in varios places
+        // description could be in various places
         $description = '';
         if (array_key_exists('remittanceInformationStructured', $transaction)) {
             $description = $transaction["remittanceInformationStructured"];
         } elseif (array_key_exists('remittanceInformationStructuredArray', $transaction)) {
-            $description = implode('\n', $transaction["remittanceInformationStructuredArray"]);
+            $remittanceInformationStructuredArray = $transaction["remittanceInformationStructuredArray"];
+            if (array_key_exists('rawTransactionDescription', $remittanceInformationStructuredArray)) {
+                $description = $remittanceInformationStructuredArray["rawTransactionDescription"];
+            } else {
+                $description = implode('\n', $transaction["remittanceInformationStructuredArray"]);
+            }
         } elseif (array_key_exists('remittanceInformationUnstructured', $transaction)) {
             $description = $transaction["remittanceInformationUnstructured"];
         } elseif (array_key_exists('remittanceInformationUnstructuredArray', $transaction)) {


### PR DESCRIPTION
If 'rawTransactionDescription' exists in remittanceInformationStructuredArray, use it, otherwise implode.

Prevents descriptions appearing as "declined: False rawTransactionDescription: Payment"