### PR TITLE
fix creditnote validation fails for peppol

### DIFF
--- a/app/Http/Requests/EInvoice/ValidateEInvoiceRequest.php
+++ b/app/Http/Requests/EInvoice/ValidateEInvoiceRequest.php
@@ -16,6 +16,7 @@ use App\Utils\Ninja;
 use App\Models\Client;
 use App\Models\Company;
 use App\Models\Invoice;
+use App\Models\Credit;
 use App\Http\Requests\Request;
 use Illuminate\Validation\Rule;
 use App\Models\RecurringInvoice;
@@ -92,7 +93,17 @@ class ValidateEInvoiceRequest extends Request
             return auth()->user()->company();
         }
 
-        return $class::withTrashed()->find(is_string($this->entity_id) ? $this->decodePrimaryKey($this->entity_id) : $this->entity_id);
+        $id = is_string($this->entity_id) ? $this->decodePrimaryKey($this->entity_id) : $this->entity_id;
+        $entity = $class::withTrashed()->find($id);
+
+        if ($this->entity === 'invoices') {
+            $credit = Credit::withTrashed()->find($id);
+            if ($credit) {
+                return $credit;
+            }
+        }
+
+        return $entity;
 
     }
 


### PR DESCRIPTION
## Fix: Credit note Peppol validation loads wrong entity due to hashid collision

### Problem

When validating a credit note for Peppol e-invoicing via `POST /api/v1/einvoice/validateEntity`, the endpoint loads the **wrong entity**, causing false validation failures.

The Flutter frontend sends `entity=invoices` for credit notes (since `Credit` extends `Invoice` in the data model). `ValidateEInvoiceRequest::getEntity()` resolves `Invoice::withTrashed()->find($id)` for this entity type. However, Invoice Ninja hashids are **not entity-scoped** — the same hash decodes to a numeric ID that can match both an `Invoice` and a `Credit` simultaneously. If a soft-deleted invoice shares that ID with a different client, the invoice is loaded instead of the credit note, and validation runs against the wrong client entirely.

### Steps to reproduce

1. Create a credit note for a client with proper Peppol routing configured (classification, VAT, routing identifier)
2. Have a soft-deleted invoice sharing the same numeric ID, belonging to a **different** client without Peppol configuration
3. Open the credit note → E-Invoice tab → click **Validate**
4. Validation fails with: *"A valid routing identifier is required for Peppol delivery to Kingdom of Belgium"*

### Root cause

`ValidateEInvoiceRequest::getEntity()` unconditionally loads an `Invoice` for `entity=invoices` and never checks whether the decoded ID belongs to a `Credit`. When both records exist with the same ID, the invoice wins — even if it's soft-deleted and unrelated to the credit note being validated.

### Fix

When `entity === 'invoices'`, attempt to load a `Credit` with the decoded ID first. If one exists, return it immediately. Otherwise, fall back to the `Invoice` as before.

This is a minimal, backwards-compatible change. It requires no frontend modifications and adds a single query.

