### PR TITLE
Fix Google account connection — fall back to access_token path

### DIFF
--- a/app/Http/Controllers/ConnectedAccountController.php
+++ b/app/Http/Controllers/ConnectedAccountController.php
@@ -147,7 +147,14 @@ class ConnectedAccountController extends BaseController
 
         $google = new Google();
 
-        $user = $google->getTokenResponse(request()->input('id_token'));
+        // The google_sign_in v7 SDK used by the Flutter client no longer issues a
+        // usable id_token, so it sends only an access_token. Verify the id_token
+        // when present, otherwise fall back to the access_token (userinfo) path.
+        if (request()->filled('id_token')) {
+            $user = $google->getTokenResponse(request()->input('id_token'));
+        } elseif (request()->filled('access_token')) {
+            $user = $google->harvestUser(request()->input('access_token'));
+        }
 
         if ($user) {
             $client = new Google_Client();


### PR DESCRIPTION
handleGoogleOauth() unconditionally called getTokenResponse() -> verifyIdToken(). The google_sign_in v7 SDK in the Flutter client no longer issues a usable id_token, so /connected_account receives only an access_token; passing the null id_token into verifyIdToken() throws "id_token must be passed in or set as part of setAccessToken".

Branch on the token type, mirroring LoginController::handleGoogleOauth(): verify the id_token when present, otherwise fall back to Google::harvestUser($access_token), which resolves the user via Google's userinfo endpoint. Uses filled() so an empty/null id_token key is handled.