### PR TITLE
security: add allowed_classes to unserialize() in Verifactu models to prevent PHP Object Injection

### DIFF
--- a/app/Services/EDocument/Standards/Verifactu.php
+++ b/app/Services/EDocument/Standards/Verifactu.php
@@ -200,7 +200,7 @@ class Verifactu extends AbstractService
 
             // Intentar usar el importe que realmente se envió a la AEAT (sin retenciones)
             try {
-                $state = @unserialize($log->state);
+                $state = @unserialize($log->state, ['allowed_classes' => [\App\Services\EDocument\Standards\Verifactu\Models\Invoice::class]]);
 
                 if ($state instanceof VerifactuInvoice) {
                     $stateTotal = $state->getImporteTotal();

--- a/app/Services/EDocument/Standards/Verifactu/Models/IDFactura.php
+++ b/app/Services/EDocument/Standards/Verifactu/Models/IDFactura.php
@@ -95,7 +95,7 @@ class IDFactura extends BaseXmlModel
 
     public static function unserialize(string $data): self
     {
-        $object = unserialize($data);
+        $object = unserialize($data, ['allowed_classes' => [self::class]]);
 
         if (!$object instanceof self) {
             throw new \InvalidArgumentException('Invalid serialized data - not an IDFactura object');

--- a/app/Services/EDocument/Standards/Verifactu/Models/Invoice.php
+++ b/app/Services/EDocument/Standards/Verifactu/Models/Invoice.php
@@ -1314,7 +1314,7 @@ class Invoice extends BaseXmlModel implements XmlModelInterface
 
     public static function unserialize(string $data): self
     {
-        $object = unserialize($data);
+        $object = unserialize($data, ['allowed_classes' => [self::class]]);
 
         if (!$object instanceof self) {
             throw new \InvalidArgumentException('Invalid serialized data - not an Invoice object');


### PR DESCRIPTION
## Summary

Three `unserialize()` calls in the Verifactu e-invoicing implementation lack `allowed_classes` restrictions, exposing a PHP Object Injection vector if attacker-controlled data reaches these call sites.

### Affected files

| File | Location | Fix |
|------|----------|-----|
| `app/Services/EDocument/Standards/Verifactu/Models/Invoice.php` | `Invoice::unserialize()` | `allowed_classes => [self::class]` |
| `app/Services/EDocument/Standards/Verifactu/Models/IDFactura.php` | `IDFactura::unserialize()` | `allowed_classes => [self::class]` |
| `app/Services/EDocument/Standards/Verifactu.php` | `@unserialize($log->state)` | `allowed_classes => [Invoice::class]` |

### The problem

`Invoice::unserialize()` and `IDFactura::unserialize()` both call bare `unserialize()` and only check `instanceof self` afterwards. **PHP object constructors and destructors run during deserialization** — before the `instanceof` check. An attacker who can influence `$log->state` in the database can trigger a gadget chain through any autoloaded class.

### Fix

Restrict deserialization to only the expected class at each call site. The `self::class` allowlist means PHP will only instantiate `Invoice` (or `IDFactura`) during deserialization — all other classes are blocked.

This is a minimal, backward-compatible change with no functional impact on valid data.