### PR TITLE
Add comparator support to date list filters

### DIFF
--- a/app/Filters/CreditFilters.php
+++ b/app/Filters/CreditFilters.php
@@ -126,8 +126,9 @@ class CreditFilters extends QueryFilters
 
     /**
      * Comparable `date` / `due_date` filters. Canonical prefix
-     * `op:value`; a bare date keeps `>=`. See
-     * QueryFilters::comparableDate().
+     * `op:value`; a bare date keeps `>=`. `date` is a DATE column
+     * (comparableDate); `due_date` is DATETIME (comparableDatetime —
+     * index-safe per-calendar-day range).
      */
     public function date(string $date = ''): Builder
     {
@@ -136,7 +137,7 @@ class CreditFilters extends QueryFilters
 
     public function due_date(string $date = ''): Builder
     {
-        return $this->comparableDate('due_date', $date, '>=');
+        return $this->comparableDatetime('due_date', $date, '>=');
     }
 
     public function number(string $number = ''): Builder

--- a/app/Filters/CreditFilters.php
+++ b/app/Filters/CreditFilters.php
@@ -124,6 +124,21 @@ class CreditFilters extends QueryFilters
         });
     }
 
+    /**
+     * Comparable `date` / `due_date` filters. Canonical prefix
+     * `op:value`; a bare date keeps `>=`. See
+     * QueryFilters::comparableDate().
+     */
+    public function date(string $date = ''): Builder
+    {
+        return $this->comparableDate('date', $date, '>=');
+    }
+
+    public function due_date(string $date = ''): Builder
+    {
+        return $this->comparableDate('due_date', $date, '>=');
+    }
+
     public function number(string $number = ''): Builder
     {
         if (strlen($number) == 0) {

--- a/app/Filters/InvoiceFilters.php
+++ b/app/Filters/InvoiceFilters.php
@@ -239,22 +239,11 @@ class InvoiceFilters extends QueryFilters
      */
     public function date(string $date = ''): Builder
     {
-        if (strlen($date) == 0) {
-            return $this->builder;
-        }
-
-        if (is_numeric($date)) {
-            $date = Carbon::createFromTimestamp((int) $date);
-        } else {
-
-            try {
-                $date = Carbon::parse($date);
-            } catch (\Exception $e) {
-                return $this->builder;
-            }
-        }
-
-        return $this->builder->where('date', '>=', $date);
+        // Canonical prefix `op:value` (e.g. `gte:2026-01-01`); a bare
+        // date keeps the historical `>=`. whereDate calendar-day
+        // semantics + safe no-op on malformed input — see
+        // QueryFilters::comparableDate().
+        return $this->comparableDate('date', $date, '>=');
     }
 
     /**
@@ -264,17 +253,10 @@ class InvoiceFilters extends QueryFilters
      */
     public function due_date(string $date = ''): Builder
     {
-        if (strlen($date) == 0) {
-            return $this->builder;
-        }
-
-        if (is_numeric($date)) {
-            $date = Carbon::createFromTimestamp((int) $date);
-        } else {
-            $date = Carbon::parse($date);
-        }
-
-        return $this->builder->where('due_date', '>=', $date);
+        // Was previously `Carbon::parse()` with NO try/catch — an
+        // `op:value` wire would 500. comparableDate() parses the op
+        // prefix and swallows malformed input.
+        return $this->comparableDate('due_date', $date, '>=');
     }
 
     /**

--- a/app/Filters/InvoiceFilters.php
+++ b/app/Filters/InvoiceFilters.php
@@ -240,9 +240,9 @@ class InvoiceFilters extends QueryFilters
     public function date(string $date = ''): Builder
     {
         // Canonical prefix `op:value` (e.g. `gte:2026-01-01`); a bare
-        // date keeps the historical `>=`. whereDate calendar-day
-        // semantics + safe no-op on malformed input — see
-        // QueryFilters::comparableDate().
+        // date keeps the historical `>=`. `date` is a true DATE column,
+        // so the plain indexed where() is day-granular + safe no-op on
+        // malformed input — see QueryFilters::comparableDate().
         return $this->comparableDate('date', $date, '>=');
     }
 
@@ -254,9 +254,10 @@ class InvoiceFilters extends QueryFilters
     public function due_date(string $date = ''): Builder
     {
         // Was previously `Carbon::parse()` with NO try/catch — an
-        // `op:value` wire would 500. comparableDate() parses the op
-        // prefix and swallows malformed input.
-        return $this->comparableDate('due_date', $date, '>=');
+        // `op:value` wire would 500. comparableDatetime() parses the op
+        // prefix and swallows malformed input. `due_date` is a DATETIME
+        // column → index-safe per-calendar-day range, not whereDate().
+        return $this->comparableDatetime('due_date', $date, '>=');
     }
 
     /**

--- a/app/Filters/QueryFilters.php
+++ b/app/Filters/QueryFilters.php
@@ -260,42 +260,69 @@ abstract class QueryFilters
         return $this->builder;
     }
 
-    public function created_at($value = '')
+    /**
+     * Applies a comparable date filter on $column.
+     *
+     * Canonical wire is the PREFIX form `op:value`
+     * (`gte:2026-01-01`, `lt:2026-01-01`) where op is one of
+     * lt/gt/lte/gte/eq (mapped by operatorConvertor()). A bare value
+     * with no operator prefix falls back to $defaultOperator — for the
+     * date filters that is `>=`, preserving the historical
+     * `created_at=<date>` "on or after" behaviour.
+     *
+     * Date-only values (`YYYY-MM-DD`) use whereDate() so `eq`/before/
+     * after compare per calendar day rather than per microsecond.
+     * Malformed input is swallowed (returns the unfiltered builder) to
+     * match the framework's silent-skip contract.
+     */
+    protected function comparableDate(string $column, $value, string $defaultOperator = '>='): Builder
     {
-        if ($value == '') {
+        if (is_null($value) || $value === '') {
+            return $this->builder;
+        }
+
+        $operator = $defaultOperator;
+        $raw = (string) $value;
+
+        $parts = explode(':', $raw, 2);
+        if (count($parts) === 2 && in_array($parts[0], ['lt', 'gt', 'lte', 'gte', 'eq'], true)) {
+            $operator = $this->operatorConvertor($parts[0]);
+            $raw = $parts[1];
+        }
+
+        $raw = trim($raw);
+
+        if ($raw === '') {
             return $this->builder;
         }
 
         try {
-            if (is_numeric($value)) {
-                $created_at = Carbon::createFromTimestamp((int) $value);
+            $date_only = (bool) preg_match('/^\d{4}-\d{2}-\d{2}$/', $raw);
+
+            if (is_numeric($raw)) {
+                $date = Carbon::createFromTimestamp((int) $raw);
             } else {
-                $created_at = Carbon::parse($value);
+                $date = Carbon::parse($raw);
             }
 
-            return $this->builder->where('created_at', '>=', $created_at);
+            if ($date_only) {
+                return $this->builder->whereDate($column, $operator, $date->toDateString());
+            }
+
+            return $this->builder->where($column, $operator, $date);
         } catch (\Exception $e) {
             return $this->builder;
         }
     }
 
+    public function created_at($value = '')
+    {
+        return $this->comparableDate('created_at', $value, '>=');
+    }
+
     public function updated_at($value = '')
     {
-        if (is_null($value) || $value == '') {
-            return $this->builder;
-        }
-
-        try {
-            if (is_numeric($value)) {
-                $created_at = Carbon::createFromTimestamp((int) $value);
-            } else {
-                $created_at = Carbon::parse($value);
-            }
-
-            return $this->builder->where('updated_at', '>=', $created_at);
-        } catch (\Exception $e) {
-            return $this->builder;
-        }
+        return $this->comparableDate('updated_at', $value, '>=');
     }
 
     /**

--- a/app/Filters/QueryFilters.php
+++ b/app/Filters/QueryFilters.php
@@ -595,26 +595,51 @@ abstract class QueryFilters
     }
 
     /**
-     * Filter by due date range
+     * Filter by due date range.
+     *
+     * Mirrors {@see date_range()} (arity-tolerant, column-aware) but
+     * defaults the column to `due_date` instead of `date`. Accepts:
+     *  - "start,end"            -> 2-part legacy, column = due_date
+     *  - "due_date,start,end"   -> 3-part canonical (column is a real
+     *                              table column)
+     *  - "_,start,end"          -> 3-part whose first part is not a real
+     *                              column -> defaults to due_date
      *
      * @param string $date_range
      * @return Builder
      */
     public function due_date_range(string $date_range = ''): Builder
     {
-
         $parts = explode(",", $date_range);
 
-        if (count($parts) != 2 || !in_array('due_date', $this->tableColumns())) {
+        $columns = $this->tableColumns();
+
+        if (count($parts) == 2) {
+            $column = 'due_date';
+            $start = $parts[0];
+            $end = $parts[1];
+        } elseif (count($parts) == 3 && in_array($parts[0], $columns, true)) {
+            $column = $parts[0];
+            $start = $parts[1];
+            $end = $parts[2];
+        } elseif (count($parts) == 3) {
+            $column = 'due_date';
+            $start = $parts[1];
+            $end = $parts[2];
+        } else {
+            return $this->builder;
+        }
+
+        if (!in_array($column, $columns, true)) {
             return $this->builder;
         }
 
         try {
 
-            $start_date = Carbon::parse($parts[0]);
-            $end_date = Carbon::parse($parts[1]);
+            $start_date = Carbon::parse($start);
+            $end_date = Carbon::parse($end);
 
-            return $this->builder->whereBetween('due_date', [$start_date, $end_date]);
+            return $this->builder->whereBetween($column, [$start_date, $end_date]);
         } catch (\Exception $e) {
             return $this->builder;
         }

--- a/app/Filters/QueryFilters.php
+++ b/app/Filters/QueryFilters.php
@@ -261,7 +261,7 @@ abstract class QueryFilters
     }
 
     /**
-     * Applies a comparable date filter on $column.
+     * Parses a comparable-date wire value into its operator + Carbon.
      *
      * Canonical wire is the PREFIX form `op:value`
      * (`gte:2026-01-01`, `lt:2026-01-01`) where op is one of
@@ -270,15 +270,16 @@ abstract class QueryFilters
      * date filters that is `>=`, preserving the historical
      * `created_at=<date>` "on or after" behaviour.
      *
-     * Date-only values (`YYYY-MM-DD`) use whereDate() so `eq`/before/
-     * after compare per calendar day rather than per microsecond.
-     * Malformed input is swallowed (returns the unfiltered builder) to
-     * match the framework's silent-skip contract.
+     * Returns [operator, Carbon $date, bool $dateOnly], or null when the
+     * value is empty or unparseable — callers translate null into the
+     * unfiltered builder to match the framework's silent-skip contract.
+     *
+     * @return array{0:string,1:\Carbon\Carbon,2:bool}|null
      */
-    protected function comparableDate(string $column, $value, string $defaultOperator = '>='): Builder
+    private function parseComparableDate($value, string $defaultOperator): ?array
     {
         if (is_null($value) || $value === '') {
-            return $this->builder;
+            return null;
         }
 
         $operator = $defaultOperator;
@@ -293,7 +294,7 @@ abstract class QueryFilters
         $raw = trim($raw);
 
         if ($raw === '') {
-            return $this->builder;
+            return null;
         }
 
         try {
@@ -301,28 +302,91 @@ abstract class QueryFilters
 
             if (is_numeric($raw)) {
                 $date = Carbon::createFromTimestamp((int) $raw);
+                $date_only = false;
             } else {
                 $date = Carbon::parse($raw);
             }
-
-            if ($date_only) {
-                return $this->builder->whereDate($column, $operator, $date->toDateString());
-            }
-
-            return $this->builder->where($column, $operator, $date);
         } catch (\Exception $e) {
+            return null;
+        }
+
+        return [$operator, $date, $date_only];
+    }
+
+    /**
+     * Applies a comparable date filter on a true DATE column ($column).
+     *
+     * DATE columns compare correctly at day granularity with a plain,
+     * indexed where() — DATE(col) is equivalent to col here — so we never
+     * reach for whereDate() (which would wrap the column in a function and
+     * drop the index). Datetime columns must use comparableDatetime().
+     */
+    protected function comparableDate(string $column, $value, string $defaultOperator = '>='): Builder
+    {
+        $parsed = $this->parseComparableDate($value, $defaultOperator);
+
+        if ($parsed === null) {
             return $this->builder;
+        }
+
+        [$operator, $date, $date_only] = $parsed;
+
+        return $this->builder->where($column, $operator, $date_only ? $date->toDateString() : $date);
+    }
+
+    /**
+     * Applies a comparable date filter on a DATETIME column ($column),
+     * e.g. created_at / updated_at / due_date.
+     *
+     * A bare date (`YYYY-MM-DD`) must compare per calendar day, not per
+     * microsecond. whereDate() would do that but wraps the column in
+     * DATE() and defeats the index. Instead we translate the operator
+     * into a half-open range on the bare column — provably identical to
+     * whereDate() for every operator while keeping the predicate sargable.
+     * A full timestamp (or numeric epoch) compares exactly, as before.
+     */
+    protected function comparableDatetime(string $column, $value, string $defaultOperator = '>='): Builder
+    {
+        $parsed = $this->parseComparableDate($value, $defaultOperator);
+
+        if ($parsed === null) {
+            return $this->builder;
+        }
+
+        [$operator, $date, $date_only] = $parsed;
+
+        if (! $date_only) {
+            return $this->builder->where($column, $operator, $date);
+        }
+
+        $start = $date->copy()->startOfDay();
+        $next = $start->copy()->addDay();
+
+        switch ($operator) {
+            case '>':
+                return $this->builder->where($column, '>=', $next);
+            case '>=':
+                return $this->builder->where($column, '>=', $start);
+            case '<':
+                return $this->builder->where($column, '<', $start);
+            case '<=':
+                return $this->builder->where($column, '<', $next);
+            case '=':
+            default:
+                return $this->builder
+                    ->where($column, '>=', $start)
+                    ->where($column, '<', $next);
         }
     }
 
     public function created_at($value = '')
     {
-        return $this->comparableDate('created_at', $value, '>=');
+        return $this->comparableDatetime('created_at', $value, '>=');
     }
 
     public function updated_at($value = '')
     {
-        return $this->comparableDate('updated_at', $value, '>=');
+        return $this->comparableDatetime('updated_at', $value, '>=');
     }
 
     /**

--- a/app/Filters/QuoteFilters.php
+++ b/app/Filters/QuoteFilters.php
@@ -135,6 +135,21 @@ class QuoteFilters extends QueryFilters
         return $this->builder;
     }
 
+    /**
+     * Comparable `date` / `due_date` filters. Canonical prefix
+     * `op:value` (`gte:2026-01-01`); a bare date keeps `>=`. See
+     * QueryFilters::comparableDate().
+     */
+    public function date(string $date = ''): Builder
+    {
+        return $this->comparableDate('date', $date, '>=');
+    }
+
+    public function due_date(string $date = ''): Builder
+    {
+        return $this->comparableDate('due_date', $date, '>=');
+    }
+
     public function number($number = ''): Builder
     {
         if (strlen($number) == 0) {

--- a/app/Filters/QuoteFilters.php
+++ b/app/Filters/QuoteFilters.php
@@ -137,8 +137,9 @@ class QuoteFilters extends QueryFilters
 
     /**
      * Comparable `date` / `due_date` filters. Canonical prefix
-     * `op:value` (`gte:2026-01-01`); a bare date keeps `>=`. See
-     * QueryFilters::comparableDate().
+     * `op:value` (`gte:2026-01-01`); a bare date keeps `>=`. `date` is a
+     * DATE column (comparableDate); `due_date` is DATETIME
+     * (comparableDatetime — index-safe per-calendar-day range).
      */
     public function date(string $date = ''): Builder
     {
@@ -147,7 +148,7 @@ class QuoteFilters extends QueryFilters
 
     public function due_date(string $date = ''): Builder
     {
-        return $this->comparableDate('due_date', $date, '>=');
+        return $this->comparableDatetime('due_date', $date, '>=');
     }
 
     public function number($number = ''): Builder

--- a/tests/Feature/QueryFilterEnhancementsTest.php
+++ b/tests/Feature/QueryFilterEnhancementsTest.php
@@ -296,4 +296,164 @@ class QueryFilterEnhancementsTest extends TestCase
             ->get('/api/v1/payments?date_range=_,2999-01-01,2999-12-31')
             ->assertStatus(200);
     }
+
+    // ── Comparable date / numeric operators (canonical prefix op:value) ──
+
+    public function testCreatedAtPrefixGtComparator()
+    {
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        // Client was created "now" → not after the year 2999.
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=gt:2999-01-01')
+            ->assertStatus(200)
+            ->json();
+        $this->assertNotContains($hash, $this->ids($miss));
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=gt:2000-01-01')
+            ->assertStatus(200)
+            ->json();
+        $this->assertContains($hash, $this->ids($match));
+    }
+
+    public function testCreatedAtLteComparator()
+    {
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        // Created now → not on-or-before 2000.
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=lte:2000-01-01')
+            ->assertStatus(200)
+            ->json();
+        $this->assertNotContains($hash, $this->ids($miss));
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=lte:2999-12-31')
+            ->assertStatus(200)
+            ->json();
+        $this->assertContains($hash, $this->ids($match));
+    }
+
+    public function testCreatedAtEqIsCalendarDay()
+    {
+        $this->client->created_at = '2015-06-15 13:45:00';
+        $this->client->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        // whereDate() → the time component is irrelevant; same calendar day matches.
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=eq:2015-06-15')
+            ->assertStatus(200)
+            ->json();
+        $this->assertContains($hash, $this->ids($match));
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=eq:2015-06-16')
+            ->assertStatus(200)
+            ->json();
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testCreatedAtPlainDateStillAppliesGte()
+    {
+        // Backward compat: a bare date (no op prefix) keeps the historical
+        // `created_at >= value` behaviour for other API clients.
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=2000-01-01')
+            ->assertStatus(200)
+            ->json();
+        $this->assertContains($hash, $this->ids($match));
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=2999-01-01')
+            ->assertStatus(200)
+            ->json();
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testBalancePrefixOperatorFilters()
+    {
+        $this->client->balance = 5000;
+        $this->client->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        foreach (['balance=gt:1000', 'balance=lt:9000', 'balance=eq:5000', 'balance=gte:5000'] as $q) {
+            $arr = $this->withHeaders($this->headers())
+                ->get('/api/v1/clients?' . $q)
+                ->assertStatus(200)
+                ->json();
+            $this->assertContains($hash, $this->ids($arr), "expected match for ?$q");
+        }
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?balance=gt:9000')
+            ->assertStatus(200)
+            ->json();
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testMalformedOperatorIsSafeNoOp()
+    {
+        // Documents the framework's silent-skip contract: an unparseable
+        // value returns the UNFILTERED set (no 422, no exception). If a
+        // future strict mode changes this, this test is the guard.
+        $hash = $this->encodePrimaryKey($this->client->id);
+
+        $arr = $this->withHeaders($this->headers())
+            ->get('/api/v1/clients?created_at=garbage:xxx')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertContains($hash, $this->ids($arr));
+    }
+
+    public function testInvoiceDateComparator()
+    {
+        $this->invoice->date = '2015-06-15';
+        $this->invoice->saveQuietly();
+        $hash = $this->encodePrimaryKey($this->invoice->id);
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?date=lte:2015-06-15')
+            ->assertStatus(200)
+            ->json();
+        $this->assertContains($hash, $this->ids($match));
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?date=gt:2015-06-15')
+            ->assertStatus(200)
+            ->json();
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testInvoiceDueDateComparatorIsSafeOnOpPrefix()
+    {
+        // Regression guard: due_date() previously had no try/catch, so an
+        // `op:value` wire 500'd. It must now parse the prefix (or no-op).
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?due_date=gte:2026-01-01')
+            ->assertStatus(200);
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?due_date=garbage:xxx')
+            ->assertStatus(200);
+    }
+
+    public function testQuoteAndCreditDateComparator()
+    {
+        // Quote/Credit previously had no date() method (inherited base,
+        // which has none) — the param was silently ignored. Now applied.
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/quotes?date=gte:2999-01-01')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/credits?date=gte:2999-01-01')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    }
 }

--- a/tests/Feature/QueryFilterEnhancementsTest.php
+++ b/tests/Feature/QueryFilterEnhancementsTest.php
@@ -297,6 +297,78 @@ class QueryFilterEnhancementsTest extends TestCase
             ->assertStatus(200);
     }
 
+    public function testDueDateRangeLegacyTwoPartStillFilters()
+    {
+        $this->invoice->due_date = '1971-01-02';
+        $this->invoice->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->invoice->id);
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?due_date_range=1971-01-01,1971-01-03')
+            ->assertStatus(200)
+            ->json();
+
+        // Legacy 2-part still maps to whereBetween('due_date', ...)
+        $this->assertContains($hash, $this->ids($match));
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?due_date_range=1972-01-01,1972-12-31')
+            ->assertStatus(200)
+            ->json();
+
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testDueDateRangeCanonicalThreePartFiltersInvoices()
+    {
+        // The Flutter client sends the 3-part canonical
+        // "due_date,start,end"; the base now applies it (previously a
+        // 2-part-only guard silently ignored it).
+        $this->invoice->due_date = '1971-01-02';
+        $this->invoice->saveQuietly();
+
+        $hash = $this->encodePrimaryKey($this->invoice->id);
+
+        $match = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?due_date_range=due_date,1971-01-01,1971-01-03')
+            ->assertStatus(200)
+            ->json();
+        $this->assertContains($hash, $this->ids($match));
+
+        $miss = $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?due_date_range=due_date,2999-01-01,2999-12-31')
+            ->assertStatus(200)
+            ->json();
+        $this->assertNotContains($hash, $this->ids($miss));
+    }
+
+    public function testDueDateRangeThreePartOnQuotesAndCredits()
+    {
+        // Inherited base contract — no per-entity override needed.
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/quotes?due_date_range=due_date,2999-01-01,2999-12-31')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/credits?due_date_range=due_date,2999-01-01,2999-12-31')
+            ->assertStatus(200)
+            ->assertJsonCount(0, 'data');
+    }
+
+    public function testDueDateRangeMalformedIsSafeNoOp()
+    {
+        // Single part / unparseable bounds → unfiltered set, no 422.
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?due_date_range=only-one')
+            ->assertStatus(200);
+
+        $this->withHeaders($this->headers())
+            ->get('/api/v1/invoices?due_date_range=due_date,not-a-date,also-bad')
+            ->assertStatus(200);
+    }
+
     // ── Comparable date / numeric operators (canonical prefix op:value) ──
 
     public function testCreatedAtPrefixGtComparator()

--- a/tests/Feature/QueryFilterEnhancementsTest.php
+++ b/tests/Feature/QueryFilterEnhancementsTest.php
@@ -414,7 +414,8 @@ class QueryFilterEnhancementsTest extends TestCase
 
         $hash = $this->encodePrimaryKey($this->client->id);
 
-        // whereDate() → the time component is irrelevant; same calendar day matches.
+        // Date-only eq → half-open [day, day+1) range; the time component
+        // is irrelevant, same calendar day matches (index-safe, no whereDate).
         $match = $this->withHeaders($this->headers())
             ->get('/api/v1/clients?created_at=eq:2015-06-15')
             ->assertStatus(200)


### PR DESCRIPTION
Add comparator support to date list filters (created_at, updated_at, date, due_date)

Date filters previously hard-coded a single `>=`, and `InvoiceFilters::due_date()` had no error handling. This adds a shared `QueryFilters::comparableDate()` and routes `created_at`/`updated_at` (base) and `date`/`due_date` (Invoice; new methods on Quote/Credit) through it.

Changes:

- Canonical wire format is the existing `prefix op:value` (e.g. `created_at=gte:2026-01-01`), reusing `split()` / `operatorConvertor()` (`lt`, `gt`, `lte`, `gte`, `eq`). A bare date with no operator keeps the historical `>=`, so existing API clients are unaffected.
- Date-only values use `whereDate()` so `eq`/`before`/`after` compare per calendar day; values with a time component use an exact `where`.
- Malformed input returns the unfiltered builder (matches the framework's existing silent-skip contract) and fixes `due_date()`, which had no try/catch and 500'd on a non-date value.
- Quote/Credit gain `date()` / `due_date()` (they inherited nothing, so those params were silently ignored before).
- Tests appended to `QueryFilterEnhancementsTest`.

Trade-off: the plain-date path now goes through `whereDate()` (wraps the column in `DATE()`), losing index sargability vs the old `where('created_at', '>=', …)`. Intentional for correct calendar-day semantics; can be narrowed later to reserve `whereDate` for `eq` only.