### PR TITLE
Fix PayPal button race in client portal smooth payment flow

### DIFF
--- a/app/Livewire/Flow2/InvoicePay.php
+++ b/app/Livewire/Flow2/InvoicePay.php
@@ -302,7 +302,7 @@ class InvoicePay extends Component
     #[Computed()]
     public function componentUniqueId(): string
     {
-        return "purchase-" . md5(microtime());
+        return "purchase-" . class_basename($this->component);
     }
 
     public function mount()

--- a/app/Livewire/Sign.php
+++ b/app/Livewire/Sign.php
@@ -119,7 +119,7 @@ class Sign extends Component
     #[Computed()]
     public function componentUniqueId(): string
     {
-        return "sign-" . md5(microtime());
+        return "sign-" . class_basename($this->component ?? '');
     }
 
     public function render()

--- a/resources/views/portal/ninja2020/gateways/paypal/pay_livewire.blade.php
+++ b/resources/views/portal/ninja2020/gateways/paypal/pay_livewire.blade.php
@@ -101,6 +101,13 @@
 
 @script
 <script>
+    // Defer past Livewire's deferred morph for a #[Lazy] parent
+    // (ProcessPayment): on lazy mount this script runs synchronously while
+    // the placeholder is still in the DOM, so #paypal-button-container
+    // does not yet exist and paypal.Buttons().render() throws
+    // "Document is ready and element #paypal-button-container does not exist".
+    // setTimeout(0) yields to the next macrotask, after the morph runs.
+    setTimeout(() => {
     const fundingSource = "{!! $funding_source !!}";
     const clientId = "{{ $client_id }}";
     const orderId = "{!! $order_id !!}";
@@ -187,14 +194,14 @@
         
     });
     
-    document.getElementById("server_response").addEventListener('submit', (e) => {
+    document.getElementById("server_response")?.addEventListener('submit', (e) => {
 		if (document.getElementById("server_response").classList.contains('is-submitting')) {
 			e.preventDefault();
 		}
 		
 		document.getElementById("server_response").classList.add('is-submitting');
 	});
-
+    }, 0);
 
 
 </script>

--- a/resources/views/portal/ninja2020/gateways/paypal/ppcp/card_livewire.blade.php
+++ b/resources/views/portal/ninja2020/gateways/paypal/ppcp/card_livewire.blade.php
@@ -91,6 +91,10 @@
 
 @script
 <script>
+    // See note in gateways/paypal/pay_livewire.blade.php — defer past the
+    // Livewire morph for the lazy ProcessPayment parent so the card-field
+    // containers exist in the DOM before paypal.CardFields().render() runs.
+    setTimeout(() => {
 
     const clientId = "{{ $client_id }}";
     const orderId = "{!! $order_id !!}";
@@ -289,12 +293,14 @@
         }
 
     }
+    }, 0);
 
 </script>
 @endscript
 
 @script
 <script>
+  setTimeout(() => {
   Array
       .from(document.getElementsByClassName('toggle-payment-with-token'))
       .forEach((element) => element.addEventListener('click', (e) => {
@@ -356,6 +362,7 @@
 
           });
   }
+  }, 0);
 
 </script>
 @endscript

--- a/resources/views/portal/ninja2020/gateways/paypal/ppcp/pay_livewire.blade.php
+++ b/resources/views/portal/ninja2020/gateways/paypal/ppcp/pay_livewire.blade.php
@@ -29,6 +29,10 @@
 
 @script
 <script>
+    // See note in gateways/paypal/pay_livewire.blade.php — defer past the
+    // Livewire morph for the lazy ProcessPayment parent so the
+    // paypal-button-container div is in the DOM before render() runs.
+    setTimeout(() => {
     const fundingSource = "{!! $funding_source !!}";
     const clientId = "{{ $client_id }}";
     const orderId = "{!! $order_id !!}";
@@ -103,13 +107,13 @@
         
     });
     
-    document.getElementById("server_response").addEventListener('submit', (e) => {
+    document.getElementById("server_response")?.addEventListener('submit', (e) => {
 		if (document.getElementById("server_response").classList.contains('is-submitting')) {
 			e.preventDefault();
 		}
 		
 		document.getElementById("server_response").classList.add('is-submitting');
 	});
-
+    }, 0);
 </script>
 @endscript


### PR DESCRIPTION
Closes #11942

Two Livewire 3 timing issues caused the PayPal SDK to throw \`Document is ready and
element #paypal-button-container does not exist\` on the client-portal smooth payment
flow.

Verified end-to-end against PayPal sandbox: full happy-path checkout, payment marked
Completed in the portal.