### PR TITLE
feat: add PHP 8.5 compatibility support

### DIFF
--- a/app/Exceptions/PeppolValidationException.php
+++ b/app/Exceptions/PeppolValidationException.php
@@ -18,7 +18,7 @@ class PeppolValidationException extends Exception
 {
     protected string $field = '';
 
-    public function __construct($message, $field, $code = 0, Exception $previous = null)
+    public function __construct($message, $field, $code = 0, ?Exception $previous = null)
     {
         // Store the custom data
         $this->field = $field;

--- a/app/Factory/PurchaseOrderFactory.php
+++ b/app/Factory/PurchaseOrderFactory.php
@@ -17,7 +17,7 @@ use App\Models\PurchaseOrder;
 
 class PurchaseOrderFactory
 {
-    public static function create(int $company_id, int $user_id, object $settings = null, Client $client = null): PurchaseOrder
+    public static function create(int $company_id, int $user_id, ?object $settings = null, ?Client $client = null): PurchaseOrder
     {
         $purchase_order = new PurchaseOrder();
         $purchase_order->status_id = PurchaseOrder::STATUS_DRAFT;

--- a/app/Jobs/Quote/QuoteWorkflowSettings.php
+++ b/app/Jobs/Quote/QuoteWorkflowSettings.php
@@ -40,7 +40,7 @@ class QuoteWorkflowSettings implements ShouldQueue
      * @param Quote $quote
      * @param Client|null $client
      */
-    public function __construct(Quote $quote, Client $client = null)
+    public function __construct(Quote $quote, ?Client $client = null)
     {
         $this->quote = $quote;
         $this->client = $client ?? $quote->client;

--- a/app/PaymentDrivers/EwayPaymentDriver.php
+++ b/app/PaymentDrivers/EwayPaymentDriver.php
@@ -135,7 +135,7 @@ class EwayPaymentDriver extends BaseDriver
         return (new Token($this))->tokenBilling($cgt, $payment_hash);
     }
 
-    public function processWebhookRequest(PaymentWebhookRequest $request, Payment $payment = null) {}
+    public function processWebhookRequest(PaymentWebhookRequest $request, ?Payment $payment = null) {}
 
     public function convertAmount($amount)
     {

--- a/app/PaymentDrivers/PayFastPaymentDriver.php
+++ b/app/PaymentDrivers/PayFastPaymentDriver.php
@@ -200,7 +200,7 @@ class PayFastPaymentDriver extends BaseDriver
         return hash_equals(md5($query), $sig);
     }
 
-    public function processWebhookRequest(PaymentNotificationWebhookRequest $request, Payment $payment = null)
+    public function processWebhookRequest(PaymentNotificationWebhookRequest $request, ?Payment $payment = null)
     {
         $data = $request->all();
         // nlog("payfast");

--- a/app/PaymentDrivers/PaytracePaymentDriver.php
+++ b/app/PaymentDrivers/PaytracePaymentDriver.php
@@ -183,7 +183,7 @@ class PaytracePaymentDriver extends BaseDriver
         $this->processUnsuccessfulTransaction($data, false);
     }
 
-    public function processWebhookRequest(PaymentWebhookRequest $request, Payment $payment = null) {}
+    public function processWebhookRequest(PaymentWebhookRequest $request, ?Payment $payment = null) {}
 
     /*Helpers*/
     private function generateAuthHeaders()

--- a/app/PaymentDrivers/Sample/PaymentDriver.php
+++ b/app/PaymentDrivers/Sample/PaymentDriver.php
@@ -95,5 +95,5 @@ class PaymentDriver extends BaseDriver
         //this is your custom implementation from here
     }
 
-    public function processWebhookRequest(PaymentWebhookRequest $request, Payment $payment = null) {}
+    public function processWebhookRequest(PaymentWebhookRequest $request, ?Payment $payment = null) {}
 }

--- a/app/PaymentDrivers/StripeConnectPaymentDriver.php
+++ b/app/PaymentDrivers/StripeConnectPaymentDriver.php
@@ -17,7 +17,7 @@ use App\Models\CompanyGateway;
 
 class StripeConnectPaymentDriver extends StripePaymentDriver
 {
-    public function __construct(CompanyGateway $company_gateway, Client $client = null, $invitation = false)
+    public function __construct(CompanyGateway $company_gateway, ?Client $client = null, $invitation = false)
     {
         parent::__construct($company_gateway, $client, $invitation);
 

--- a/app/PaymentDrivers/WePayPaymentDriver.php
+++ b/app/PaymentDrivers/WePayPaymentDriver.php
@@ -149,7 +149,7 @@ class WePayPaymentDriver extends BaseDriver
         return $this->payment_method->tokenBilling($cgt, $payment_hash);
     }
 
-    public function processWebhookRequest(PaymentWebhookRequest $request, Payment $payment = null)
+    public function processWebhookRequest(PaymentWebhookRequest $request, ?Payment $payment = null)
     {
         $this->init();
     }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "type": "project",
     "require": {
-        "php": ">=8.2",
+        "php": "^8.2|^8.3|^8.4|^8.5",
         "ext-bcmath": "*",
         "ext-curl": "*",
         "ext-dom": "*",


### PR DESCRIPTION
Fixes #11932
**Summary**

Adds PHP 8.5 compatibility as requested in #11932.

**Changes**

Widened PHP constraint to `^8.2|^8.3|^8.4|^8.5` in composer.json
Fixed implicit nullable typed parameters deprecated in PHP 8.5:
`PaytracePaymentDriver`
`WePayPaymentDriver`
`EwayPaymentDriver`
`Sample/PaymentDriver`
`PayFastPaymentDriver`
`StripeConnectPaymentDriver`
`PeppolValidationException`
`PurchaseOrderFactory`
`QuoteWorkflowSettings`

**Notes**
 No behaviour changes, compatibility fixes only
 The bus error (SIGBUS) is an environment-level issue from native extensions, not fixable in PHP code

