### PR TITLE
feat(bank-rules): add participant fields to transaction rule matching

### DIFF
--- a/app/Models/BankTransactionRule.php
+++ b/app/Models/BankTransactionRule.php
@@ -92,6 +92,8 @@ class BankTransactionRule extends BaseModel
     protected array $search_keys = [
         'description' => 'string',
         'amount' => 'number',
+        'participant' => 'string',
+        'participant_name' => 'string',
     ];
 
     /* Amount */

--- a/app/Services/Bank/ProcessBankRules.php
+++ b/app/Services/Bank/ProcessBankRules.php
@@ -273,6 +273,18 @@ class ProcessBankRules extends AbstractService
 
             foreach ($bank_transaction_rule['rules'] as $rule) {
 
+                if ($rule['search_key'] == 'participant') {
+                    if ($this->matchStringOperator($this->bank_transaction->participant ?? '', $rule['value'] ?? '', $rule['operator'] ?? '')) {
+                        $matches++;
+                    }
+                }
+
+                if ($rule['search_key'] == 'participant_name') {
+                    if ($this->matchStringOperator($this->bank_transaction->participant_name ?? '', $rule['value'] ?? '', $rule['operator'] ?? '')) {
+                        $matches++;
+                    }
+                }
+
                 if ($rule['search_key'] == 'description') {
                     if ($this->matchStringOperator($this->bank_transaction->description ?? '', $rule['value'] ?? '', $rule['operator'] ?? '')) {
                         $matches++;


### PR DESCRIPTION
Add `participant` and `participant_name` as searchable keys in `BankTransactionRule`, and implement the corresponding matching logic in `ProcessBankRules`. This allows bank transaction rules to filter and match transactions based on participant identifiers and names, expanding rule criteria beyond description and amount.

Related PR's: 
https://github.com/invoiceninja/admin-portal/pull/754
and:
https://github.com/invoiceninja/ui/pull/3121