### PR TITLE
security: add allowed_classes to Verifactu model unserialize() to prevent PHP Object Injection

### DIFF
--- a/app/Services/EDocument/Standards/Verifactu.php
+++ b/app/Services/EDocument/Standards/Verifactu.php
@@ -200,7 +200,7 @@ class Verifactu extends AbstractService
 
             // Intentar usar el importe que realmente se envió a la AEAT (sin retenciones)
             try {
-                $state = @unserialize($log->state);
+                $state = @unserialize($log->state, ['allowed_classes' => [\App\Services\EDocument\Standards\Verifactu\Models\Invoice::class]]);
 
                 if ($state instanceof VerifactuInvoice) {
                     $stateTotal = $state->getImporteTotal();

--- a/app/Services/EDocument/Standards/Verifactu/Models/IDFactura.php
+++ b/app/Services/EDocument/Standards/Verifactu/Models/IDFactura.php
@@ -95,7 +95,7 @@ class IDFactura extends BaseXmlModel
 
     public static function unserialize(string $data): self
     {
-        $object = unserialize($data);
+        $object = unserialize($data, ['allowed_classes' => [self::class, BaseXmlModel::class]]);
 
         if (!$object instanceof self) {
             throw new \InvalidArgumentException('Invalid serialized data - not an IDFactura object');

--- a/app/Services/EDocument/Standards/Verifactu/Models/Invoice.php
+++ b/app/Services/EDocument/Standards/Verifactu/Models/Invoice.php
@@ -1314,7 +1314,23 @@ class Invoice extends BaseXmlModel implements XmlModelInterface
 
     public static function unserialize(string $data): self
     {
-        $object = unserialize($data);
+        $object = unserialize($data, [
+            'allowed_classes' => [
+                self::class,
+                BaseXmlModel::class,
+                SistemaInformatico::class,
+                PersonaFisicaJuridica::class,
+                RegistroAnterior::class,
+                Desglose::class,
+                DetalleDesglose::class,
+                DesgloseRectificacion::class,
+                Encadenamiento::class,
+                IDFactura::class,
+                IDOtro::class,
+                Cupon::class,
+                RegistroAnulacion::class,
+            ],
+        ]);
 
         if (!$object instanceof self) {
             throw new \InvalidArgumentException('Invalid serialized data - not an Invoice object');


### PR DESCRIPTION
## What

`Invoice::unserialize()`, `IDFactura::unserialize()`, and the Verifactu log state reader all call PHP's `unserialize()` on data read from the database (`verifactu_logs.state`) without specifying an `allowed_classes` restriction.

## Why it matters

When `unserialize()` runs without `allowed_classes`, PHP will instantiate any class available in the autoloader that appears in the serialized payload. An attacker who can write to the `verifactu_logs.state` column — through a SQL injection in a related endpoint, or through a compromised admin account — can craft a PHP Object Injection payload that triggers a gadget chain. Depending on what gadget classes are available in the Composer dependency tree, this can lead to arbitrary code execution.

## The fix

Each `unserialize()` call now passes an explicit `allowed_classes` list restricted to the model classes that legitimately appear in the serialized state. Any other class becomes `__PHP_Incomplete_Class`, and the existing `instanceof` guard immediately rejects it before any further processing. No behavior changes for valid data.

- `Invoice::unserialize()`: restricted to the BaseXmlModel subclasses that Invoice can contain
- `IDFactura::unserialize()`: restricted to `[IDFactura::class, BaseXmlModel::class]`
- `Verifactu.php` state reader: restricted to `[Invoice::class]`