### PR TITLE
Add translation keys for payware gateway config fields

### DIFF
--- a/lang/bg/texts.php
+++ b/lang/bg/texts.php
@@ -5930,6 +5930,13 @@ $lang = array(
     'no_compatible_app_installed' => 'Ако нищо не се случва, може би нямате инсталирано съвместимо приложение.',
     'payment_type_Mobile Payment' => 'Мобилно плащане',
     'gateway_temporarily_unavailable' => 'Този начин на плащане е временно недостъпен. Моля, опитайте отново по-късно или изберете друг начин на плащане.',
+    'payment_period' => 'Период на плащане',
+    'payment_period_help' => 'Времето за завършване на плащането в секунди. Допустим диапазон 60 - 600.',
+    'payware_partner_id_label' => 'Идентификатор на партньор',
+    'payware_partner_id_help' => 'Предоставя се от payware при регистрация',
+    'payware_vpos_id_label' => 'Идентификатор на webPOS',
+    'payware_vpos_id_help' => 'Идентификатор на webPOS от таблото на payware',
+    'payware_public_key_help' => 'RSA публичен ключ за валидиране на подписа на webhook',
 );
 
 return $lang;

--- a/lang/en/texts.php
+++ b/lang/en/texts.php
@@ -5979,6 +5979,13 @@ $lang = array(
     'widget_border_color_help' => 'Color of the border around the widget area.',
     'card_already_exists' => 'Card already exists',
     'income_account' => 'Income Account',
+    'payment_period' => 'Payment Period',
+    'payment_period_help' => 'The time allowed for payment completion in seconds. Accepted range 60 - 600.',
+    'payware_partner_id_label' => 'Partner Identifier',
+    'payware_partner_id_help' => 'Provided by payware upon registration',
+    'payware_vpos_id_label' => 'webPOS Identifier',
+    'payware_vpos_id_help' => 'webPOS identifier from the payware dashboard',
+    'payware_public_key_help' => 'RSA public key for webhook signature validation',
 );
 
 return $lang;

--- a/lang/es/texts.php
+++ b/lang/es/texts.php
@@ -5878,6 +5878,13 @@ $lang = array(
     'awaiting_payment' => 'Esperando pago',
     'payment_confirmed' => 'Pago confirmado',
     'payment_expired' => 'El pago ha expirado. Por favor, vuelva e inténtelo de nuevo.',
+    'payment_period' => 'Período de pago',
+    'payment_period_help' => 'El tiempo permitido para completar el pago en segundos. Rango aceptado 60 - 600.',
+    'payware_partner_id_label' => 'Identificador de socio',
+    'payware_partner_id_help' => 'Proporcionado por payware al registrarse',
+    'payware_vpos_id_label' => 'Identificador de webPOS',
+    'payware_vpos_id_help' => 'Identificador de webPOS desde el panel de payware',
+    'payware_public_key_help' => 'Clave pública RSA para la validación de firma del webhook',
 );
 
 return $lang;


### PR DESCRIPTION
## Summary

Adds 7 translation keys referenced by the payware gateway UI in [invoiceninja/ui#2967](https://github.com/invoiceninja/ui/pull/2967) but currently missing from this repo's `lang/*/texts.php`:

- `payment_period` / `payment_period_help` (TTL field label + help)
- `payware_partner_id_label` / `payware_partner_id_help`
- `payware_vpos_id_label` / `payware_vpos_id_help`
- `payware_public_key_help`

Companion to backend PR #11697 (merged 2026-05-12), which registered the payware gateway (`b0a6294fca4488c2bab58f3e11e3c623`) and its credential/settings fields (`partnerId`, `vposId`, `paywarePublicKey`, `testMode`, `timeToLive`) but did not add the labels/help for those fields.

Without these keys, the gateway configuration form in the UI shows raw key names instead of human-readable labels.

## Languages

- **EN** (source of truth) - 7 keys added.
- **BG** (Bulgarian) - 7 keys added, payware is a Bulgarian payment network.
- **ES** (Spanish) - 7 keys added.

## Test plan

- [ ] Pull invoiceninja/ui#2967 against `develop`, point the UI at a backend on this branch (after merge), and confirm the payware gateway create/edit page renders the new labels and help text in each language.
- [ ] Browse to the payware gateway config in EN, BG, ES locales and verify no raw keys are shown.