### PR TITLE
[Security] Add allowed_classes to Verifactu unserialize() to prevent PHP Object Injection

### DIFF
--- a/app/Services/EDocument/Standards/Verifactu.php
+++ b/app/Services/EDocument/Standards/Verifactu.php
@@ -200,7 +200,7 @@ class Verifactu extends AbstractService
 
             // Intentar usar el importe que realmente se envió a la AEAT (sin retenciones)
             try {
-                $state = @unserialize($log->state);
+                $state = @unserialize($log->state, ['allowed_classes' => [VerifactuInvoice::class]]);
 
                 if ($state instanceof VerifactuInvoice) {
                     $stateTotal = $state->getImporteTotal();

--- a/app/Services/EDocument/Standards/Verifactu/Models/IDFactura.php
+++ b/app/Services/EDocument/Standards/Verifactu/Models/IDFactura.php
@@ -95,7 +95,8 @@ class IDFactura extends BaseXmlModel
 
     public static function unserialize(string $data): self
     {
-        $object = unserialize($data);
+        // Restrict deserialization to expected Verifactu model classes.
+        $object = unserialize($data, ['allowed_classes' => [self::class]]);
 
         if (!$object instanceof self) {
             throw new \InvalidArgumentException('Invalid serialized data - not an IDFactura object');

--- a/app/Services/EDocument/Standards/Verifactu/Models/Invoice.php
+++ b/app/Services/EDocument/Standards/Verifactu/Models/Invoice.php
@@ -1314,7 +1314,24 @@ class Invoice extends BaseXmlModel implements XmlModelInterface
 
     public static function unserialize(string $data): self
     {
-        $object = unserialize($data);
+        // Restrict deserialization to the Verifactu model classes to prevent
+        // PHP Object Injection via the verifactu_log.state database column.
+        $object = unserialize($data, [
+            'allowed_classes' => [
+                self::class,
+                IDFactura::class,
+                Encadenamiento::class,
+                RegistroAnterior::class,
+                RegistroAnulacion::class,
+                SistemaInformatico::class,
+                Desglose::class,
+                DesgloseRectificacion::class,
+                DetalleDesglose::class,
+                IDOtro::class,
+                PersonaFisicaJuridica::class,
+                Cupon::class,
+            ],
+        ]);
 
         if (!$object instanceof self) {
             throw new \InvalidArgumentException('Invalid serialized data - not an Invoice object');


### PR DESCRIPTION
## Summary

The Verifactu e-document module stores serialized PHP objects in the `verifactu_log.state` database column and deserializes them in three places without restricting which PHP classes may be instantiated.

An attacker who can write to the `verifactu_log` table (e.g. via SQL injection elsewhere, compromised admin account, or elevated privileges) can inject a crafted serialized payload that triggers PHP Object Injection, potentially leading to Remote Code Execution via gadget chains available in the application's dependencies.

## Affected locations

| File | Method | Data source |
|------|--------|-------------|
| `app/Services/EDocument/Standards/Verifactu/Models/Invoice.php` | `Invoice::unserialize()` | `verifactu_log.state` (DB) |
| `app/Services/EDocument/Standards/Verifactu/Models/IDFactura.php` | `IDFactura::unserialize()` | `verifactu_log.state` (DB) |
| `app/Services/EDocument/Standards/Verifactu.php` | QR generation (line ~203) | `$log->state` (DB) |

## Fix

Add `allowed_classes` to each `unserialize()` call, restricting deserialization to the specific Verifactu model classes that are legitimately stored:

- `Invoice::unserialize()` — allows all Verifactu model classes (the Invoice object graph)
- `IDFactura::unserialize()` — allows only `IDFactura::class`  
- `Verifactu.php` QR path — allows only `VerifactuInvoice` (alias for `Invoice`)

## Security Impact

PHP Object Injection (CVE class) — severity depends on available gadget chains in the dependency tree (Laravel, common PHP libraries). With `allowed_classes` set to the specific expected classes, gadget chains from third-party libraries are blocked entirely.
