### PR TITLE
extract "balance" from last transaction and update the balance in the Job for the nordigen bank_integration.

### DIFF
--- a/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
@@ -107,6 +107,10 @@ class TransactionTransformer implements BankRevenueInterface
         $amount = (float) $transaction["transactionAmount"]["amount"];
         $base_type = $amount < 0 ? 'DEBIT' : 'CREDIT';
 
+        if (array_key_exists('balanceAfterTransaction', $transaction)) {
+            $balanceAfterTransaction = $transaction['balanceAfterTransaction'];
+        }
+
         // description could be in various places
         $description = '';
         if (array_key_exists('remittanceInformationStructured', $transaction)) {
@@ -149,6 +153,7 @@ class TransactionTransformer implements BankRevenueInterface
             'nordigen_transaction_id' => $transactionId,
             'amount' => abs($amount),
             'currency_id' => $this->convertCurrency($transaction["transactionAmount"]["currency"]),
+            'balance_after_transaction' => $balanceAfterTransaction ?? null,
             'category_id' => null,
             'category_type' => array_key_exists('additionalInformation', $transaction) ? $transaction["additionalInformation"] : '',
             'date' => $transaction["bookingDate"],

--- a/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
+++ b/app/Helpers/Bank/Nordigen/Transformer/TransactionTransformer.php
@@ -139,14 +139,18 @@ class TransactionTransformer implements BankRevenueInterface
         }
 
         // participant data
-        $participant = array_key_exists('debtorAccount', $transaction) && array_key_exists('iban', $transaction["debtorAccount"])
-            ? $transaction['debtorAccount']['iban']
-            : (array_key_exists('creditorAccount', $transaction) && array_key_exists('iban', $transaction["creditorAccount"])
-                ? $transaction['creditorAccount']['iban'] : null);
-        $participant_name = array_key_exists('debtorName', $transaction)
-            ? $transaction['debtorName']
-            : (array_key_exists('creditorName', $transaction)
-                ? $transaction['creditorName'] : null);
+        if ($base_type === 'DEBIT') {
+            $participant      = data_get($transaction, 'creditorAccount.iban');
+            $participant_name = data_get($transaction, 'creditorName');
+        } else {
+            $participant      = data_get($transaction, 'debtorAccount.iban');
+            $participant_name = data_get($transaction, 'debtorName');
+        }
+
+        // Fallback
+        $participant = $participant ?? data_get($transaction, 'debtorAccount.iban') ?? data_get($transaction, 'creditorAccount.iban');
+        $participant_name = $participant_name ?? data_get($transaction, 'debtorName') ?? data_get($transaction, 'creditorName');
+
 
         $data = [
             'transaction_id' => 0,

--- a/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
+++ b/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
@@ -214,7 +214,7 @@ class ProcessBankTransactionsNordigen implements ShouldQueue
         }
 
         // update balance if last transaction has optional "balanceAfterTransaction"
-        $last_transaction = end($transactions);
+        $last_transaction = $transactions[0];
         if (!empty($last_transaction['balance_after_transaction'])) {
             $this->bank_integration->balance = $last_transaction['balance_after_transaction']['balanceAmount']['amount'];
             $this->bank_integration->currency = $last_transaction['balance_after_transaction']['balanceAmount']['currency'];

--- a/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
+++ b/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
@@ -214,10 +214,18 @@ class ProcessBankTransactionsNordigen implements ShouldQueue
         }
 
         // update balance if last transaction has optional "balanceAfterTransaction"
-        $last_transaction = $transactions[0];
-        if (!empty($last_transaction['balance_after_transaction'])) {
-            $this->bank_integration->balance = $last_transaction['balance_after_transaction']['balanceAmount']['amount'];
-            $this->bank_integration->currency = $last_transaction['balance_after_transaction']['balanceAmount']['currency'];
+        $newest_balance_transaction = null;
+        foreach ($transactions as $transaction) {
+            if (!empty($transaction['balance_after_transaction'])) {
+                $newest_balance_transaction = $transaction;
+                break;
+            }
+        }
+
+        if ($newest_balance_transaction) {
+            $balance_data = $newest_balance_transaction['balance_after_transaction'];
+            $this->bank_integration->balance = $balance_data['balanceAmount']['amount'];
+            $this->bank_integration->currency = $balance_data['balanceAmount']['currency'];
         }
 
         $this->bank_integration->from_date = now()->subDays(5);

--- a/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
+++ b/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
@@ -213,6 +213,11 @@ class ProcessBankTransactionsNordigen implements ShouldQueue
             );
         }
 
+        $transactions = collect($transactions)->sortByDesc(function ($transaction) {
+            return data_get($transaction, 'booking_date_time')
+                ?? data_get($transaction, 'booking_date');
+        });
+
         // update balance if last transaction has optional "balanceAfterTransaction"
         $newest_balance_transaction = null;
         foreach ($transactions as $transaction) {

--- a/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
+++ b/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
@@ -216,16 +216,14 @@ class ProcessBankTransactionsNordigen implements ShouldQueue
         // update balance if last transaction has optional "balanceAfterTransaction"
         $newest_balance_transaction = null;
         foreach ($transactions as $transaction) {
-            if (!empty($transaction['balance_after_transaction'])) {
+            if (data_get($transaction, 'balance_after_transaction.balanceAmount.amount') !== null) {
                 $newest_balance_transaction = $transaction;
                 break;
             }
         }
 
         if ($newest_balance_transaction) {
-            $balance_data = $newest_balance_transaction['balance_after_transaction'];
-            $this->bank_integration->balance = $balance_data['balanceAmount']['amount'];
-            $this->bank_integration->currency = $balance_data['balanceAmount']['currency'];
+            $this->bank_integration->balance  = data_get($newest_balance_transaction, 'balance_after_transaction.balanceAmount.amount');
         }
 
         $this->bank_integration->from_date = now()->subDays(5);

--- a/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
+++ b/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
@@ -211,7 +211,13 @@ class ProcessBankTransactionsNordigen implements ShouldQueue
                     'updated_at' => $now,
                 ])
             );
+        }
 
+        // update balance if last transaction has optional "balanceAfterTransaction"
+        $last_transaction = end($transactions);
+        if (!empty($last_transaction['balance_after_transaction'])) {
+            $this->bank_integration->balance = $last_transaction['balance_after_transaction']['balanceAmount']['amount'];
+            $this->bank_integration->currency = $last_transaction['balance_after_transaction']['balanceAmount']['currency'];
         }
 
         $this->bank_integration->from_date = now()->subDays(5);

--- a/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
+++ b/app/Jobs/Bank/ProcessBankTransactionsNordigen.php
@@ -190,6 +190,12 @@ class ProcessBankTransactionsNordigen implements ShouldQueue
 
         $now = now();
 
+        // Always sort Desc Transaction based on the BookingDateTime fallback BookingDate
+        $transactions = collect($transactions)->sortByDesc(function ($transaction) {
+            return data_get($transaction, 'booking_date_time')
+                ?? data_get($transaction, 'booking_date');
+        });
+
         foreach ($transactions as $transaction) {
 
             if (BankTransaction::where('nordigen_transaction_id', $transaction['nordigen_transaction_id'])
@@ -212,11 +218,6 @@ class ProcessBankTransactionsNordigen implements ShouldQueue
                 ])
             );
         }
-
-        $transactions = collect($transactions)->sortByDesc(function ($transaction) {
-            return data_get($transaction, 'booking_date_time')
-                ?? data_get($transaction, 'booking_date');
-        });
 
         // update balance if last transaction has optional "balanceAfterTransaction"
         $newest_balance_transaction = null;


### PR DESCRIPTION
when retreiving Transactions from Nordigen API, an optional field: "balanceAfterTransaction" is used to update the Nordigin BankAccount balance and currency. 

Added because Rate Limit on API request Balances was commented out.