### PR TITLE
Fix ERROR_EMAIL access in ninja:check-data

### DIFF
--- a/app/Console/Commands/CheckData.php
+++ b/app/Console/Commands/CheckData.php
@@ -162,7 +162,7 @@ class CheckData extends Command
         $this->logMessage('Done: ' . strtoupper($this->isValid ? Account::RESULT_SUCCESS : Account::RESULT_FAILURE));
         $this->logMessage('Total execution time in seconds: ' . (microtime(true) - $time_start));
 
-        $errorEmail = config('ninja.error_email');
+        $errorEmail = config('ninja.error.email');
 
         if (strlen($errorEmail) > 1) {
             Mail::raw($this->log, function ($message) use ($errorEmail, $database) {


### PR DESCRIPTION
On running `php artisan ninja:check-data` I received

```
In Address.php line 54:
                                                        
  Email "" does not comply with addr-spec of RFC 2822. 
```

though successful execution beside of that.

It seems the access to the `ERROR_EMAIL` environment variable was wrong. This fixes the error.