### PR TITLE
Fix client portal switcher showing company name instead of client name

### DIFF
--- a/resources/views/portal/ninja2020/components/general/sidebar/header.blade.php
+++ b/resources/views/portal/ninja2020/components/general/sidebar/header.blade.php
@@ -12,7 +12,7 @@
                 <div>
                     <span class="rounded shadow-sm">
                         <button x-on:click="open = !open" x-on:click.outside="open = false" type="button" class="inline-flex justify-center w-full rounded-md border border-gray-300 px-4 py-2 bg-white text-sm leading-5 font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:ring-blue active:bg-gray-50 active:text-gray-800 transition ease-in-out duration-150">
-                            <span class="hidden md:block mr-1">{{ auth()->guard('contact')->user()->company->present()->name }}</span>
+                            <span class="hidden md:block mr-1">{{ auth()->guard('contact')->user()->client->present()->name() }}</span>
                             <svg class="md:-mr-1 md:ml-2 h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
                                 <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
                             </svg>


### PR DESCRIPTION
## Summary
- The client/company switcher dropdown in the client portal header always displayed the company name regardless of which client was selected
- Changed `company->present()->name` to `client->present()->name()` to show the currently active client name
- This is consistent with the dropdown menu items that already display client names

## Steps to reproduce
1. Create a contact that is associated with multiple clients
2. Log in to the client portal as that contact
3. The header dropdown always shows the company name instead of the selected client name
4. Switching clients updates the dashboard data but the dropdown label stays as company name

## Fix
One-line change in `resources/views/portal/ninja2020/components/general/sidebar/header.blade.php` line 15