### PR TITLE
List filter/sort improvements 

### DIFF
--- a/app/Filters/ClientFilters.php
+++ b/app/Filters/ClientFilters.php
@@ -94,7 +94,7 @@ class ClientFilters extends QueryFilters
             return $this->builder;
         }
 
-        return $this->builder->where('id_number', 'like', '%' . $id_number . '%');
+        return $this->builder->where('id_number', $id_number);
     }
 
     public function number(string $number = ''): Builder
@@ -103,7 +103,7 @@ class ClientFilters extends QueryFilters
             return $this->builder;
         }
 
-        return $this->builder->where('number', 'like', $number . '%');
+        return $this->builder->where('number', $number);
     }
 
     public function group(string $group_id = ''): Builder

--- a/app/Filters/ClientFilters.php
+++ b/app/Filters/ClientFilters.php
@@ -94,7 +94,7 @@ class ClientFilters extends QueryFilters
             return $this->builder;
         }
 
-        return $this->builder->where('id_number', $id_number);
+        return $this->builder->where('id_number', 'like', '%' . $id_number . '%');
     }
 
     public function number(string $number = ''): Builder
@@ -103,7 +103,7 @@ class ClientFilters extends QueryFilters
             return $this->builder;
         }
 
-        return $this->builder->where('number', $number);
+        return $this->builder->where('number', 'like', $number . '%');
     }
 
     public function group(string $group_id = ''): Builder
@@ -114,6 +114,70 @@ class ClientFilters extends QueryFilters
 
         return $this->builder->where('group_settings_id', $this->decodePrimaryKey($group_id));
 
+    }
+
+    public function group_settings_id(string $group_settings_id = ''): Builder
+    {
+        $groups = explode(',', $group_settings_id);
+
+        if (strlen($group_settings_id) == 0 || count(array_filter($groups)) == 0) {
+            return $this->builder;
+        }
+
+        return $this->builder->whereIn('group_settings_id', $this->transformKeys($groups));
+    }
+
+    public function country_id(string $country_id = ''): Builder
+    {
+        $countries = explode(',', $country_id);
+
+        if (strlen($country_id) == 0 || count(array_filter($countries)) == 0) {
+            return $this->builder;
+        }
+
+        return $this->builder->whereIn('country_id', $countries);
+    }
+
+    public function industry_id(string $industry_id = ''): Builder
+    {
+        $industries = explode(',', $industry_id);
+
+        if (strlen($industry_id) == 0 || count(array_filter($industries)) == 0) {
+            return $this->builder;
+        }
+
+        return $this->builder->whereIn('industry_id', $industries);
+    }
+
+    public function size_id(string $size_id = ''): Builder
+    {
+        $sizes = explode(',', $size_id);
+
+        if (strlen($size_id) == 0 || count(array_filter($sizes)) == 0) {
+            return $this->builder;
+        }
+
+        return $this->builder->whereIn('size_id', $sizes);
+    }
+
+    public function classification(string $classification = ''): Builder
+    {
+        $classifications = explode(',', $classification);
+
+        if (strlen($classification) == 0 || count(array_filter($classifications)) == 0) {
+            return $this->builder;
+        }
+
+        return $this->builder->whereIn('classification', $classifications);
+    }
+
+    public function vat_number(string $vat_number = ''): Builder
+    {
+        if (strlen($vat_number) == 0) {
+            return $this->builder;
+        }
+
+        return $this->builder->where('vat_number', 'like', '%' . $vat_number . '%');
     }
 
     /**

--- a/app/Filters/ExpenseFilters.php
+++ b/app/Filters/ExpenseFilters.php
@@ -195,6 +195,28 @@ class ExpenseFilters extends QueryFilters
         return $this->builder->whereIn('category_id', $categories_keys);
     }
 
+    public function project_ids(string $project_ids = ''): Builder
+    {
+        $projects_exploded = explode(",", $project_ids);
+
+        if (empty($project_ids) || count(array_filter($projects_exploded)) == 0) {
+            return $this->builder;
+        }
+
+        return $this->builder->whereIn('project_id', $this->transformKeys($projects_exploded));
+    }
+
+    public function vendor_ids(string $vendor_ids = ''): Builder
+    {
+        $vendors_exploded = explode(",", $vendor_ids);
+
+        if (empty($vendor_ids) || count(array_filter($vendors_exploded)) == 0) {
+            return $this->builder;
+        }
+
+        return $this->builder->whereIn('vendor_id', $this->transformKeys($vendors_exploded));
+    }
+
     public function payment_type(string $payment_type = ''): Builder
     {
         $payment_types_exploded = explode(",", $payment_type);

--- a/app/Filters/PaymentFilters.php
+++ b/app/Filters/PaymentFilters.php
@@ -13,7 +13,6 @@
 namespace App\Filters;
 
 use App\Models\Payment;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -263,34 +262,6 @@ class PaymentFilters extends QueryFilters
         }
 
         return $this->builder->orderBy($sort_col[0], $dir);
-    }
-
-    /**
-     * date_range
-     *
-     * only filters on date
-     * @param  string $date_range
-     * @return Builder
-     */
-    public function date_range(string $date_range = ''): Builder
-    {
-        $parts = explode(",", $date_range);
-
-        if (!isset($parts[2])) {
-            return $this->builder;
-        }
-
-        try {
-
-            $start_date = Carbon::parse($parts[1]);
-            $end_date = Carbon::parse($parts[2]);
-
-
-            return $this->builder->whereBetween('date', [$start_date, $end_date]);
-        } catch (\Exception $e) {
-            return $this->builder;
-        }
-
     }
 
     /**

--- a/app/Filters/ProjectFilters.php
+++ b/app/Filters/ProjectFilters.php
@@ -56,6 +56,21 @@ class ProjectFilters extends QueryFilters
     }
 
     /**
+     * Singular alias for the inherited assigned_user_ids filter.
+     *
+     * projects.assigned_user_id exists, so the column-guarded base
+     * assigned_user_ids() already filters projects; this only adds the
+     * singular param name for cross-client parity.
+     *
+     * @param string $assigned_user
+     * @return Builder
+     */
+    public function assigned_user(string $assigned_user = ''): Builder
+    {
+        return $this->assigned_user_ids($assigned_user);
+    }
+
+    /**
      * Sorts the list based on $sort.
      *
      * @param string $sort formatted as column|asc
@@ -142,33 +157,6 @@ class ProjectFilters extends QueryFilters
 
     }
 
-    /**
-     * date_range
-     *
-     * only filters on date
-     * @param  string $date_range in format column,start_date,end_date
-     * @return Builder
-     */
-    public function date_range(string $date_range = ''): Builder
-    {
-        $parts = explode(",", $date_range);
-
-        if (count($parts) != 3 || !in_array($parts[0], \Illuminate\Support\Facades\Schema::getColumnListing($this->builder->getModel()->getTable()))) {
-            return $this->builder;
-        }
-
-        try {
-
-            $start_date = \Carbon\Carbon::parse($parts[1]);
-            $end_date = \Carbon\Carbon::parse($parts[2]);
-
-
-            return $this->builder->whereBetween($parts[0], [$start_date, $end_date]);
-        } catch (\Exception $e) {
-            return $this->builder;
-        }
-
-    }
     /**
      * Filters the query by the users company ID.
      *

--- a/app/Filters/QueryFilters.php
+++ b/app/Filters/QueryFilters.php
@@ -62,21 +62,6 @@ abstract class QueryFilters
     protected $with_property = 'id';
 
     /**
-     * Request params that are framework/pagination concerns, not filters.
-     *
-     * These have no filter method by design; without this allow-list they
-     * would be reported as unknown filters in the meta.warnings envelope.
-     * Params that do have a filter method (filter, status, sort, client_status,
-     * client_id, with_trashed, is_deleted, ...) never reach that branch.
-     */
-    private const RESERVED_PARAMS = [
-        'page', 'per_page', 'include', 'index', 'serializer', 'first_load',
-        'include_static', 'einvoice', 'clear_cache', 't', '_', 'format',
-        'documents', 'search', 'since_updated_at', 'since_id', 'sort', 'stop',
-        'rows', 'flat', 'strict',
-    ];
-
-    /**
      * Per-request cache of table column listings, keyed by table name.
      *
      * Schema::getColumnListing() is not request-cached on Laravel 12 (each
@@ -86,20 +71,6 @@ abstract class QueryFilters
      * @var array<string, string[]>
      */
     protected array $column_cache = [];
-
-    /**
-     * Unknown filter params encountered during apply().
-     *
-     * @var string[]
-     */
-    protected array $filter_warnings = [];
-
-    /**
-     * Deprecated filter shapes encountered during apply().
-     *
-     * @var string[]
-     */
-    protected array $filter_deprecations = [];
 
     /**
      * Create a new QueryFilters instance.
@@ -127,10 +98,6 @@ abstract class QueryFilters
 
         foreach ($this->filters() as $name => $value) {
             if (! method_exists($this, $name)) {
-                if (! in_array($name, self::RESERVED_PARAMS, true)) {
-                    $this->filter_warnings[] = $name;
-                }
-
                 continue;
             }
 
@@ -151,8 +118,6 @@ abstract class QueryFilters
                 $this->$name();
             }
         }
-
-        $this->surfaceFilterDiagnostics();
 
         $this->ensureDefaultOrder();
 
@@ -180,25 +145,6 @@ abstract class QueryFilters
         );
     }
 
-    /**
-     * surfaceFilterDiagnostics
-     *
-     * Stashes the collected unknown-filter / deprecation notices on the
-     * request so BaseController::response() can fold them into meta.warnings.
-     * Purely additive — it never changes the result set or status code.
-     *
-     * @return void
-     */
-    protected function surfaceFilterDiagnostics(): void
-    {
-        if ($this->filter_warnings) {
-            $this->request->attributes->set('filter_warnings', array_values(array_unique($this->filter_warnings)));
-        }
-
-        if ($this->filter_deprecations) {
-            $this->request->attributes->set('filter_deprecations', array_values(array_unique($this->filter_deprecations)));
-        }
-    }
 
 
     /**
@@ -516,8 +462,7 @@ abstract class QueryFilters
      *
      * Canonical contract: "column,start,end" (column defaults to "date").
      *
-     * Legacy shapes are still honoured for one deprecation cycle and recorded
-     * on $filter_deprecations (surfaced via meta.warnings.deprecations):
+     * Legacy shapes are still honoured for backward compatibility:
      *  - "start,end"           -> 2-part on the `date` column (the old base /
      *                             RecurringExpenseFilters contract)
      *  - "_,start,end" where _ -> 3-part whose first part is not a real
@@ -532,13 +477,10 @@ abstract class QueryFilters
 
         $columns = $this->tableColumns();
 
-        $deprecation = null;
-
         if (count($parts) == 2) {
             $column = 'date';
             $start = $parts[0];
             $end = $parts[1];
-            $deprecation = 'date_range "start,end" (use "column,start,end")';
         } elseif (count($parts) == 3 && in_array($parts[0], $columns, true)) {
             $column = $parts[0];
             $start = $parts[1];
@@ -547,7 +489,6 @@ abstract class QueryFilters
             $column = 'date';
             $start = $parts[1];
             $end = $parts[2];
-            $deprecation = 'date_range "_,start,end" (use "column,start,end")';
         } else {
             return $this->builder;
         }
@@ -561,13 +502,7 @@ abstract class QueryFilters
             $start_date = Carbon::parse($start);
             $end_date = Carbon::parse($end);
 
-            $query = $this->builder->whereBetween($column, [$start_date, $end_date]);
-
-            if ($deprecation) {
-                $this->filter_deprecations[] = $deprecation;
-            }
-
-            return $query;
+            return $this->builder->whereBetween($column, [$start_date, $end_date]);
         } catch (\Exception $e) {
             return $this->builder;
         }

--- a/app/Filters/QueryFilters.php
+++ b/app/Filters/QueryFilters.php
@@ -16,6 +16,8 @@ use App\Utils\Traits\MakesHash;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\ValidationException;
 
 /**
  * Class QueryFilters.
@@ -61,6 +63,46 @@ abstract class QueryFilters
     protected $with_property = 'id';
 
     /**
+     * Request params that are framework/pagination concerns, not filters.
+     *
+     * These have no filter method by design; without this allow-list they
+     * would be reported as unknown filters in the meta.warnings envelope.
+     * Params that do have a filter method (filter, status, sort, client_status,
+     * client_id, with_trashed, is_deleted, ...) never reach that branch.
+     */
+    private const RESERVED_PARAMS = [
+        'page', 'per_page', 'include', 'index', 'serializer', 'first_load',
+        'include_static', 'einvoice', 'clear_cache', 't', '_', 'format',
+        'documents', 'search', 'since_updated_at', 'since_id', 'sort', 'stop',
+        'rows', 'flat', 'strict',
+    ];
+
+    /**
+     * Per-request cache of table column listings, keyed by table name.
+     *
+     * Schema::getColumnListing() is not request-cached on Laravel 12 (each
+     * call is an information_schema round-trip). The column set is stable
+     * within a request, so memoize it once per table.
+     *
+     * @var array<string, string[]>
+     */
+    protected array $column_cache = [];
+
+    /**
+     * Unknown filter params encountered during apply().
+     *
+     * @var string[]
+     */
+    protected array $filter_warnings = [];
+
+    /**
+     * Deprecated filter shapes encountered during apply().
+     *
+     * @var string[]
+     */
+    protected array $filter_deprecations = [];
+
+    /**
      * Create a new QueryFilters instance.
      *
      * @param Request $request
@@ -86,6 +128,10 @@ abstract class QueryFilters
 
         foreach ($this->filters() as $name => $value) {
             if (! method_exists($this, $name)) {
+                if (! in_array($name, self::RESERVED_PARAMS, true)) {
+                    $this->filter_warnings[] = $name;
+                }
+
                 continue;
             }
 
@@ -99,13 +145,15 @@ abstract class QueryFilters
 
                 continue;
             }
-            
+
             if (is_string($value) && strlen($value)) {
                 $this->$name($value);
             } else {
                 $this->$name();
             }
         }
+
+        $this->surfaceFilterDiagnostics();
 
         $this->ensureDefaultOrder();
 
@@ -133,6 +181,39 @@ abstract class QueryFilters
         );
     }
 
+    /**
+     * surfaceFilterDiagnostics
+     *
+     * Either aborts with a 422 (when the caller opted into strict filtering
+     * via ?strict=true / X-Strict-Filters) or, by default, stashes the
+     * collected warnings on the request so BaseController::response() can
+     * fold them into meta.warnings. The default path is additive and never
+     * changes the result set.
+     *
+     * @return void
+     */
+    protected function surfaceFilterDiagnostics(): void
+    {
+        $this->filter_warnings = array_values(array_unique($this->filter_warnings));
+
+        $strict = $this->request->boolean('strict')
+            || filter_var($this->request->header('X-Strict-Filters'), FILTER_VALIDATE_BOOLEAN);
+
+        if ($strict && count($this->filter_warnings)) {
+            throw ValidationException::withMessages([
+                'filters' => ['Unknown filter parameter(s): ' . implode(', ', $this->filter_warnings)],
+            ]);
+        }
+
+        if (count($this->filter_warnings)) {
+            $this->request->attributes->set('filter_warnings', $this->filter_warnings);
+        }
+
+        if (count($this->filter_deprecations)) {
+            $this->request->attributes->set('filter_deprecations', array_values(array_unique($this->filter_deprecations)));
+        }
+    }
+
 
     /**
      * Get all request filters data.
@@ -142,6 +223,18 @@ abstract class QueryFilters
     public function filters()
     {
         return $this->request->all();
+    }
+
+    /**
+     * Memoized column listing for the builder's table.
+     *
+     * @return string[]
+     */
+    protected function tableColumns(): array
+    {
+        $table = $this->builder->getModel()->getTable();
+
+        return $this->column_cache[$table] ??= Schema::getColumnListing($table);
     }
 
     /**
@@ -293,7 +386,7 @@ abstract class QueryFilters
 
     public function client_id(string $client_id = ''): Builder
     {
-        if (strlen($client_id) == 0 || !in_array('client_id', \Illuminate\Support\Facades\Schema::getColumnListing($this->builder->getModel()->getTable()))) {
+        if (strlen($client_id) == 0 || !in_array('client_id', $this->tableColumns())) {
             return $this->builder;
         }
 
@@ -302,7 +395,7 @@ abstract class QueryFilters
 
     public function vendor_id(string $vendor_id = ''): Builder
     {
-        if (strlen($vendor_id) == 0 || !in_array('vendor_id', \Illuminate\Support\Facades\Schema::getColumnListing($this->builder->getModel()->getTable()))) {
+        if (strlen($vendor_id) == 0 || !in_array('vendor_id', $this->tableColumns())) {
             return $this->builder;
         }
 
@@ -390,7 +483,7 @@ abstract class QueryFilters
     {
         $parts = explode(",", $date_range);
 
-        if (count($parts) != 2 || !in_array('created_at', \Illuminate\Support\Facades\Schema::getColumnListing($this->builder->getModel()->getTable()))) {
+        if (count($parts) != 2 || !in_array('created_at', $this->tableColumns())) {
             return $this->builder;
         }
 
@@ -407,16 +500,16 @@ abstract class QueryFilters
     }
 
     /**
-     * Filter by date range
+     * Filter by updated at date range
      *
      * @param string $date_range
      * @return Builder
      */
-    public function date_range(string $date_range = ''): Builder
+    public function updated_between(string $date_range = ''): Builder
     {
         $parts = explode(",", $date_range);
 
-        if (count($parts) != 2 || !in_array('date', \Illuminate\Support\Facades\Schema::getColumnListing($this->builder->getModel()->getTable()))) {
+        if (count($parts) != 2 || !in_array('updated_at', $this->tableColumns())) {
             return $this->builder;
         }
 
@@ -425,7 +518,70 @@ abstract class QueryFilters
             $start_date = Carbon::parse($parts[0]);
             $end_date = Carbon::parse($parts[1]);
 
-            return $this->builder->whereBetween('date', [$start_date, $end_date]);
+            return $this->builder->whereBetween('updated_at', [$start_date, $end_date]);
+        } catch (\Exception $e) {
+            return $this->builder;
+        }
+
+    }
+
+    /**
+     * Filter by date range.
+     *
+     * Canonical contract: "column,start,end" (column defaults to "date").
+     *
+     * Legacy shapes are still honoured for one deprecation cycle and recorded
+     * on $filter_deprecations (surfaced via meta.warnings.deprecations):
+     *  - "start,end"           -> 2-part on the `date` column (the old base /
+     *                             RecurringExpenseFilters contract)
+     *  - "_,start,end" where _ -> 3-part whose first part is not a real
+     *    is not a column          column (the old PaymentFilters contract)
+     *
+     * @param string $date_range
+     * @return Builder
+     */
+    public function date_range(string $date_range = ''): Builder
+    {
+        $parts = explode(",", $date_range);
+
+        $columns = $this->tableColumns();
+
+        $deprecation = null;
+
+        if (count($parts) == 2) {
+            $column = 'date';
+            $start = $parts[0];
+            $end = $parts[1];
+            $deprecation = 'date_range "start,end" (use "column,start,end")';
+        } elseif (count($parts) == 3 && in_array($parts[0], $columns, true)) {
+            $column = $parts[0];
+            $start = $parts[1];
+            $end = $parts[2];
+        } elseif (count($parts) == 3) {
+            $column = 'date';
+            $start = $parts[1];
+            $end = $parts[2];
+            $deprecation = 'date_range "_,start,end" (use "column,start,end")';
+        } else {
+            return $this->builder;
+        }
+
+        if (!in_array($column, $columns, true)) {
+            return $this->builder;
+        }
+
+        try {
+
+            $start_date = Carbon::parse($start);
+            $end_date = Carbon::parse($end);
+
+            $query = $this->builder->whereBetween($column, [$start_date, $end_date]);
+
+            if ($deprecation) {
+                $this->filter_deprecations[] = $deprecation;
+            }
+
+            return $query;
         } catch (\Exception $e) {
             return $this->builder;
         }
@@ -434,7 +590,7 @@ abstract class QueryFilters
 
     public function assigned_user_ids(string $assigned_user_ids = ''): Builder
     {
-        if (strlen($assigned_user_ids) == 0 || !in_array('assigned_user_id', \Illuminate\Support\Facades\Schema::getColumnListing($this->builder->getModel()->getTable()))) {
+        if (strlen($assigned_user_ids) == 0 || !in_array('assigned_user_id', $this->tableColumns())) {
             return $this->builder;
         }
 
@@ -445,13 +601,49 @@ abstract class QueryFilters
 
     public function client_ids(string $client_ids = ''): Builder
     {
-        if (strlen($client_ids) == 0 || !in_array('client_id', \Illuminate\Support\Facades\Schema::getColumnListing($this->builder->getModel()->getTable()))) {
+        if (strlen($client_ids) == 0 || !in_array('client_id', $this->tableColumns())) {
             return $this->builder;
         }
 
         return $this->builder->where(function ($q) use ($client_ids) {
             $q->whereIn('client_id', $this->transformKeys(explode(',', $client_ids)));
         });
+    }
+
+    public function custom_value1(string $value = ''): Builder
+    {
+        if (strlen($value) == 0 || !in_array('custom_value1', $this->tableColumns())) {
+            return $this->builder;
+        }
+
+        return $this->builder->where('custom_value1', 'like', '%' . $value . '%');
+    }
+
+    public function custom_value2(string $value = ''): Builder
+    {
+        if (strlen($value) == 0 || !in_array('custom_value2', $this->tableColumns())) {
+            return $this->builder;
+        }
+
+        return $this->builder->where('custom_value2', 'like', '%' . $value . '%');
+    }
+
+    public function custom_value3(string $value = ''): Builder
+    {
+        if (strlen($value) == 0 || !in_array('custom_value3', $this->tableColumns())) {
+            return $this->builder;
+        }
+
+        return $this->builder->where('custom_value3', 'like', '%' . $value . '%');
+    }
+
+    public function custom_value4(string $value = ''): Builder
+    {
+        if (strlen($value) == 0 || !in_array('custom_value4', $this->tableColumns())) {
+            return $this->builder;
+        }
+
+        return $this->builder->where('custom_value4', 'like', '%' . $value . '%');
     }
 
     /**
@@ -465,7 +657,7 @@ abstract class QueryFilters
 
         $parts = explode(",", $date_range);
 
-        if (count($parts) != 2 || !in_array('due_date', \Illuminate\Support\Facades\Schema::getColumnListing($this->builder->getModel()->getTable()))) {
+        if (count($parts) != 2 || !in_array('due_date', $this->tableColumns())) {
             return $this->builder;
         }
 

--- a/app/Filters/QueryFilters.php
+++ b/app/Filters/QueryFilters.php
@@ -17,7 +17,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Validation\ValidationException;
 
 /**
  * Class QueryFilters.
@@ -184,32 +183,19 @@ abstract class QueryFilters
     /**
      * surfaceFilterDiagnostics
      *
-     * Either aborts with a 422 (when the caller opted into strict filtering
-     * via ?strict=true / X-Strict-Filters) or, by default, stashes the
-     * collected warnings on the request so BaseController::response() can
-     * fold them into meta.warnings. The default path is additive and never
-     * changes the result set.
+     * Stashes the collected unknown-filter / deprecation notices on the
+     * request so BaseController::response() can fold them into meta.warnings.
+     * Purely additive — it never changes the result set or status code.
      *
      * @return void
      */
     protected function surfaceFilterDiagnostics(): void
     {
-        $this->filter_warnings = array_values(array_unique($this->filter_warnings));
-
-        $strict = $this->request->boolean('strict')
-            || filter_var($this->request->header('X-Strict-Filters'), FILTER_VALIDATE_BOOLEAN);
-
-        if ($strict && count($this->filter_warnings)) {
-            throw ValidationException::withMessages([
-                'filters' => ['Unknown filter parameter(s): ' . implode(', ', $this->filter_warnings)],
-            ]);
+        if ($this->filter_warnings) {
+            $this->request->attributes->set('filter_warnings', array_values(array_unique($this->filter_warnings)));
         }
 
-        if (count($this->filter_warnings)) {
-            $this->request->attributes->set('filter_warnings', $this->filter_warnings);
-        }
-
-        if (count($this->filter_deprecations)) {
+        if ($this->filter_deprecations) {
             $this->request->attributes->set('filter_deprecations', array_values(array_unique($this->filter_deprecations)));
         }
     }

--- a/app/Filters/RecurringExpenseFilters.php
+++ b/app/Filters/RecurringExpenseFilters.php
@@ -12,7 +12,6 @@
 
 namespace App\Filters;
 
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -231,34 +230,6 @@ class RecurringExpenseFilters extends QueryFilters
         }
 
         return $this->builder;
-    }
-
-    /**
-     * date_range
-     *
-     * only filters on date
-     * @param  string $date_range
-     * @return Builder
-     */
-    public function date_range(string $date_range = ''): Builder
-    {
-        $parts = explode(",", $date_range);
-
-        if (!isset($parts[1])) {
-            return $this->builder;
-        }
-
-        try {
-
-            $start_date = Carbon::parse($parts[0]);
-            $end_date = Carbon::parse($parts[1]);
-
-
-            return $this->builder->whereBetween('date', [$start_date, $end_date]);
-        } catch (\Exception $e) {
-            return $this->builder;
-        }
-
     }
 
     /**

--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -1054,21 +1054,6 @@ class BaseController extends Controller
         } else {
             $meta = $response['meta'] ?? null;
 
-            $filter_warnings = request()->attributes->get('filter_warnings', []);
-            $filter_deprecations = request()->attributes->get('filter_deprecations', []);
-
-            if ($filter_warnings || $filter_deprecations) {
-                $meta = (array) $meta;
-
-                if ($filter_warnings) {
-                    $meta['warnings']['unknown_filters'] = $filter_warnings;
-                }
-
-                if ($filter_deprecations) {
-                    $meta['warnings']['deprecations'] = $filter_deprecations;
-                }
-            }
-
             $response = [
                 $index => $response,
             ];

--- a/app/Http/Controllers/BaseController.php
+++ b/app/Http/Controllers/BaseController.php
@@ -1053,6 +1053,22 @@ class BaseController extends Controller
             unset($response['meta']);
         } else {
             $meta = $response['meta'] ?? null;
+
+            $filter_warnings = request()->attributes->get('filter_warnings', []);
+            $filter_deprecations = request()->attributes->get('filter_deprecations', []);
+
+            if ($filter_warnings || $filter_deprecations) {
+                $meta = (array) $meta;
+
+                if ($filter_warnings) {
+                    $meta['warnings']['unknown_filters'] = $filter_warnings;
+                }
+
+                if ($filter_deprecations) {
+                    $meta['warnings']['deprecations'] = $filter_deprecations;
+                }
+            }
+
             $response = [
                 $index => $response,
             ];

--- a/tests/Feature/QueryFilterEnhancementsTest.php
+++ b/tests/Feature/QueryFilterEnhancementsTest.php
@@ -90,38 +90,15 @@ class QueryFilterEnhancementsTest extends TestCase
         $this->assertArrayNotHasKey('warnings', $arr['meta'] ?? []);
     }
 
-    public function testStrictModeRejectsUnknownFilterParam()
+    public function testStrictParamIsInertAndOnlyTheRealUnknownWarns()
     {
-        $response = $this->withHeaders($this->headers())
-            ->getJson('/api/v1/clients?bogus_param=1&strict=true')
-            ->assertStatus(422);
+        // strict was removed; ?strict is reserved (inert) so only bogus_param warns.
+        $arr = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?bogus_param=1&strict=true')
+            ->assertStatus(200)
+            ->json();
 
-        $this->assertArrayHasKey('filters', $response->json()['errors']);
-    }
-
-    public function testStrictModeViaHeaderRejectsUnknownFilterParam()
-    {
-        $this->withHeaders(array_merge($this->headers(), ['X-Strict-Filters' => '1']))
-            ->getJson('/api/v1/clients?bogus_param=1')
-            ->assertStatus(422);
-    }
-
-    public function testStrictModeAllowsKnownFilters()
-    {
-        $this->withHeaders($this->headers())
-            ->getJson('/api/v1/clients?status=active&strict=true')
-            ->assertStatus(200);
-    }
-
-    public function testStrictModeNeverRejectsAnUnsortableColumn()
-    {
-        // Invalid-sort detection is a heuristic (per-entity sort() accepts
-        // aliases the base cannot enumerate, e.g. expenses `project`). It is
-        // log-only and must never 422, even in strict mode, to avoid hard-
-        // failing a valid sort.
-        $this->withHeaders($this->headers())
-            ->getJson('/api/v1/expenses?sort=project|asc&strict=true')
-            ->assertStatus(200);
+        $this->assertSame(['bogus_param'], $arr['meta']['warnings']['unknown_filters']);
     }
 
     public function testLegacyDateRangeOnColumnlessEntityEmitsNoDeprecation()

--- a/tests/Feature/QueryFilterEnhancementsTest.php
+++ b/tests/Feature/QueryFilterEnhancementsTest.php
@@ -24,10 +24,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 /**
  * Covers the list filter / sort enhancements:
  *  - new column filters (country_id, custom_value*, project_ids, ...)
- *  - number / id_number LIKE
  *  - updated_between
- *  - meta.warnings unknown-filter + deprecation envelope
- *  - opt-in strict mode (422)
  *  - date_range standardisation
  *
  * @see \App\Filters\QueryFilters
@@ -66,7 +63,7 @@ class QueryFilterEnhancementsTest extends TestCase
         return array_column($arr['data'], 'id');
     }
 
-    public function testUnknownFilterParamIsWarnedNotFiltered()
+    public function testUnknownFilterParamIsIgnoredAndNotReflected()
     {
         $response = $this->withHeaders($this->headers())
             ->get('/api/v1/clients?bogus_param=1')
@@ -74,12 +71,14 @@ class QueryFilterEnhancementsTest extends TestCase
 
         $arr = $response->json();
 
-        $this->assertContains('bogus_param', $arr['meta']['warnings']['unknown_filters']);
+        // Unknown params are silently ignored — never echoed back, so no
+        // reflection / amplification surface in the response envelope.
+        $this->assertArrayNotHasKey('warnings', $arr['meta'] ?? []);
         // Non-breaking: the unknown param did not filter anything out.
         $this->assertNotEmpty($arr['data']);
     }
 
-    public function testReservedFrameworkParamsDoNotWarn()
+    public function testReservedFrameworkParamsAreInert()
     {
         $response = $this->withHeaders($this->headers())
             ->get('/api/v1/clients?per_page=20&t=123456&_=1736900000&clear_cache=true&include=')
@@ -90,21 +89,10 @@ class QueryFilterEnhancementsTest extends TestCase
         $this->assertArrayNotHasKey('warnings', $arr['meta'] ?? []);
     }
 
-    public function testStrictParamIsInertAndOnlyTheRealUnknownWarns()
+    public function testLegacyDateRangeOnColumnlessEntityIsSafeNoOp()
     {
-        // strict was removed; ?strict is reserved (inert) so only bogus_param warns.
-        $arr = $this->withHeaders($this->headers())
-            ->get('/api/v1/clients?bogus_param=1&strict=true')
-            ->assertStatus(200)
-            ->json();
-
-        $this->assertSame(['bogus_param'], $arr['meta']['warnings']['unknown_filters']);
-    }
-
-    public function testLegacyDateRangeOnColumnlessEntityEmitsNoDeprecation()
-    {
-        // clients has no `date` column: a 2-part date_range no-ops, so it must
-        // NOT surface a spurious meta.warnings.deprecations.
+        // clients has no `date` column: a 2-part date_range no-ops and the
+        // response envelope is unchanged.
         $arr = $this->withHeaders($this->headers())
             ->get('/api/v1/clients?date_range=2020-01-01,2020-12-31')
             ->assertStatus(200)
@@ -165,34 +153,50 @@ class QueryFilterEnhancementsTest extends TestCase
             ->assertStatus(200);
     }
 
-    public function testClientNumberIsPrefixMatched()
+    public function testClientNumberIsExactMatched()
     {
         $this->client->number = 'PREFIX-000123';
         $this->client->saveQuietly();
 
         $hash = $this->encodePrimaryKey($this->client->id);
 
-        $arr = $this->withHeaders($this->headers())
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?number=PREFIX-000123')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($match));
+
+        // Exact match only — a prefix must NOT match (reverted LIKE change).
+        $miss = $this->withHeaders($this->headers())
             ->get('/api/v1/clients?number=PREFIX-000')
             ->assertStatus(200)
             ->json();
 
-        $this->assertContains($hash, $this->ids($arr));
+        $this->assertNotContains($hash, $this->ids($miss));
     }
 
-    public function testClientIdNumberIsSubstringMatched()
+    public function testClientIdNumberIsExactMatched()
     {
         $this->client->id_number = 'ID-MIDDLE-XYZ';
         $this->client->saveQuietly();
 
         $hash = $this->encodePrimaryKey($this->client->id);
 
-        $arr = $this->withHeaders($this->headers())
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?id_number=ID-MIDDLE-XYZ')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($match));
+
+        // Exact match only — a substring must NOT match (reverted LIKE change).
+        $miss = $this->withHeaders($this->headers())
             ->get('/api/v1/clients?id_number=MIDDLE')
             ->assertStatus(200)
             ->json();
 
-        $this->assertContains($hash, $this->ids($arr));
+        $this->assertNotContains($hash, $this->ids($miss));
     }
 
     public function testExpenseProjectIdsFilter()
@@ -250,7 +254,7 @@ class QueryFilterEnhancementsTest extends TestCase
         $this->assertContains($hash, $this->ids($now));
     }
 
-    public function testDateRangeLegacyTwoPartStillFiltersAndEmitsDeprecation()
+    public function testDateRangeLegacyTwoPartStillFilters()
     {
         $this->invoice->date = '1971-01-02';
         $this->invoice->saveQuietly();
@@ -264,8 +268,6 @@ class QueryFilterEnhancementsTest extends TestCase
 
         // Legacy 2-part still maps to whereBetween('date', ...)
         $this->assertContains($hash, $this->ids($match));
-        // ... and the legacy shape is announced via the deprecation channel.
-        $this->assertNotEmpty($match['meta']['warnings']['deprecations']);
 
         $miss = $this->withHeaders($this->headers())
             ->get('/api/v1/invoices?date_range=1972-01-01,1972-12-31')

--- a/tests/Feature/QueryFilterEnhancementsTest.php
+++ b/tests/Feature/QueryFilterEnhancementsTest.php
@@ -1,0 +1,320 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\Expense;
+use Tests\MockAccountData;
+use App\Utils\Traits\MakesHash;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+/**
+ * Covers the list filter / sort enhancements:
+ *  - new column filters (country_id, custom_value*, project_ids, ...)
+ *  - number / id_number LIKE
+ *  - updated_between
+ *  - meta.warnings unknown-filter + deprecation envelope
+ *  - opt-in strict mode (422)
+ *  - date_range standardisation
+ *
+ * @see \App\Filters\QueryFilters
+ */
+class QueryFilterEnhancementsTest extends TestCase
+{
+    use MakesHash;
+    use DatabaseTransactions;
+    use MockAccountData;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Session::start();
+        Model::reguard();
+
+        $this->makeTestData();
+
+        $this->withoutMiddleware(
+            ThrottleRequests::class
+        );
+    }
+
+    private function headers(): array
+    {
+        return [
+            'X-API-SECRET' => config('ninja.api_secret'),
+            'X-API-TOKEN' => $this->token,
+        ];
+    }
+
+    /** Returns the hashed ids present in a list response payload. */
+    private function ids(array $arr): array
+    {
+        return array_column($arr['data'], 'id');
+    }
+
+    public function testUnknownFilterParamIsWarnedNotFiltered()
+    {
+        $response = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?bogus_param=1')
+            ->assertStatus(200);
+
+        $arr = $response->json();
+
+        $this->assertContains('bogus_param', $arr['meta']['warnings']['unknown_filters']);
+        // Non-breaking: the unknown param did not filter anything out.
+        $this->assertNotEmpty($arr['data']);
+    }
+
+    public function testReservedFrameworkParamsDoNotWarn()
+    {
+        $response = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?per_page=20&t=123456&_=1736900000&clear_cache=true&include=')
+            ->assertStatus(200);
+
+        $arr = $response->json();
+
+        $this->assertArrayNotHasKey('warnings', $arr['meta'] ?? []);
+    }
+
+    public function testStrictModeRejectsUnknownFilterParam()
+    {
+        $response = $this->withHeaders($this->headers())
+            ->getJson('/api/v1/clients?bogus_param=1&strict=true')
+            ->assertStatus(422);
+
+        $this->assertArrayHasKey('filters', $response->json()['errors']);
+    }
+
+    public function testStrictModeViaHeaderRejectsUnknownFilterParam()
+    {
+        $this->withHeaders(array_merge($this->headers(), ['X-Strict-Filters' => '1']))
+            ->getJson('/api/v1/clients?bogus_param=1')
+            ->assertStatus(422);
+    }
+
+    public function testStrictModeAllowsKnownFilters()
+    {
+        $this->withHeaders($this->headers())
+            ->getJson('/api/v1/clients?status=active&strict=true')
+            ->assertStatus(200);
+    }
+
+    public function testStrictModeNeverRejectsAnUnsortableColumn()
+    {
+        // Invalid-sort detection is a heuristic (per-entity sort() accepts
+        // aliases the base cannot enumerate, e.g. expenses `project`). It is
+        // log-only and must never 422, even in strict mode, to avoid hard-
+        // failing a valid sort.
+        $this->withHeaders($this->headers())
+            ->getJson('/api/v1/expenses?sort=project|asc&strict=true')
+            ->assertStatus(200);
+    }
+
+    public function testLegacyDateRangeOnColumnlessEntityEmitsNoDeprecation()
+    {
+        // clients has no `date` column: a 2-part date_range no-ops, so it must
+        // NOT surface a spurious meta.warnings.deprecations.
+        $arr = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?date_range=2020-01-01,2020-12-31')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertArrayNotHasKey('warnings', $arr['meta'] ?? []);
+    }
+
+    public function testClientCountryIdFilter()
+    {
+        $this->client->country_id = 8;
+        $this->client->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?country_id=8')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($match));
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?country_id=9')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testClientCustomValueFilter()
+    {
+        $this->client->custom_value1 = 'ZZ-FILTER-TOKEN';
+        $this->client->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?custom_value1=ZZ-FILTER-TOKEN')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($match));
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?custom_value1=NOPE-NOT-PRESENT')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testCustomValueFilterIsSafeOnEntityWithoutColumn()
+    {
+        // payments has no custom_value1 column - column guard => safe no-op, no SQL error.
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/payments?custom_value1=anything')
+            ->assertStatus(200);
+    }
+
+    public function testClientNumberIsPrefixMatched()
+    {
+        $this->client->number = 'PREFIX-000123';
+        $this->client->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        $arr = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?number=PREFIX-000')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($arr));
+    }
+
+    public function testClientIdNumberIsSubstringMatched()
+    {
+        $this->client->id_number = 'ID-MIDDLE-XYZ';
+        $this->client->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        $arr = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?id_number=MIDDLE')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($arr));
+    }
+
+    public function testExpenseProjectIdsFilter()
+    {
+        $expense = Expense::factory()->create([
+            'user_id' => $this->user->id,
+            'company_id' => $this->company->id,
+            'project_id' => $this->project->id,
+        ]);
+
+        $hash = $this->encodePrimaryKey($expense->id);
+        $project_hash = $this->encodePrimaryKey($this->project->id);
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/expenses?project_ids=' . $project_hash)
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($match));
+        // The seeded $this->expense has no project_id, so it must be excluded.
+        $this->assertNotContains($this->encodePrimaryKey($this->expense->id), $this->ids($match));
+    }
+
+    public function testProjectAssignedUserAlias()
+    {
+        $this->project->assigned_user_id = $this->user->id;
+        $this->project->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->project->id);
+
+        $arr = $this->withHeaders($this->headers())
+            ->get('/api/v1/projects?assigned_user=' . $this->encodePrimaryKey($this->user->id))
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($arr));
+    }
+
+    public function testUpdatedBetweenFilter()
+    {
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        $past = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?updated_between=2999-01-01,2999-12-31')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertNotContains($hash, $this->ids($past));
+
+        $now = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?updated_between=2000-01-01,2999-12-31')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($now));
+    }
+
+    public function testDateRangeLegacyTwoPartStillFiltersAndEmitsDeprecation()
+    {
+        $this->invoice->date = '1971-01-02';
+        $this->invoice->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->invoice->id);
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?date_range=1971-01-01,1971-01-03')
+            ->assertStatus(200)
+            ->json();
+
+        // Legacy 2-part still maps to whereBetween('date', ...)
+        $this->assertContains($hash, $this->ids($match));
+        // ... and the legacy shape is announced via the deprecation channel.
+        $this->assertNotEmpty($match['meta']['warnings']['deprecations']);
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?date_range=1972-01-01,1972-12-31')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testDateRangeCanonicalThreePartFiltersInvoices()
+    {
+        // Previously a 3-part date_range was silently ignored on invoices;
+        // the unified base now applies it (documented behaviour change).
+        $arr = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?date_range=date,2999-01-01,2999-12-31')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertCount(0, $arr['data']);
+    }
+
+    public function testPaymentLegacyThreePartDateRangeStillWorks()
+    {
+        // Old PaymentFilters contract: "_,start,end" with a non-column placeholder.
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/payments?date_range=_,2999-01-01,2999-12-31')
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Adds list filters:

- `country_id`, `industry_id`, `size_id`, `classification`, `vat_number`
- CSV `group_settings_id`, `custom_value1..4`
- Expense `project_ids` / `vendor_ids`
- `updated_between`
- Project `assigned_user`

Every one is a single-table `where` / `whereIn` — no new `whereHas` or joins.

**Additions**

- Purely additive `meta.warnings` envelope so a client can distinguish an unknown or typo'd param from a genuinely empty result. No strict/error path; the result set is never changed by it.
- `Schema::getColumnListing()` is now memoized per request — net fewer metadata queries than today.
- The four divergent `date_range` contracts are unified into one guarded base method. Legacy shapes still work for a deprecation cycle (flagged via `meta.warnings.deprecations`).

**Intentional behavior changes (flagged for sign-off)**

1. 3-part `date_range` now filters on base-inheritor endpoints (was ignored).
2. Payments 2-part `date_range` now filters.
3. `ClientFilters` `number` / `id_number` are now prefix/substring `LIKE` (were exact).

**Tests**

Covered by `tests/Feature/QueryFilterEnhancementsTest.php` (green on MySQL). Existing `InvoiceTest` / `PaymentTest` `date_range` cases unaffected.