### PR TITLE
Calendar connect — let native clients complete OAuth via a custom-scheme callback redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ APP_DEBUG=false
 
 APP_URL=http://localhost
 REACT_URL=http://localhost:3001
+CALENDAR_NATIVE_REDIRECT=invoiceninja://calendar_connection/complete
 
 DB_CONNECTION=mysql
 MULTI_DB_ENABLED=false

--- a/app/Http/Controllers/CalendarConnectionController.php
+++ b/app/Http/Controllers/CalendarConnectionController.php
@@ -43,7 +43,11 @@ class CalendarConnectionController extends BaseController
     {
         MultiDB::findAndSetDbByCompanyKey($request->getTokenContent()['company_key']);
 
-        $url = $service->buildAuthorizationUrl($request->resolveUser(), $provider);
+        $url = $service->buildAuthorizationUrl(
+            $request->resolveUser(),
+            $provider,
+            $request->getTokenContent()['platform'] ?? null,
+        );
 
         return redirect()->to($url);
     }
@@ -53,24 +57,27 @@ class CalendarConnectionController extends BaseController
      *
      * Pure bouncepoint: never calls Socialite, never persists tokens. Stores
      * the provider state and code in a short-lived handoff cache entry, then
-     * forwards only that handoff token to the React SPA hash route.
+     * forwards only that handoff token to the client that started the flow
+     * (React / Flutter-web SPA hash route, or a native app's custom scheme).
      */
     public function callback(string $provider, Request $request, CalendarConnectionService $service): RedirectResponse
     {
+        $state = (string) $request->query('state', '');
+        $platform = $service->platformForState($state);
+
         if ($request->query('error')) {
-            return $this->redirectToReact($provider, 'denied');
+            return $this->redirectToClient($provider, 'denied', null, $platform);
         }
 
-        $state = (string) $request->query('state', '');
-        $code  = (string) $request->query('code', '');
+        $code = (string) $request->query('code', '');
 
         if ($state === '' || $code === '') {
-            return $this->redirectToReact($provider, 'failed');
+            return $this->redirectToClient($provider, 'failed', null, $platform);
         }
 
         $handoff = $service->cacheCallbackHandoff($provider, $state, $code);
 
-        return $this->redirectToReact($provider, 'pending', $handoff);
+        return $this->redirectToClient($provider, 'pending', $handoff, $platform);
     }
 
     /**
@@ -147,17 +154,33 @@ class CalendarConnectionController extends BaseController
         ]);
     }
 
-    private function redirectToReact(string $provider, string $status, ?string $handoff = null): RedirectResponse
+    /**
+     * Sends the user back to the client that started the flow, carrying the
+     * one-time handoff. Web clients (React or Flutter web) land on the SPA hash
+     * route via react_url; native apps land on an allow-listed custom scheme.
+     * Targets come from config — never from client input.
+     */
+    private function redirectToClient(string $provider, string $status, ?string $handoff = null, ?string $platform = null): RedirectResponse
     {
-        $baseUrl = rtrim(config('ninja.react_url') ?: config('ninja.app_url'), '/#');
-
         $params = ['calendar_connection' => $status, 'provider' => $provider];
 
         if ($handoff !== null) {
             $params['handoff'] = $handoff;
         }
 
-        return redirect()->away($baseUrl . '/#/calendar_connection/complete?' . http_build_query($params));
+        $query = http_build_query($params);
+
+        // Native: registered custom scheme (e.g. invoiceninja://calendar_connection/complete).
+        if ($platform === 'flutter_native' && ($scheme = config('ninja.calendar.native_redirect'))) {
+            $separator = str_contains($scheme, '?') ? '&' : '?';
+
+            return redirect()->away($scheme . $separator . $query);
+        }
+
+        // Default: React / web clients (or unspecified) — existing behavior, untouched.
+        $baseUrl = rtrim(config('ninja.react_url') ?: config('ninja.app_url'), '/#');
+
+        return redirect()->away($baseUrl . '/#/calendar_connection/complete?' . $query);
     }
 
     private function user(): User

--- a/app/Http/Controllers/OneTimeTokenController.php
+++ b/app/Http/Controllers/OneTimeTokenController.php
@@ -82,6 +82,10 @@ class OneTimeTokenController extends BaseController
             $data['provider_id'] = $request->provider_id;
         }
 
+        if ($request->platform) {
+            $data['platform'] = $request->platform;
+        }
+
         Cache::put($hash, $data, 3600);
 
         return response()->json(['hash' => $hash], 200);

--- a/app/Http/Requests/OneTimeToken/OneTimeTokenRequest.php
+++ b/app/Http/Requests/OneTimeToken/OneTimeTokenRequest.php
@@ -35,6 +35,7 @@ class OneTimeTokenRequest extends Request
     {
         return [
             'context' => 'required',
+            'platform' => 'sometimes|nullable|string|in:flutter_native',
         ];
     }
 

--- a/app/Services/Calendar/CalendarConnectionService.php
+++ b/app/Services/Calendar/CalendarConnectionService.php
@@ -70,9 +70,11 @@ class CalendarConnectionService
      *
      * The opaque, single-use state token is stored server-side and bound to
      * the initiating user/tenant so the authenticated `/complete` step can
-     * verify the same user is completing the flow they started.
+     * verify the same user is completing the flow they started. The optional
+     * client `platform` hint is bound to the state too, so the callback can
+     * return the handoff to the right client (e.g. a native app's custom scheme).
      */
-    public function buildAuthorizationUrl(User $user, string $provider): string
+    public function buildAuthorizationUrl(User $user, string $provider, ?string $platform = null): string
     {
         $provider = $this->validateProvider($provider);
         $state = Str::random(64);
@@ -81,9 +83,27 @@ class CalendarConnectionService
             'database' => config('database.default'),
             'provider' => $provider,
             'user_id' => $user->id,
+            'platform' => $platform,
         ], now()->addMinutes(self::STATE_TTL_MINUTES));
 
         return $this->providerAuthorizationUrl($provider, $state);
+    }
+
+    /**
+     * The platform hint bound to an OAuth state, read WITHOUT consuming the
+     * cache entry (completeConnection still pulls it). Used by the public
+     * callback to pick the redirect target (only `flutter_native` is acted on;
+     * anything else falls back to React). Returns null for unknown/expired state.
+     */
+    public function platformForState(string $state): ?string
+    {
+        if ($state === '') {
+            return null;
+        }
+
+        $context = Cache::get(self::STATE_CACHE_PREFIX . $state);
+
+        return is_array($context) ? ($context['platform'] ?? null) : null;
     }
 
     private function providerAuthorizationUrl(string $provider, string $state): string

--- a/config/ninja.php
+++ b/config/ninja.php
@@ -6,6 +6,14 @@ return [
     'admin_token' => env('NINJA_ADMIN_TOKEN', ''),
     'license_url' => 'https://app.invoiceninja.com',
     'react_url' => env('REACT_URL', env('APP_URL', '')),
+    'calendar' => [
+        // OAuth-callback return target for native (Flutter) apps, which can't
+        // ride a full-page browser redirect. The client sends platform=flutter_native
+        // on /one_time_token; it's bound to the OAuth state, and the callback
+        // redirects the handoff to this allow-listed custom scheme (never a
+        // client-supplied URL). Web clients (React or Flutter web) use react_url.
+        'native_redirect' => env('CALENDAR_NATIVE_REDIRECT', 'invoiceninja://calendar_connection/complete'),
+    ],
     'production' => env('NINJA_PROD', false),
     'license' => env('NINJA_LICENSE', ''),
     'version_url' => 'https://pdf.invoicing.co/api/version',

--- a/tests/Feature/CalendarConnectionTest.php
+++ b/tests/Feature/CalendarConnectionTest.php
@@ -187,6 +187,82 @@ class CalendarConnectionTest extends TestCase
         $this->assertArrayNotHasKey('handoff', $query);
     }
 
+    public function testAuthorizeBindsPlatformToState(): void
+    {
+        $hash = $this->cacheOneTimeToken('calendar_google', 'flutter_native');
+
+        $response = $this->get(route('calendar_connection.authorize', [
+            'provider' => CalendarConnection::PROVIDER_GOOGLE,
+            'hash' => $hash,
+        ]));
+
+        $response->assertStatus(302);
+
+        $query = $this->parseUrlQuery($response->headers->get('Location'));
+        $stateContext = Cache::get(CalendarConnectionService::STATE_CACHE_PREFIX . $query['state']);
+
+        $this->assertSame('flutter_native', $stateContext['platform']);
+    }
+
+    public function testCallbackRedirectsNativeClientToCustomScheme(): void
+    {
+        Socialite::shouldReceive('driver')->never();
+
+        $state = $this->cacheCalendarState(CalendarConnection::PROVIDER_GOOGLE, 'flutter_native');
+
+        $response = $this->get(route('calendar_connection.callback', [
+            'provider' => CalendarConnection::PROVIDER_GOOGLE,
+            'state' => $state,
+            'code' => 'oauth-code',
+        ]));
+
+        $location = $response->headers->get('Location');
+        $this->assertStringStartsWith('invoiceninja://calendar_connection/complete?', $location);
+
+        $query = $this->parseUrlQuery($location);
+        $this->assertSame('pending', $query['calendar_connection']);
+        $this->assertSame(CalendarConnection::PROVIDER_GOOGLE, $query['provider']);
+        $this->assertArrayHasKey('handoff', $query);
+    }
+
+    public function testCallbackIgnoresUnknownPlatformAndDefaultsToReact(): void
+    {
+        Socialite::shouldReceive('driver')->never();
+
+        $state = $this->cacheCalendarState(CalendarConnection::PROVIDER_GOOGLE, 'evil://attacker');
+
+        $response = $this->get(route('calendar_connection.callback', [
+            'provider' => CalendarConnection::PROVIDER_GOOGLE,
+            'state' => $state,
+            'code' => 'oauth-code',
+        ]));
+
+        $this->assertStringStartsWith(
+            'https://react.test/#/calendar_connection/complete?',
+            $response->headers->get('Location'),
+        );
+    }
+
+    public function testCallbackNativeErrorStillDeepLinksWithoutHandoff(): void
+    {
+        Socialite::shouldReceive('driver')->never();
+
+        $state = $this->cacheCalendarState(CalendarConnection::PROVIDER_GOOGLE, 'flutter_native');
+
+        $response = $this->get(route('calendar_connection.callback', [
+            'provider' => CalendarConnection::PROVIDER_GOOGLE,
+            'state' => $state,
+            'error' => 'access_denied',
+        ]));
+
+        $location = $response->headers->get('Location');
+        $this->assertStringStartsWith('invoiceninja://calendar_connection/complete?', $location);
+
+        $query = $this->parseUrlQuery($location);
+        $this->assertSame('denied', $query['calendar_connection']);
+        $this->assertArrayNotHasKey('handoff', $query);
+    }
+
     public function testCompleteStoresSingleCalendarConnectionAndAutoSelectsGooglePrimaryCalendar(): void
     {
         $state = $this->cacheCalendarState(CalendarConnection::PROVIDER_GOOGLE);
@@ -1637,15 +1713,21 @@ class CalendarConnectionTest extends TestCase
         ];
     }
 
-    private function cacheCalendarState(string $provider): string
+    private function cacheCalendarState(string $provider, ?string $platform = null): string
     {
         $state = Str::random(64);
 
-        Cache::put(CalendarConnectionService::STATE_CACHE_PREFIX . $state, [
+        $context = [
             'database' => config('database.default'),
             'provider' => $provider,
             'user_id' => $this->user->id,
-        ], now()->addMinutes(10));
+        ];
+
+        if ($platform !== null) {
+            $context['platform'] = $platform;
+        }
+
+        Cache::put(CalendarConnectionService::STATE_CACHE_PREFIX . $state, $context, now()->addMinutes(10));
 
         return $state;
     }
@@ -1663,15 +1745,21 @@ class CalendarConnectionTest extends TestCase
         return $handoff;
     }
 
-    private function cacheOneTimeToken(string $context): string
+    private function cacheOneTimeToken(string $context, ?string $platform = null): string
     {
         $hash = Str::random(64);
 
-        Cache::put($hash, [
+        $data = [
             'user_id' => $this->user->id,
             'company_key' => $this->company->company_key,
             'context' => $context,
-        ], 3600);
+        ];
+
+        if ($platform !== null) {
+            $data['platform'] = $platform;
+        }
+
+        Cache::put($hash, $data, 3600);
 
         return $hash;
     }


### PR DESCRIPTION
## Summary

Adds an optional platform hint to the calendar OAuth flow so native clients can receive the one-time handoff. Today the callback always redirects to `react_url` (the React SPA), which native apps can't reach. React/web behavior is unchanged; one new opt-in env var; no migration; no new dependency.

## Why this is needed (the Flutter admin app)

The new cross-platform Flutter admin client is implementing calendar connect (the client-side counterpart to `invoiceninja/ui#3180`). The OAuth handshake is server-mediated via Socialite and ends in `CalendarConnectionController::callback`, which forwards the handoff to:

    {ninja.react_url}/#/calendar_connection/complete?...&handoff=...

That works for any client that can ride a full-page browser redirect and land back on that SPA route — React, and Flutter web.

It does **not** work for the Flutter native apps (macOS / iOS / Android):

- A native app has no full-page redirect to ride.
- Google blocks OAuth inside embedded webviews, so the native app must open the system browser.
- The only way for the system browser to hand the result back to the app is a custom-scheme deep link (e.g. `invoiceninja://...`).
- But the server only ever redirects to an `https` `react_url`, which never reaches the app — so native calendar-connect is impossible without this change.

The native client side is already in place (URL-scheme registration + a deep-link handler that bridges `invoiceninja://calendar_connection/complete` into the app's router). It just needs the server to redirect there when the flow was started by a native client.

## What changed

1. `POST /api/v1/one_time_token` accepts an optional `platform` (validated `in:flutter_native`). The native client sends `{"context":"calendar_<provider>","platform":"flutter_native"}`; web/React send nothing. Stored on the token only when present, so other `one_time_token` callers (QuickBooks/bank) are unaffected.
2. `CalendarConnectionService::buildAuthorizationUrl` binds that platform to the existing OAuth state cache entry.
3. The public callback reads it back non-destructively (`Cache::get`, via `platformForState`) and picks the redirect target:
   - `flutter_native` → the allow-listed custom scheme from `config('ninja.calendar.native_redirect')` (default `invoiceninja://calendar_connection/complete`)
   - anything else (web / React / absent) → `react_url`, unchanged
4. `redirectToReact` → `redirectToClient` (it now targets React/web or a native scheme).

## Security

- The redirect target is server config, never client input — the client only sends a `platform` enum, so there's no open-redirect surface.
- The `state.user_id === auth_user.id` check in `completeConnection` is untouched. Even if a custom-scheme deep link were intercepted (scheme squatting), the handoff is useless without the authenticated originating user.

## Backward compatibility

- The default arm of `redirectToClient` is byte-for-byte the previous `redirectToReact` (`react_url`), so existing React behavior is identical. Pinned by the existing `testCallbackBouncepoint…` tests.
- `platform` is opt-in; nothing changes for requests that don't send it.

## Config

One new env var (defaults to the scheme above, overridable for white-label apps):

    CALENDAR_NATIVE_REDIRECT=invoiceninja://calendar_connection/complete

## Tests

New feature tests in `tests/Feature/CalendarConnectionTest.php`: platform binds to the OAuth state; `flutter_native` → custom scheme; an unknown platform falls back to React; a denied native callback still deep-links back without a handoff.