### PR TITLE
Issue #12001 &  #12002 - Add custom fields section to client portal profile and registration form

### DIFF
--- a/app/Http/Controllers/Auth/ContactRegisterController.php
+++ b/app/Http/Controllers/Auth/ContactRegisterController.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\ClientPortal\RegisterRequest;
 use App\Livewire\BillingPortal\Authentication\ClientRegisterService;
 use App\Models\Company;
+use App\Services\ClientPortal\CustomFieldService;
 use App\Utils\Ninja;
 use App\Utils\Traits\GeneratesCounter;
 use Illuminate\Support\Facades\App;
@@ -53,12 +54,15 @@ class ContactRegisterController extends Controller
             $show_turnstile = true;
         }
 
+        $service = app(CustomFieldService::class);
+
         $data = [
             'formed_disabled' => $company->account->isFreeHostedClient(),
             'register_company' => $company,
             'account' => $company->account,
             'submitsForm' => false,
             'show_turnstile' => $show_turnstile,
+            'custom_field_definitions' => collect($service->buildFields($company))->keyBy('key')->all(),
         ];
 
         return render('auth.register', $data);

--- a/app/Http/Requests/ClientPortal/RegisterRequest.php
+++ b/app/Http/Requests/ClientPortal/RegisterRequest.php
@@ -12,6 +12,7 @@
 
 namespace App\Http\Requests\ClientPortal;
 
+use App\Services\ClientPortal\CustomFieldService;
 use App\Utils\Ninja;
 use App\Models\Account;
 use App\Models\Company;
@@ -40,16 +41,27 @@ class RegisterRequest extends FormRequest
     public function rules(): array
     {
         $rules = [];
+        $company = $this->company();
 
-        foreach ($this->company()->client_registration_fields as $field) {
+        $service = app(CustomFieldService::class);
+        $customRules = $service->buildRules($service->buildFields($company));
+
+        $customKeys = ['custom_value1', 'custom_value2', 'custom_value3', 'custom_value4'];
+
+        foreach ($company->client_registration_fields as $field) {
             if ($field['visible'] ?? true) {
-                $rules[$field['key']] = $field['required'] ? ['bail','required'] : ['sometimes'];
+                if (in_array($field['key'], $customKeys)) {
+                    $rules[$field['key']] = $customRules[$field['key']]
+                        ?? ($field['required'] ? ['bail', 'required'] : ['sometimes']);
+                } else {
+                    $rules[$field['key']] = $field['required'] ? ['bail', 'required'] : ['sometimes'];
+                }
             }
         }
 
-        foreach ($rules as $field => $properties) {
+        foreach (array_keys($rules) as $field) {
             if ($field === 'email') {
-                $rules[$field] = array_merge($rules[$field], ['email:rfc,dns', 'max:191', Rule::unique('client_contacts')->where('company_id', $this->company()->id)]);
+                $rules[$field] = array_merge($rules[$field], ['email:rfc,dns', 'max:191', Rule::unique('client_contacts')->where('company_id', $company->id)]);
             }
 
             if ($field === 'current_password') {
@@ -57,7 +69,7 @@ class RegisterRequest extends FormRequest
             }
         }
 
-        if ($this->company()->settings->client_portal_terms || $this->company()->settings->client_portal_privacy_policy) {
+        if ($company->settings->client_portal_terms || $company->settings->client_portal_privacy_policy) {
             $rules['terms'] = ['required'];
         }
 

--- a/app/Livewire/Profile/Settings/CustomFields.php
+++ b/app/Livewire/Profile/Settings/CustomFields.php
@@ -1,0 +1,166 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Livewire\Profile\Settings;
+
+use App\Utils\Helpers;
+use Illuminate\Validation\Rule;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+class CustomFields extends Component
+{
+    public $custom_value1;
+
+    public $custom_value2;
+
+    public $custom_value3;
+
+    public $custom_value4;
+
+    public $saved;
+
+    public function client()
+    {
+        $client = auth()->guard('contact')->user()->client;
+        $client->loadMissing('company');
+
+        return $client;
+    }
+
+    public function mount(): void
+    {
+        $client = $this->client();
+
+        $this->fill([
+            'custom_value1' => $client->custom_value1 ?: '',
+            'custom_value2' => $client->custom_value2 ?: '',
+            'custom_value3' => $client->custom_value3 ?: '',
+            'custom_value4' => $client->custom_value4 ?: '',
+            'saved' => ctrans('texts.save'),
+        ]);
+    }
+
+    public function render()
+    {
+        return render('profile.settings.custom-fields', [
+            'custom_field_definitions' => $this->customFieldDefinitions,
+        ]);
+    }
+
+    public function submit(): void
+    {
+        $client = $this->client();
+        $fields = $this->customFieldDefinitions;
+        $rules = $this->buildRules($fields);
+
+        if (empty($rules)) {
+            return;
+        }
+
+        $data = $this->validate($rules);
+
+        $client
+            ->fill($data)
+            ->save();
+
+        $this->saved = ctrans('texts.saved_at', ['time' => now()->toTimeString()]);
+    }
+
+
+    #[Computed]
+    public function customFieldDefinitions(): array
+    {
+        return $this->buildFields($this->client()->company);
+    }
+
+    private function buildRules(array $fields): array
+    {
+        return collect($fields)
+            ->mapWithKeys(fn ($field) => [$field['key'] => $this->rulesForField($field)])
+            ->all();
+    }
+
+    private function rulesForField(array $field): array
+    {
+        $base = ($field['required'] ?? false)
+            ? ['bail', 'required']
+            : ['sometimes', 'nullable'];
+
+        return match ($field['type']) {
+            'date' => array_merge($base, ['date']),
+            'dropdown' => array_merge($base, [Rule::in($field['options'])]),
+            'switch' => array_merge($base, [Rule::in(['yes', 'no', ''])]),
+            default => array_merge($base, ['string', 'max:1000']),
+        };
+    }
+
+    private function buildFields($company): array
+    {
+        if ($company === null) {
+            return [];
+        }
+
+        $helper = app(Helpers::class);
+        $fields = [];
+
+        $registration_fields = collect($company->client_registration_fields ?? [])->keyBy('key');
+
+        foreach (['custom_value1', 'custom_value2', 'custom_value3', 'custom_value4'] as $key) {
+            $field = $registration_fields->get($key);
+
+            if ($field === null) {
+                continue;
+            }
+
+            $isShown = ($field['required'] ?? false) || ($field['visible'] ?? true);
+
+            if (! $isShown) {
+                continue;
+            }
+
+            $definition_key = str_replace('custom_value', 'client', $key);
+            $definition = data_get($company->custom_fields, $definition_key, '');
+
+            $parsed = $this->parseCustomFieldDefinition($definition);
+
+            $fields[] = [
+                'key' => $key,
+                'label' => $helper->makeCustomField($company->custom_fields, $definition_key) ?: $parsed['label'],
+                'required' => $field['required'] ?? false,
+                'type' => $parsed['type'],
+                'options' => $parsed['options'],
+            ];
+        }
+
+        return $fields;
+    }
+
+    private function parseCustomFieldDefinition(string $definition): array
+    {
+        $parts = explode('|', $definition, 2);
+        $label = $parts[0] ?? '';
+
+        if (count($parts) === 1) {
+            return ['label' => $label, 'type' => 'textarea', 'options' => []];
+        }
+
+        $type_part = $parts[1];
+
+        return match ($type_part) {
+            'date' => ['label' => $label, 'type' => 'date', 'options' => []],
+            'single_line_text' => ['label' => $label, 'type' => 'text', 'options' => []],
+            'switch' => ['label' => $label, 'type' => 'switch', 'options' => []],
+            default => ['label' => $label, 'type' => 'dropdown', 'options' => array_map('trim', explode(',', $type_part))],
+        };
+    }
+}

--- a/app/Livewire/Profile/Settings/CustomFields.php
+++ b/app/Livewire/Profile/Settings/CustomFields.php
@@ -12,8 +12,7 @@
 
 namespace App\Livewire\Profile\Settings;
 
-use App\Utils\Helpers;
-use Illuminate\Validation\Rule;
+use App\Services\ClientPortal\CustomFieldService;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
 
@@ -61,7 +60,7 @@ class CustomFields extends Component
     {
         $client = $this->client();
         $fields = $this->customFieldDefinitions;
-        $rules = $this->buildRules($fields);
+        $rules = app(CustomFieldService::class)->buildRules($fields);
 
         if (empty($rules)) {
             return;
@@ -76,91 +75,9 @@ class CustomFields extends Component
         $this->saved = ctrans('texts.saved_at', ['time' => now()->toTimeString()]);
     }
 
-
     #[Computed]
     public function customFieldDefinitions(): array
     {
-        return $this->buildFields($this->client()->company);
-    }
-
-    private function buildRules(array $fields): array
-    {
-        return collect($fields)
-            ->mapWithKeys(fn ($field) => [$field['key'] => $this->rulesForField($field)])
-            ->all();
-    }
-
-    private function rulesForField(array $field): array
-    {
-        $base = ($field['required'] ?? false)
-            ? ['bail', 'required']
-            : ['sometimes', 'nullable'];
-
-        return match ($field['type']) {
-            'date' => array_merge($base, ['date']),
-            'dropdown' => array_merge($base, [Rule::in($field['options'])]),
-            'switch' => array_merge($base, [Rule::in(['yes', 'no', ''])]),
-            default => array_merge($base, ['string', 'max:1000']),
-        };
-    }
-
-    private function buildFields($company): array
-    {
-        if ($company === null) {
-            return [];
-        }
-
-        $helper = app(Helpers::class);
-        $fields = [];
-
-        $registration_fields = collect($company->client_registration_fields ?? [])->keyBy('key');
-
-        foreach (['custom_value1', 'custom_value2', 'custom_value3', 'custom_value4'] as $key) {
-            $field = $registration_fields->get($key);
-
-            if ($field === null) {
-                continue;
-            }
-
-            $isShown = ($field['required'] ?? false) || ($field['visible'] ?? true);
-
-            if (! $isShown) {
-                continue;
-            }
-
-            $definition_key = str_replace('custom_value', 'client', $key);
-            $definition = data_get($company->custom_fields, $definition_key, '');
-
-            $parsed = $this->parseCustomFieldDefinition($definition);
-
-            $fields[] = [
-                'key' => $key,
-                'label' => $helper->makeCustomField($company->custom_fields, $definition_key) ?: $parsed['label'],
-                'required' => $field['required'] ?? false,
-                'type' => $parsed['type'],
-                'options' => $parsed['options'],
-            ];
-        }
-
-        return $fields;
-    }
-
-    private function parseCustomFieldDefinition(string $definition): array
-    {
-        $parts = explode('|', $definition, 2);
-        $label = $parts[0] ?? '';
-
-        if (count($parts) === 1) {
-            return ['label' => $label, 'type' => 'textarea', 'options' => []];
-        }
-
-        $type_part = $parts[1];
-
-        return match ($type_part) {
-            'date' => ['label' => $label, 'type' => 'date', 'options' => []],
-            'single_line_text' => ['label' => $label, 'type' => 'text', 'options' => []],
-            'switch' => ['label' => $label, 'type' => 'switch', 'options' => []],
-            default => ['label' => $label, 'type' => 'dropdown', 'options' => array_map('trim', explode(',', $type_part))],
-        };
+        return app(CustomFieldService::class)->buildFields($this->client()->company);
     }
 }

--- a/app/Services/ClientPortal/CustomFieldService.php
+++ b/app/Services/ClientPortal/CustomFieldService.php
@@ -1,0 +1,127 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Services\ClientPortal;
+
+use App\Models\Company;
+use App\Utils\Helpers;
+use Illuminate\Validation\Rule;
+
+class CustomFieldService
+{
+    /**
+     * Build a structured list of custom field definitions for a company's client fields.
+     *
+     * Each entry contains: key, label, required, type, options.
+     * Only fields that are required or visible in client_registration_fields are included.
+     */
+    public function buildFields(Company $company): array
+    {
+        if ($company === null) {
+            return [];
+        }
+
+        $helper = app(Helpers::class);
+        $fields = [];
+
+        $registration_fields = collect($company->client_registration_fields ?? [])->keyBy('key');
+
+        foreach (['custom_value1', 'custom_value2', 'custom_value3', 'custom_value4'] as $key) {
+            $field = $registration_fields->get($key);
+
+            if ($field === null) {
+                continue;
+            }
+
+            $isShown = ($field['required'] ?? false) || ($field['visible'] ?? true);
+
+            if (! $isShown) {
+                continue;
+            }
+
+            $definition_key = str_replace('custom_value', 'client', $key);
+            $definition = data_get($company->custom_fields, $definition_key, '');
+
+            $parsed = $this->parseCustomFieldDefinition($definition);
+
+            $fields[] = [
+                'key' => $key,
+                'label' => $helper->makeCustomField($company->custom_fields, $definition_key) ?: $parsed['label'],
+                'required' => $field['required'] ?? false,
+                'type' => $parsed['type'],
+                'options' => $parsed['options'],
+            ];
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Build a map of validation rules keyed by field key.
+     *
+     * @param  array<int, array{key: string, required: bool, type: string, options: array<string>}>  $fields
+     * @return array<string, array<mixed>>
+     */
+    public function buildRules(array $fields): array
+    {
+        return collect($fields)
+            ->mapWithKeys(fn ($field) => [$field['key'] => $this->rulesForField($field)])
+            ->all();
+    }
+
+    /**
+     * Return validation rules for a single field definition.
+     *
+     * @param  array{key: string, required: bool, type: string, options: array<string>}  $field
+     * @return array<mixed>
+     */
+    public function rulesForField(array $field): array
+    {
+        $base = ($field['required'] ?? false)
+            ? ['bail', 'required']
+            : ['sometimes', 'nullable'];
+
+        return match ($field['type']) {
+            'date' => array_merge($base, ['date']),
+            'dropdown' => array_merge($base, [Rule::in($field['options'])]),
+            'switch' => array_merge($base, [Rule::in(['yes', 'no', ''])]),
+            default => array_merge($base, ['string', 'max:1000']),
+        };
+    }
+
+    /**
+     * Parse a custom field definition string of the form "Label|type".
+     *
+     * Returns ['label', 'type', 'options'] where type is one of:
+     * 'date', 'text', 'switch', 'textarea', 'dropdown'.
+     *
+     * @return array{label: string, type: string, options: array<string>}
+     */
+    public function parseCustomFieldDefinition(string $definition): array
+    {
+        $parts = explode('|', $definition, 2);
+        $label = $parts[0] ?? '';
+
+        if (count($parts) === 1) {
+            return ['label' => $label, 'type' => 'textarea', 'options' => []];
+        }
+
+        $type_part = $parts[1];
+
+        return match ($type_part) {
+            'date' => ['label' => $label, 'type' => 'date', 'options' => []],
+            'single_line_text' => ['label' => $label, 'type' => 'text', 'options' => []],
+            'switch' => ['label' => $label, 'type' => 'switch', 'options' => []],
+            default => ['label' => $label, 'type' => 'dropdown', 'options' => array_map('trim', explode(',', $type_part))],
+        };
+    }
+}

--- a/app/Services/ClientPortal/CustomFieldService.php
+++ b/app/Services/ClientPortal/CustomFieldService.php
@@ -24,7 +24,7 @@ class CustomFieldService
      * Each entry contains: key, label, required, type, options.
      * Only fields that are required or visible in client_registration_fields are included.
      */
-    public function buildFields(Company $company): array
+    public function buildFields(?Company $company): array
     {
         if ($company === null) {
             return [];

--- a/resources/views/portal/ninja2020/auth/partials/custom-field-input.blade.php
+++ b/resources/views/portal/ninja2020/auth/partials/custom-field-input.blade.php
@@ -1,0 +1,56 @@
+@switch($field['type'])
+    @case('date')
+        <input
+            id="{{ $field['key'] }}"
+            type="date"
+            class="input w-full"
+            name="{{ $field['key'] }}"
+            value="{{ old($field['key']) }}"
+        />
+        @break
+
+    @case('textarea')
+        <textarea
+            id="{{ $field['key'] }}"
+            class="input w-full"
+            rows="4"
+            name="{{ $field['key'] }}"
+        >{{ old($field['key']) }}</textarea>
+        @break
+
+    @case('dropdown')
+        <select
+            id="{{ $field['key'] }}"
+            class="input w-full form-select bg-white"
+            name="{{ $field['key'] }}"
+        >
+            <option value=""></option>
+            @foreach($field['options'] as $option)
+                <option value="{{ $option }}" {{ old($field['key']) === $option ? 'selected' : '' }}>
+                    {{ $option }}
+                </option>
+            @endforeach
+        </select>
+        @break
+
+    @case('switch')
+        <select
+            id="{{ $field['key'] }}"
+            class="input w-full form-select bg-white"
+            name="{{ $field['key'] }}"
+        >
+            <option value=""></option>
+            <option value="yes" {{ old($field['key']) === 'yes' ? 'selected' : '' }}>{{ ctrans('texts.yes') }}</option>
+            <option value="no" {{ old($field['key']) === 'no' ? 'selected' : '' }}>{{ ctrans('texts.no') }}</option>
+        </select>
+        @break
+
+    @default
+        <input
+            id="{{ $field['key'] }}"
+            type="text"
+            class="input w-full"
+            name="{{ $field['key'] }}"
+            value="{{ old($field['key']) }}"
+        />
+@endswitch

--- a/resources/views/portal/ninja2020/auth/register.blade.php
+++ b/resources/views/portal/ninja2020/auth/register.blade.php
@@ -88,6 +88,10 @@
                                             </option>
                                         @endforeach
                                     </select>
+                                @elseif(in_array($field['key'], ['custom_value1','custom_value2','custom_value3','custom_value4']) && isset($custom_field_definitions[$field['key']]))
+                                    @include('portal.ninja2020.auth.partials.custom-field-input', [
+                                        'field' => $custom_field_definitions[$field['key']],
+                                    ])
                                 @else
                                     <input
                                         id="{{ $field['key'] }}"

--- a/resources/views/portal/ninja2020/profile/index.blade.php
+++ b/resources/views/portal/ninja2020/profile/index.blade.php
@@ -32,4 +32,8 @@
 
     <!-- Client shipping address -->
     @livewire('profile.settings.shipping-address')
+
+    <!-- Client custom fields -->
+    @livewire('profile.settings.custom-fields')
+
 @endsection

--- a/resources/views/portal/ninja2020/profile/settings/custom-fields.blade.php
+++ b/resources/views/portal/ninja2020/profile/settings/custom-fields.blade.php
@@ -1,0 +1,52 @@
+<div>
+    @if(count($custom_field_definitions))
+        <div class="mt-10 sm:mt-6">
+            <div class="md:grid md:grid-cols-3 md:gap-6">
+                <div class="md:col-span-1">
+                    <div class="sm:px-0">
+                        <h3 class="text-lg font-medium leading-6 text-gray-900">{{ ctrans('texts.custom_fields') }}</h3>
+                    </div>
+                </div>
+
+                <div class="mt-5 md:mt-0 md:col-span-2">
+                    <div class="shadow overflow-hidden rounded">
+                        <div class="px-4 py-5 bg-white sm:p-6">
+                            <div class="grid grid-cols-6 gap-6">
+                                @foreach($custom_field_definitions as $field)
+                                    <div
+                                        wire:key="custom-field-{{ $field['key'] }}"
+                                        @class([
+                                            'col-span-6 sm:col-span-3' => $field['type'] !== 'textarea',
+                                            'col-span-6' => $field['type'] === 'textarea',
+                                        ])
+                                    >
+                                        <section class="flex items-center">
+                                            <label for="{{ $field['key'] }}" class="input-label">
+                                                {{ $field['label'] }}
+                                            </label>
+
+                                            @if($field['required'])
+                                                <section class="text-red-400 ml-1 text-sm">*</section>
+                                            @endif
+                                        </section>
+
+                                        @include('portal.ninja2020.profile.settings.partials.custom-field-input', ['field' => $field])
+
+                                        @error($field['key'])
+                                            <div class="validation validation-fail">
+                                                {{ $message }}
+                                            </div>
+                                        @enderror
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                        <div class="px-4 py-3 bg-gray-50 text-right sm:px-6">
+                            <button type="button" wire:click="submit" class="button button-primary bg-primary">{{ $saved }}</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    @endif
+</div>

--- a/resources/views/portal/ninja2020/profile/settings/partials/custom-field-input.blade.php
+++ b/resources/views/portal/ninja2020/profile/settings/partials/custom-field-input.blade.php
@@ -1,0 +1,113 @@
+@switch($field['key'])
+    @case('custom_value1')
+        @switch($field['type'])
+            @case('date')
+                <input id="custom_value1" type="date" class="input w-full" wire:model="custom_value1" />
+                @break
+            @case('textarea')
+                <textarea id="custom_value1" class="input w-full" rows="4" wire:model="custom_value1"></textarea>
+                @break
+            @case('dropdown')
+                <select id="custom_value1" class="input w-full form-select bg-white" wire:model="custom_value1">
+                    <option value=""></option>
+                    @foreach($field['options'] as $option)
+                        <option value="{{ $option }}">{{ $option }}</option>
+                    @endforeach
+                </select>
+                @break
+            @case('switch')
+                <select id="custom_value1" class="input w-full form-select bg-white" wire:model="custom_value1">
+                    <option value=""></option>
+                    <option value="yes">{{ ctrans('texts.yes') }}</option>
+                    <option value="no">{{ ctrans('texts.no') }}</option>
+                </select>
+                @break
+            @default
+                <input id="custom_value1" type="text" class="input w-full" wire:model="custom_value1" />
+        @endswitch
+        @break
+
+    @case('custom_value2')
+        @switch($field['type'])
+            @case('date')
+                <input id="custom_value2" type="date" class="input w-full" wire:model="custom_value2" />
+                @break
+            @case('textarea')
+                <textarea id="custom_value2" class="input w-full" rows="4" wire:model="custom_value2"></textarea>
+                @break
+            @case('dropdown')
+                <select id="custom_value2" class="input w-full form-select bg-white" wire:model="custom_value2">
+                    <option value=""></option>
+                    @foreach($field['options'] as $option)
+                        <option value="{{ $option }}">{{ $option }}</option>
+                    @endforeach
+                </select>
+                @break
+            @case('switch')
+                <select id="custom_value2" class="input w-full form-select bg-white" wire:model="custom_value2">
+                    <option value=""></option>
+                    <option value="yes">{{ ctrans('texts.yes') }}</option>
+                    <option value="no">{{ ctrans('texts.no') }}</option>
+                </select>
+                @break
+            @default
+                <input id="custom_value2" type="text" class="input w-full" wire:model="custom_value2" />
+        @endswitch
+        @break
+
+    @case('custom_value3')
+        @switch($field['type'])
+            @case('date')
+                <input id="custom_value3" type="date" class="input w-full" wire:model="custom_value3" />
+                @break
+            @case('textarea')
+                <textarea id="custom_value3" class="input w-full" rows="4" wire:model="custom_value3"></textarea>
+                @break
+            @case('dropdown')
+                <select id="custom_value3" class="input w-full form-select bg-white" wire:model="custom_value3">
+                    <option value=""></option>
+                    @foreach($field['options'] as $option)
+                        <option value="{{ $option }}">{{ $option }}</option>
+                    @endforeach
+                </select>
+                @break
+            @case('switch')
+                <select id="custom_value3" class="input w-full form-select bg-white" wire:model="custom_value3">
+                    <option value=""></option>
+                    <option value="yes">{{ ctrans('texts.yes') }}</option>
+                    <option value="no">{{ ctrans('texts.no') }}</option>
+                </select>
+                @break
+            @default
+                <input id="custom_value3" type="text" class="input w-full" wire:model="custom_value3" />
+        @endswitch
+        @break
+
+    @case('custom_value4')
+        @switch($field['type'])
+            @case('date')
+                <input id="custom_value4" type="date" class="input w-full" wire:model="custom_value4" />
+                @break
+            @case('textarea')
+                <textarea id="custom_value4" class="input w-full" rows="4" wire:model="custom_value4"></textarea>
+                @break
+            @case('dropdown')
+                <select id="custom_value4" class="input w-full form-select bg-white" wire:model="custom_value4">
+                    <option value=""></option>
+                    @foreach($field['options'] as $option)
+                        <option value="{{ $option }}">{{ $option }}</option>
+                    @endforeach
+                </select>
+                @break
+            @case('switch')
+                <select id="custom_value4" class="input w-full form-select bg-white" wire:model="custom_value4">
+                    <option value=""></option>
+                    <option value="yes">{{ ctrans('texts.yes') }}</option>
+                    <option value="no">{{ ctrans('texts.no') }}</option>
+                </select>
+                @break
+            @default
+                <input id="custom_value4" type="text" class="input w-full" wire:model="custom_value4" />
+        @endswitch
+        @break
+@endswitch

--- a/resources/views/portal/ninja2020/profile/settings/partials/custom-field-input.blade.php
+++ b/resources/views/portal/ninja2020/profile/settings/partials/custom-field-input.blade.php
@@ -1,113 +1,29 @@
-@switch($field['key'])
-    @case('custom_value1')
-        @switch($field['type'])
-            @case('date')
-                <input id="custom_value1" type="date" class="input w-full" wire:model="custom_value1" />
-                @break
-            @case('textarea')
-                <textarea id="custom_value1" class="input w-full" rows="4" wire:model="custom_value1"></textarea>
-                @break
-            @case('dropdown')
-                <select id="custom_value1" class="input w-full form-select bg-white" wire:model="custom_value1">
-                    <option value=""></option>
-                    @foreach($field['options'] as $option)
-                        <option value="{{ $option }}">{{ $option }}</option>
-                    @endforeach
-                </select>
-                @break
-            @case('switch')
-                <select id="custom_value1" class="input w-full form-select bg-white" wire:model="custom_value1">
-                    <option value=""></option>
-                    <option value="yes">{{ ctrans('texts.yes') }}</option>
-                    <option value="no">{{ ctrans('texts.no') }}</option>
-                </select>
-                @break
-            @default
-                <input id="custom_value1" type="text" class="input w-full" wire:model="custom_value1" />
-        @endswitch
+@switch($field['type'])
+    @case('date')
+        <input id="{{ $field['key'] }}" type="date" class="input w-full" wire:model="{{ $field['key'] }}" />
         @break
 
-    @case('custom_value2')
-        @switch($field['type'])
-            @case('date')
-                <input id="custom_value2" type="date" class="input w-full" wire:model="custom_value2" />
-                @break
-            @case('textarea')
-                <textarea id="custom_value2" class="input w-full" rows="4" wire:model="custom_value2"></textarea>
-                @break
-            @case('dropdown')
-                <select id="custom_value2" class="input w-full form-select bg-white" wire:model="custom_value2">
-                    <option value=""></option>
-                    @foreach($field['options'] as $option)
-                        <option value="{{ $option }}">{{ $option }}</option>
-                    @endforeach
-                </select>
-                @break
-            @case('switch')
-                <select id="custom_value2" class="input w-full form-select bg-white" wire:model="custom_value2">
-                    <option value=""></option>
-                    <option value="yes">{{ ctrans('texts.yes') }}</option>
-                    <option value="no">{{ ctrans('texts.no') }}</option>
-                </select>
-                @break
-            @default
-                <input id="custom_value2" type="text" class="input w-full" wire:model="custom_value2" />
-        @endswitch
+    @case('textarea')
+        <textarea id="{{ $field['key'] }}" class="input w-full" rows="4" wire:model="{{ $field['key'] }}"></textarea>
         @break
 
-    @case('custom_value3')
-        @switch($field['type'])
-            @case('date')
-                <input id="custom_value3" type="date" class="input w-full" wire:model="custom_value3" />
-                @break
-            @case('textarea')
-                <textarea id="custom_value3" class="input w-full" rows="4" wire:model="custom_value3"></textarea>
-                @break
-            @case('dropdown')
-                <select id="custom_value3" class="input w-full form-select bg-white" wire:model="custom_value3">
-                    <option value=""></option>
-                    @foreach($field['options'] as $option)
-                        <option value="{{ $option }}">{{ $option }}</option>
-                    @endforeach
-                </select>
-                @break
-            @case('switch')
-                <select id="custom_value3" class="input w-full form-select bg-white" wire:model="custom_value3">
-                    <option value=""></option>
-                    <option value="yes">{{ ctrans('texts.yes') }}</option>
-                    <option value="no">{{ ctrans('texts.no') }}</option>
-                </select>
-                @break
-            @default
-                <input id="custom_value3" type="text" class="input w-full" wire:model="custom_value3" />
-        @endswitch
+    @case('dropdown')
+        <select id="{{ $field['key'] }}" class="input w-full form-select bg-white" wire:model="{{ $field['key'] }}">
+            <option value=""></option>
+            @foreach($field['options'] as $option)
+                <option value="{{ $option }}">{{ $option }}</option>
+            @endforeach
+        </select>
         @break
 
-    @case('custom_value4')
-        @switch($field['type'])
-            @case('date')
-                <input id="custom_value4" type="date" class="input w-full" wire:model="custom_value4" />
-                @break
-            @case('textarea')
-                <textarea id="custom_value4" class="input w-full" rows="4" wire:model="custom_value4"></textarea>
-                @break
-            @case('dropdown')
-                <select id="custom_value4" class="input w-full form-select bg-white" wire:model="custom_value4">
-                    <option value=""></option>
-                    @foreach($field['options'] as $option)
-                        <option value="{{ $option }}">{{ $option }}</option>
-                    @endforeach
-                </select>
-                @break
-            @case('switch')
-                <select id="custom_value4" class="input w-full form-select bg-white" wire:model="custom_value4">
-                    <option value=""></option>
-                    <option value="yes">{{ ctrans('texts.yes') }}</option>
-                    <option value="no">{{ ctrans('texts.no') }}</option>
-                </select>
-                @break
-            @default
-                <input id="custom_value4" type="text" class="input w-full" wire:model="custom_value4" />
-        @endswitch
+    @case('switch')
+        <select id="{{ $field['key'] }}" class="input w-full form-select bg-white" wire:model="{{ $field['key'] }}">
+            <option value=""></option>
+            <option value="yes">{{ ctrans('texts.yes') }}</option>
+            <option value="no">{{ ctrans('texts.no') }}</option>
+        </select>
         @break
+
+    @default
+        <input id="{{ $field['key'] }}" type="text" class="input w-full" wire:model="{{ $field['key'] }}" />
 @endswitch

--- a/tests/Feature/ClientPortal/ClientRegistrationCustomFieldsTest.php
+++ b/tests/Feature/ClientPortal/ClientRegistrationCustomFieldsTest.php
@@ -1,0 +1,285 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace Tests\Feature\ClientPortal;
+
+use App\DataMapper\ClientRegistrationFields;
+use App\Factory\CompanyUserFactory;
+use App\Http\Middleware\ContactRegister;
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\Account;
+use App\Models\Company;
+use App\Models\User;
+use App\Services\ClientPortal\CustomFieldService;
+use App\Utils\Traits\AppSetup;
+use Faker\Factory;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use stdClass;
+use Tests\TestCase;
+
+class ClientRegistrationCustomFieldsTest extends TestCase
+{
+    use DatabaseTransactions;
+    use AppSetup;
+
+    private $faker;
+
+    private Account $account;
+
+    private Company $company;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->faker = Factory::create();
+        $this->withoutMiddleware([
+            VerifyCsrfToken::class,
+            ThrottleRequests::class,
+            ContactRegister::class,
+        ]);
+
+        $this->account = Account::factory()->create();
+
+        $this->user = User::factory()->create([
+            'account_id' => $this->account->id,
+            'email' => $this->faker->unique()->safeEmail(),
+        ]);
+
+        $this->company = Company::factory()->create([
+            'account_id' => $this->account->id,
+            'client_can_register' => true,
+        ]);
+        $this->company->settings->language_id = '1';
+
+        // client1 = date, client2 = dropdown, client3 = switch, client4 = single_line_text
+        $customFields = new stdClass();
+        $customFields->client1 = 'Birth Date|date';
+        $customFields->client2 = 'Country|SK,CZ,HU,AT';
+        $customFields->client3 = 'Consent|switch';
+        $customFields->client4 = 'Contract No|single_line_text';
+        $this->company->custom_fields = $customFields;
+
+        $fields = ClientRegistrationFields::generate();
+        foreach ($fields as &$field) {
+            if ($field['key'] === 'custom_value1') {
+                $field['visible'] = true;
+                $field['required'] = true;
+            }
+            if (in_array($field['key'], ['custom_value2', 'custom_value3', 'custom_value4'])) {
+                $field['visible'] = true;
+                $field['required'] = false;
+            }
+        }
+        $this->company->client_registration_fields = $fields;
+        $this->company->save();
+
+        $cu = CompanyUserFactory::create($this->user->id, $this->company->id, $this->account->id);
+        $cu->is_owner = true;
+        $cu->save();
+    }
+
+    // --- CustomFieldService integration ---
+
+    public function testBuildFieldsReturnsAllVisibleCustomFields(): void
+    {
+        $service = app(CustomFieldService::class);
+        $fields = $service->buildFields($this->company);
+
+        $keys = array_column($fields, 'key');
+        $this->assertContains('custom_value1', $keys);
+        $this->assertContains('custom_value2', $keys);
+        $this->assertContains('custom_value3', $keys);
+        $this->assertContains('custom_value4', $keys);
+    }
+
+    public function testBuildFieldsResolvesCorrectTypes(): void
+    {
+        $service = app(CustomFieldService::class);
+        $fields = collect($service->buildFields($this->company))->keyBy('key');
+
+        $this->assertEquals('date', $fields['custom_value1']['type']);
+        $this->assertEquals('dropdown', $fields['custom_value2']['type']);
+        $this->assertEquals('switch', $fields['custom_value3']['type']);
+        $this->assertEquals('text', $fields['custom_value4']['type']);
+    }
+
+    public function testBuildFieldsDropdownHasCorrectOptions(): void
+    {
+        $service = app(CustomFieldService::class);
+        $fields = collect($service->buildFields($this->company))->keyBy('key');
+
+        $this->assertEquals(['SK', 'CZ', 'HU', 'AT'], $fields['custom_value2']['options']);
+    }
+
+    public function testBuildFieldsExcludesHiddenFields(): void
+    {
+        $company = Company::factory()->create([
+            'account_id' => $this->account->id,
+        ]);
+        $company->custom_fields = $this->company->custom_fields;
+        $company->client_registration_fields = ClientRegistrationFields::generate();
+        $company->save();
+
+        $service = app(CustomFieldService::class);
+        $fields = $service->buildFields($company);
+
+        $keys = array_column($fields, 'key');
+        $this->assertNotContains('custom_value1', $keys);
+        $this->assertNotContains('custom_value2', $keys);
+    }
+
+    // --- GET: registration form rendering ---
+
+    public function testRegistrationFormRendersDateInputForDateCustomField(): void
+    {
+        $response = $this->get(route('client.register', $this->company->company_key));
+
+        $response->assertOk();
+        $response->assertSee('type="date"', false);
+        $response->assertSee('name="custom_value1"', false);
+    }
+
+    public function testRegistrationFormRendersSelectForDropdownCustomField(): void
+    {
+        $response = $this->get(route('client.register', $this->company->company_key));
+
+        $response->assertOk();
+        $response->assertSee('name="custom_value2"', false);
+        $response->assertSee('value="SK"', false);
+        $response->assertSee('value="CZ"', false);
+    }
+
+    public function testRegistrationFormRendersSwitchAsSelectWithYesNo(): void
+    {
+        $response = $this->get(route('client.register', $this->company->company_key));
+
+        $response->assertOk();
+        $response->assertSee('name="custom_value3"', false);
+        $response->assertSee('value="yes"', false);
+        $response->assertSee('value="no"', false);
+    }
+
+    public function testRegistrationFormRendersTextInputForSingleLineTextField(): void
+    {
+        $response = $this->get(route('client.register', $this->company->company_key));
+
+        $response->assertOk();
+        $response->assertSee('name="custom_value4"', false);
+        $response->assertSee('type="text"', false);
+    }
+
+    // --- POST: validation ---
+
+    public function testRegistrationRejectsInvalidDateForDateCustomField(): void
+    {
+        $response = $this->post(
+            '/client/register/' . $this->company->company_key,
+            $this->validPayload(['custom_value1' => 'not-a-date'])
+        );
+
+        $response->assertSessionHasErrors('custom_value1');
+    }
+
+    public function testRegistrationRejectsValueNotInDropdownOptions(): void
+    {
+        $response = $this->post(
+            '/client/register/' . $this->company->company_key,
+            $this->validPayload(['custom_value2' => 'DE'])
+        );
+
+        $response->assertSessionHasErrors('custom_value2');
+    }
+
+    public function testRegistrationRejectsInvalidSwitchValue(): void
+    {
+        $response = $this->post(
+            '/client/register/' . $this->company->company_key,
+            $this->validPayload(['custom_value3' => 'maybe'])
+        );
+
+        $response->assertSessionHasErrors('custom_value3');
+    }
+
+    public function testRegistrationRejectsMissingRequiredDateCustomField(): void
+    {
+        $response = $this->post(
+            '/client/register/' . $this->company->company_key,
+            $this->validPayload(['custom_value1' => ''])
+        );
+
+        $response->assertSessionHasErrors('custom_value1');
+    }
+
+    // --- POST: success ---
+
+    public function testRegistrationSucceedsWithValidCustomFieldValues(): void
+    {
+        $response = $this->post(
+            '/client/register/' . $this->company->company_key,
+            $this->validPayload([
+                'custom_value1' => '1990-05-15',
+                'custom_value2' => 'SK',
+                'custom_value3' => 'yes',
+                'custom_value4' => 'CONTRACT-2024-001',
+            ])
+        );
+
+        $response->assertRedirect(route('client.dashboard'));
+        $this->assertDatabaseHas('clients', [
+            'company_id' => $this->company->id,
+            'custom_value1' => '1990-05-15',
+            'custom_value2' => 'SK',
+            'custom_value3' => 'yes',
+            'custom_value4' => 'CONTRACT-2024-001',
+        ]);
+    }
+
+    public function testRegistrationSucceedsWithOptionalDropdownLeftEmpty(): void
+    {
+        $response = $this->post(
+            '/client/register/' . $this->company->company_key,
+            $this->validPayload([
+                'custom_value1' => '2000-01-01',
+                // custom_value2 omitted — it's optional
+            ])
+        );
+
+        $response->assertRedirect(route('client.dashboard'));
+    }
+
+    // --- Helpers ---
+
+    private function validPayload(array $overrides = []): array
+    {
+        $email = uniqid('testuser.') . '@gmail.com';
+
+        return array_merge([
+            'company_key' => $this->company->company_key,
+            'first_name' => $this->faker->firstName(),
+            'last_name' => $this->faker->lastName(),
+            'email' => $email,
+            'password' => 'password123',
+            'password_confirmation' => 'password123',
+            'custom_value1' => '1990-05-15',
+        ], $overrides);
+    }
+
+    public function tearDown(): void
+    {
+        $this->account->delete();
+        parent::tearDown();
+    }
+}

--- a/tests/Feature/ClientPortal/ProfileCustomFieldsTest.php
+++ b/tests/Feature/ClientPortal/ProfileCustomFieldsTest.php
@@ -1,0 +1,272 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace Tests\Feature\ClientPortal;
+
+use App\DataMapper\ClientRegistrationFields;
+use App\Factory\CompanyUserFactory;
+use App\Livewire\Profile\Settings\CustomFields;
+use App\Models\Account;
+use App\Models\Client;
+use App\Models\ClientContact;
+use App\Models\Company;
+use App\Models\User;
+use App\Utils\Traits\AppSetup;
+use Faker\Factory;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Livewire;
+use stdClass;
+use Tests\TestCase;
+
+class ProfileCustomFieldsTest extends TestCase
+{
+    use DatabaseTransactions;
+    use AppSetup;
+
+    private \Faker\Generator $faker;
+
+    private Account $account;
+
+    private Company $company;
+
+    private User $user;
+
+    private Client $client;
+
+    private ClientContact $contact;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->faker = Factory::create();
+
+        $this->account = Account::factory()->create();
+
+        $this->user = User::factory()->create([
+            'account_id' => $this->account->id,
+            'email' => $this->faker->unique()->safeEmail(),
+        ]);
+
+        $this->company = Company::factory()->create([
+            'account_id' => $this->account->id,
+        ]);
+        $this->company->settings->language_id = '1';
+
+        $customFields = new stdClass();
+        $customFields->client1 = 'Birth Date|date';
+        $customFields->client2 = 'Country|SK,CZ,HU,AT';
+        $customFields->client3 = 'Consent|switch';
+        $customFields->client4 = 'Contract No|single_line_text';
+        $this->company->custom_fields = $customFields;
+
+        $fields = ClientRegistrationFields::generate();
+        foreach ($fields as &$field) {
+            if ($field['key'] === 'custom_value1') {
+                $field['visible'] = true;
+                $field['required'] = true;
+            }
+            if (in_array($field['key'], ['custom_value2', 'custom_value3', 'custom_value4'])) {
+                $field['visible'] = true;
+                $field['required'] = false;
+            }
+        }
+        $this->company->client_registration_fields = $fields;
+        $this->company->save();
+
+        $cu = CompanyUserFactory::create($this->user->id, $this->company->id, $this->account->id);
+        $cu->is_owner = true;
+        $cu->save();
+
+        $this->client = Client::factory()->create([
+            'company_id' => $this->company->id,
+            'user_id' => $this->user->id,
+            'custom_value1' => '1985-03-20',
+            'custom_value2' => 'SK',
+            'custom_value3' => 'yes',
+            'custom_value4' => 'ORIG-001',
+        ]);
+
+        $this->contact = ClientContact::factory()->create([
+            'user_id' => $this->user->id,
+            'client_id' => $this->client->id,
+            'company_id' => $this->company->id,
+            'email' => $this->faker->unique()->safeEmail(),
+            'password' => Hash::make('password'),
+            'is_primary' => true,
+        ]);
+    }
+
+    // --- mount: initial values ---
+
+    public function testMountLoadsExistingCustomValuesFromClient(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->assertSet('custom_value1', '1985-03-20')
+            ->assertSet('custom_value2', 'SK')
+            ->assertSet('custom_value3', 'yes')
+            ->assertSet('custom_value4', 'ORIG-001');
+    }
+
+    public function testMountSetsEmptyStringForNullCustomValues(): void
+    {
+        $emptyClient = Client::factory()->create([
+            'company_id' => $this->company->id,
+            'user_id' => $this->user->id,
+            'custom_value1' => null,
+            'custom_value2' => null,
+        ]);
+
+        $emptyContact = ClientContact::factory()->create([
+            'user_id' => $this->user->id,
+            'client_id' => $emptyClient->id,
+            'company_id' => $this->company->id,
+            'email' => $this->faker->unique()->safeEmail(),
+            'password' => Hash::make('password'),
+            'is_primary' => true,
+        ]);
+
+        $this->actingAs($emptyContact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->assertSet('custom_value1', '')
+            ->assertSet('custom_value2', '');
+    }
+
+    // --- computed: field definitions ---
+
+    public function testCustomFieldDefinitionsContainsAllVisibleFields(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        $component = Livewire::test(CustomFields::class);
+        $defs = $component->get('customFieldDefinitions');
+
+        $keys = array_column($defs, 'key');
+        $this->assertContains('custom_value1', $keys);
+        $this->assertContains('custom_value2', $keys);
+        $this->assertContains('custom_value3', $keys);
+        $this->assertContains('custom_value4', $keys);
+    }
+
+    public function testCustomFieldDefinitionsReturnsCorrectTypes(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        $component = Livewire::test(CustomFields::class);
+        $defs = collect($component->get('customFieldDefinitions'))->keyBy('key');
+
+        $this->assertEquals('date', $defs['custom_value1']['type']);
+        $this->assertEquals('dropdown', $defs['custom_value2']['type']);
+        $this->assertEquals('switch', $defs['custom_value3']['type']);
+        $this->assertEquals('text', $defs['custom_value4']['type']);
+    }
+
+    // --- submit: validation ---
+
+    public function testSubmitRejectsInvalidDateValue(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->set('custom_value1', 'not-a-date')
+            ->call('submit')
+            ->assertHasErrors(['custom_value1']);
+    }
+
+    public function testSubmitRejectsValueNotInDropdownOptions(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->set('custom_value2', 'DE')
+            ->call('submit')
+            ->assertHasErrors(['custom_value2']);
+    }
+
+    public function testSubmitRejectsInvalidSwitchValue(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->set('custom_value3', 'maybe')
+            ->call('submit')
+            ->assertHasErrors(['custom_value3']);
+    }
+
+    public function testSubmitRejectsMissingRequiredDateField(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->set('custom_value1', '')
+            ->call('submit')
+            ->assertHasErrors(['custom_value1']);
+    }
+
+    // --- submit: success ---
+
+    public function testSubmitSavesValidCustomValuesToClient(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->set('custom_value1', '1990-06-15')
+            ->set('custom_value2', 'CZ')
+            ->set('custom_value3', 'no')
+            ->set('custom_value4', 'NEW-CONTRACT-42')
+            ->call('submit')
+            ->assertHasNoErrors();
+
+        $this->client->refresh();
+        $this->assertEquals('1990-06-15', $this->client->custom_value1);
+        $this->assertEquals('CZ', $this->client->custom_value2);
+        $this->assertEquals('no', $this->client->custom_value3);
+        $this->assertEquals('NEW-CONTRACT-42', $this->client->custom_value4);
+    }
+
+    public function testSubmitUpdatesSavedTimestamp(): void
+    {
+        $this->actingAs($this->contact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->set('custom_value1', '2000-01-01')
+            ->call('submit')
+            ->assertHasNoErrors()
+            ->assertSet('saved', fn ($value) => str_contains($value, ':'));
+    }
+
+    public function testSubmitDoesNothingWhenNoCustomFieldsDefined(): void
+    {
+        $this->company->custom_fields = new stdClass();
+        $this->company->client_registration_fields = ClientRegistrationFields::generate();
+        $this->company->save();
+
+        $this->actingAs($this->contact, 'contact');
+
+        Livewire::test(CustomFields::class)
+            ->call('submit')
+            ->assertHasNoErrors();
+
+        $this->client->refresh();
+        $this->assertEquals('1985-03-20', $this->client->custom_value1);
+    }
+
+    public function tearDown(): void
+    {
+        $this->account->delete();
+        parent::tearDown();
+    }
+}

--- a/tests/Feature/ClientPortal/ProfileCustomFieldsTest.php
+++ b/tests/Feature/ClientPortal/ProfileCustomFieldsTest.php
@@ -129,6 +129,7 @@ class ProfileCustomFieldsTest extends TestCase
             'custom_value2' => null,
         ]);
 
+        /** @var ClientContact $emptyContact */
         $emptyContact = ClientContact::factory()->create([
             'user_id' => $this->user->id,
             'client_id' => $emptyClient->id,

--- a/tests/Unit/Services/ClientPortal/CustomFieldServiceTest.php
+++ b/tests/Unit/Services/ClientPortal/CustomFieldServiceTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace Tests\Unit\Services\ClientPortal;
+
+use App\Services\ClientPortal\CustomFieldService;
+use Illuminate\Validation\Rules\In;
+use Tests\TestCase;
+
+class CustomFieldServiceTest extends TestCase
+{
+    private CustomFieldService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new CustomFieldService();
+    }
+
+    // --- parseCustomFieldDefinition ---
+
+    public function testParsesDateType(): void
+    {
+        $result = $this->service->parseCustomFieldDefinition('Birth Date|date');
+
+        $this->assertEquals('Birth Date', $result['label']);
+        $this->assertEquals('date', $result['type']);
+        $this->assertEquals([], $result['options']);
+    }
+
+    public function testParsesSingleLineTextType(): void
+    {
+        $result = $this->service->parseCustomFieldDefinition('Contract No|single_line_text');
+
+        $this->assertEquals('Contract No', $result['label']);
+        $this->assertEquals('text', $result['type']);
+        $this->assertEquals([], $result['options']);
+    }
+
+    public function testParsesSwitchType(): void
+    {
+        $result = $this->service->parseCustomFieldDefinition('Consent|switch');
+
+        $this->assertEquals('Consent', $result['label']);
+        $this->assertEquals('switch', $result['type']);
+        $this->assertEquals([], $result['options']);
+    }
+
+    public function testParsesDropdownTypeWithTrimmedOptions(): void
+    {
+        $result = $this->service->parseCustomFieldDefinition('Country|SK, CZ, HU, AT');
+
+        $this->assertEquals('Country', $result['label']);
+        $this->assertEquals('dropdown', $result['type']);
+        $this->assertEquals(['SK', 'CZ', 'HU', 'AT'], $result['options']);
+    }
+
+    public function testParsesNoPipeSeparatorAsTextarea(): void
+    {
+        $result = $this->service->parseCustomFieldDefinition('Notes');
+
+        $this->assertEquals('Notes', $result['label']);
+        $this->assertEquals('textarea', $result['type']);
+        $this->assertEquals([], $result['options']);
+    }
+
+    public function testParsesEmptyStringAsTextarea(): void
+    {
+        $result = $this->service->parseCustomFieldDefinition('');
+
+        $this->assertEquals('', $result['label']);
+        $this->assertEquals('textarea', $result['type']);
+    }
+
+    // --- rulesForField ---
+
+    public function testRulesForRequiredDateFieldContainsDateRule(): void
+    {
+        $field = ['key' => 'custom_value1', 'required' => true, 'type' => 'date', 'options' => []];
+
+        $rules = $this->service->rulesForField($field);
+
+        $this->assertContains('bail', $rules);
+        $this->assertContains('required', $rules);
+        $this->assertContains('date', $rules);
+    }
+
+    public function testRulesForOptionalDateFieldUsesNullable(): void
+    {
+        $field = ['key' => 'custom_value1', 'required' => false, 'type' => 'date', 'options' => []];
+
+        $rules = $this->service->rulesForField($field);
+
+        $this->assertContains('sometimes', $rules);
+        $this->assertContains('nullable', $rules);
+        $this->assertContains('date', $rules);
+        $this->assertNotContains('required', $rules);
+    }
+
+    public function testRulesForDropdownFieldContainsInRule(): void
+    {
+        $field = ['key' => 'custom_value2', 'required' => false, 'type' => 'dropdown', 'options' => ['SK', 'CZ', 'HU']];
+
+        $rules = $this->service->rulesForField($field);
+
+        $hasInRule = collect($rules)->contains(fn ($r) => $r instanceof In);
+        $this->assertTrue($hasInRule, 'Expected an Illuminate\\Validation\\Rules\\In rule for dropdown fields');
+    }
+
+    public function testRulesForSwitchFieldContainsInRule(): void
+    {
+        $field = ['key' => 'custom_value3', 'required' => true, 'type' => 'switch', 'options' => []];
+
+        $rules = $this->service->rulesForField($field);
+
+        $inRule = collect($rules)->first(fn ($r) => $r instanceof In);
+        $this->assertNotNull($inRule, 'Expected an Illuminate\\Validation\\Rules\\In rule for switch fields');
+    }
+
+    public function testRulesForTextareaFieldContainsStringAndMaxRules(): void
+    {
+        $field = ['key' => 'custom_value4', 'required' => false, 'type' => 'textarea', 'options' => []];
+
+        $rules = $this->service->rulesForField($field);
+
+        $this->assertContains('string', $rules);
+        $this->assertContains('max:1000', $rules);
+    }
+
+    // --- buildRules ---
+
+    public function testBuildRulesReturnsMapKeyedByFieldKey(): void
+    {
+        $fields = [
+            ['key' => 'custom_value1', 'required' => true, 'type' => 'date', 'options' => []],
+            ['key' => 'custom_value2', 'required' => false, 'type' => 'dropdown', 'options' => ['A', 'B']],
+        ];
+
+        $rules = $this->service->buildRules($fields);
+
+        $this->assertArrayHasKey('custom_value1', $rules);
+        $this->assertArrayHasKey('custom_value2', $rules);
+        $this->assertContains('date', $rules['custom_value1']);
+    }
+
+    public function testBuildRulesReturnsEmptyArrayForEmptyInput(): void
+    {
+        $this->assertEquals([], $this->service->buildRules([]));
+    }
+}


### PR DESCRIPTION
## Summary

- Add a Livewire `CustomFields` component to the client portal profile page so contacts can view and update client custom fields configured via registration settings
- Render field types (text, textarea, date, dropdown, switch) based on company custom field definitions and visibility/required flags from `client_registration_fields`
- Include shared Blade partial for custom field inputs with validation on save

Fixes #12002

## Test plan

- [ ] Configure client custom fields and registration field visibility/required settings in the admin
- [ ] Log in to the client portal and open the profile page
- [ ] Verify visible custom fields render with correct labels and input types
- [ ] Submit valid values and confirm they persist on the client record
- [ ] Verify required field validation blocks empty submissions
- [ ] Confirm hidden custom fields are not shown on the profile page