### PR TITLE
Generic OpenID Connect (OIDC) provider — env-driven, .well-known discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,14 @@ APPLE_CLIENT_ID=
 APPLE_CLIENT_SECRET=
 APPLE_REDIRECT_URI=
 
+# Generic OpenID Connect (OIDC) SSO.
+# Leave OIDC_WELL_KNOWN blank to hide the "Sign in with ..." button.
+# OIDC_WELL_KNOWN=https://sso.example.com/application/o/invoiceninja/.well-known/openid-configuration
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_SCOPES="openid profile email"
+# OIDC_PROVIDER_LABEL="OIDC"
+
 NORDIGEN_SECRET_ID=
 NORDIGEN_SECRET_KEY=
 

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -943,6 +943,15 @@ class LoginController extends BaseController
             $parameters = ['response_type' => 'code', 'redirect_uri' => config('ninja.app_url') . "/auth/microsoft"];
         }
 
+        if ($provider == 'oidc') {
+            if (!config('services.oidc.well_known')) {
+                return abort(404, 'OIDC provider is not configured');
+            }
+
+            $scopes = array_values(array_filter(explode(' ', (string) config('services.oidc.scopes', 'openid profile email'))));
+            $parameters = ['response_type' => 'code', 'redirect_uri' => config('services.oidc.redirect')];
+        }
+
         if (request()->hasHeader('X-REACT') || request()->query('react')) {
             /**@var \App\Models\User $user */
             $user = auth()->user();
@@ -952,7 +961,7 @@ class LoginController extends BaseController
         if (request()->has('code')) {
             return $this->handleProviderCallback($provider);
         } else {
-            if (!in_array($provider, ['google', 'microsoft'])) {
+            if (!in_array($provider, ['google', 'microsoft', 'oidc'])) {
                 return abort(400, 'Invalid provider');
             }
 
@@ -964,6 +973,10 @@ class LoginController extends BaseController
     {
         if ($provider == 'microsoft') {
             return $this->handleMicrosoftProviderCallback();
+        }
+
+        if ($provider == 'oidc') {
+            return $this->handleOidcProviderCallback();
         }
 
         $socialite_user = Socialite::driver($provider)->user();
@@ -1005,6 +1018,100 @@ class LoginController extends BaseController
 
         // if($request_from_react)
         $redirect_url = config('ninja.react_url') . "/#/settings/user_details/connect";
+
+        return redirect($redirect_url);
+    }
+
+    /**
+     * Publicly report whether generic OIDC SSO is configured on this
+     * self-hosted instance so the React login page can conditionally
+     * show a "Sign in with <label>" button.
+     *
+     * Returns { oidc_enabled: bool, oidc_provider_label: string }.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function oidcConfig()
+    {
+        return response()->json([
+            'oidc_enabled' => !empty(config('services.oidc.client_id')) && !empty(config('services.oidc.well_known')),
+            'oidc_provider_label' => config('services.oidc.provider_label', 'OIDC'),
+        ]);
+    }
+
+    /**
+     * Handle the browser callback from a generic OIDC identity provider.
+     *
+     * Resolves the Socialite user, then either signs an existing user in
+     * (matching by oauth_user_id/provider or by email), or provisions a
+     * fresh account when no match is found. Finally redirects to the
+     * React SPA `/auth/oauth?token=…` route with a freshly issued
+     * CompanyToken so the SPA can hydrate its Redux auth state and land
+     * the user on the dashboard.
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    public function handleOidcProviderCallback()
+    {
+        try {
+            /** @var \Laravel\Socialite\Two\User $socialite_user */
+            $socialite_user = Socialite::driver('oidc')->stateless()->user();
+        } catch (\Throwable $e) {
+            nlog('OIDC callback failed: ' . $e->getMessage());
+            return redirect(config('ninja.react_url') . '/login?error=' . urlencode('OIDC sign-in failed: ' . $e->getMessage()));
+        }
+
+        if (!$socialite_user || !$socialite_user->getId()) {
+            return redirect(config('ninja.react_url') . '/login?error=' . urlencode('OIDC sign-in failed: missing subject identifier.'));
+        }
+
+        // Reuse the shared social-login pathway (existing OAuth user,
+        // email-linked user, or fresh signup). It returns a JsonResponse
+        // for the SPA flow, but we only use it here to trigger the
+        // Auth::login()/CompanyToken provisioning as a side effect.
+        $response = $this->loginOrCreateFromSocialite($socialite_user, 'oidc');
+
+        if (!Auth::check()) {
+            // loginOrCreateFromSocialite returned a JSON error – surface it
+            // to the SPA as a query-string error rather than a raw 4xx body.
+            $message = 'OIDC sign-in failed.';
+
+            if ($response instanceof JsonResponse) {
+                $payload = $response->getData(true);
+                $message = $payload['message'] ?? $message;
+            }
+
+            return redirect(config('ninja.react_url') . '/login?error=' . urlencode($message));
+        }
+
+        /** @var \App\Models\User $user */
+        $user = auth()->user();
+
+        // Persist the oauth linkage for future logins.
+        $name = OAuth::splitName($socialite_user->getName() ?? '');
+        $user->update([
+            'first_name' => $user->first_name ?: $name[0],
+            'last_name' => $user->last_name ?: $name[1],
+            'oauth_user_id' => $socialite_user->getId(),
+            'oauth_provider_id' => 'oidc',
+        ]);
+
+        // hydrateCompanyUser() already created a system CompanyToken (see
+        // CreateCompanyToken above); grab it so the SPA can pick up its JWT.
+        $company_token = CompanyToken::where('user_id', $user->id)
+            ->where('company_id', $user->account->default_company_id)
+            ->where('is_system', true)
+            ->first();
+
+        if (!$company_token) {
+            (new CreateCompanyToken($user->account->default_company, $user, request()->server('HTTP_USER_AGENT')))->handle();
+            $company_token = CompanyToken::where('user_id', $user->id)
+                ->where('company_id', $user->account->default_company_id)
+                ->where('is_system', true)
+                ->first();
+        }
+
+        $redirect_url = config('ninja.react_url') . '/oauth-callback?token=' . $company_token->token;
 
         return redirect($redirect_url);
     }

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -28,6 +28,7 @@ use Illuminate\Http\JsonResponse;
 use PragmaRX\Google2FA\Google2FA;
 use App\Jobs\Account\CreateAccount;
 use App\Events\User\UserLoginFailed;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Auth;
 use App\Utils\Traits\User\LoginCache;
 use Illuminate\Support\Facades\Cache;
@@ -958,6 +959,15 @@ class LoginController extends BaseController
             Cache::put("react_redir:" . $user?->account->key, 'true', 300);
         }
 
+        // The IdP redirects back with `?error=...` when the user cancels or
+        // consent fails. Short-circuit here so we never fall through to
+        // Socialite::redirect() again, which would bounce the browser
+        // straight back to the IdP and loop.
+        if (request()->has('error')) {
+            nlog('OAuth provider returned error: ' . request()->query('error'));
+            return response()->json(['message' => 'OAuth sign-in was cancelled or failed.'], 400);
+        }
+
         if (request()->has('code')) {
             return $this->handleProviderCallback($provider);
         } else {
@@ -1056,7 +1066,7 @@ class LoginController extends BaseController
             $socialite_user = Socialite::driver('oidc')->user();
         } catch (\Throwable $e) {
             nlog('OIDC callback failed: ' . $e->getMessage());
-            return response()->json(['message' => 'OIDC sign-in failed: ' . $e->getMessage()], 400);
+            return response()->json(['message' => 'OIDC sign-in failed.'], 400);
         }
 
         if (!$socialite_user || !$socialite_user->getId()) {
@@ -1116,7 +1126,47 @@ class LoginController extends BaseController
             return response()->json(['message' => 'User found, but not attached to any companies, please see your administrator'], 400);
         }
 
-        return redirect(config('ninja.react_url') . '/oauth-callback?token=' . $company_token->token);
+        // Never place the CompanyToken in the redirect URL — it would land
+        // in browser history, Referer headers, and any HTTP access log
+        // between the IdP and the SPA. Instead stash the token behind a
+        // one-shot random exchange code with a 60s TTL, and hand the SPA
+        // only the code; the SPA calls POST /api/v1/oidc/exchange to swap
+        // it for the real token exactly once.
+        $exchange_code = Str::random(64);
+        Cache::put('oidc.exchange.' . $exchange_code, $company_token->token, now()->addSeconds(60));
+
+        return redirect(config('ninja.react_url') . '/oauth-callback?code=' . $exchange_code);
+    }
+
+    /**
+     * One-shot exchange of a short-lived OIDC callback code for the real
+     * CompanyToken issued during `handleOidcProviderCallback`.
+     *
+     * The React SPA POSTs the `code` query-string value it received on the
+     * `/oauth-callback` landing page; we `Cache::pull` the value so the
+     * code cannot be replayed. Codes are 64-char random strings and expire
+     * in 60 seconds, so an attacker with a leaked code has a tiny window
+     * that closes on first legitimate use.
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function oidcExchange(Request $request)
+    {
+        $code = (string) $request->input('code', '');
+
+        // Fixed-length guard rejects trivially short guesses without giving
+        // any information about which specific codes are live.
+        if (strlen($code) !== 64) {
+            return response()->json(['message' => 'Invalid OIDC exchange code.'], 400);
+        }
+
+        $token = Cache::pull('oidc.exchange.' . $code);
+
+        if (!$token) {
+            return response()->json(['message' => 'OIDC exchange code is expired or already used.'], 400);
+        }
+
+        return response()->json(['token' => $token]);
     }
 
     public function handleMicrosoftProviderCallback($provider = 'microsoft')

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1047,22 +1047,20 @@ class LoginController extends BaseController
      * self-hosted is treated as a sign-in path for accounts that already
      * exist, not a self-service signup path.
      *
-     * @return \Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
      */
     public function handleOidcProviderCallback()
     {
-        $error_redirect = fn (string $msg) => redirect(config('ninja.react_url') . '/login?error=' . urlencode($msg));
-
         try {
             /** @var \Laravel\Socialite\Two\User $socialite_user */
             $socialite_user = Socialite::driver('oidc')->user();
         } catch (\Throwable $e) {
             nlog('OIDC callback failed: ' . $e->getMessage());
-            return $error_redirect('OIDC sign-in failed: ' . $e->getMessage());
+            return response()->json(['message' => 'OIDC sign-in failed: ' . $e->getMessage()], 400);
         }
 
         if (!$socialite_user || !$socialite_user->getId()) {
-            return $error_redirect('OIDC sign-in failed: missing subject identifier.');
+            return response()->json(['message' => 'OIDC sign-in failed: missing subject identifier.'], 400);
         }
 
         $user = MultiDB::hasUser([
@@ -1087,11 +1085,11 @@ class LoginController extends BaseController
         }
 
         if (!$user) {
-            return $error_redirect('No Invoice Ninja account is linked to this OIDC identity. Ask an administrator to invite you first.');
+            return response()->json(['message' => 'No Invoice Ninja account is linked to this OIDC identity. Ask an administrator to invite you first.'], 400);
         }
 
         if (!$user->account) {
-            return $error_redirect('User exists but is not attached to any company.');
+            return response()->json(['message' => 'User exists but is not attached to any company.'], 400);
         }
 
         Auth::login($user, false);
@@ -1099,11 +1097,11 @@ class LoginController extends BaseController
         $cu = $this->hydrateCompanyUser($user);
 
         if ($cu->count() == 0) {
-            return $error_redirect('User found but not attached to any company. Please contact your administrator.');
+            return response()->json(['message' => 'User found, but not attached to any companies, please see your administrator'], 400);
         }
 
         if (Ninja::isHosted() && !$cu->first()->is_owner && !$user->account->isEnterprisePaidClient()) { //@phpstan-ignore-line
-            return $error_redirect('Pro / Free accounts only the owner can log in. Please upgrade.');
+            return response()->json(['message' => 'Pro / Free accounts only the owner can log in. Please upgrade'], 403);
         }
 
         $name = OAuth::splitName($socialite_user->getName() ?? '');
@@ -1112,17 +1110,10 @@ class LoginController extends BaseController
             'last_name' => $user->last_name ?: $name[1],
         ]);
 
-        $company_token = CompanyToken::where('user_id', $user->id)
-            ->where('company_id', $user->account->default_company_id)
-            ->where('is_system', true)
-            ->first();
+        $company_token = app(TruthSource::class)->getCompanyToken();
 
         if (!$company_token) {
-            (new CreateCompanyToken($user->account->default_company, $user, request()->server('HTTP_USER_AGENT')))->handle();
-            $company_token = CompanyToken::where('user_id', $user->id)
-                ->where('company_id', $user->account->default_company_id)
-                ->where('is_system', true)
-                ->first();
+            return response()->json(['message' => 'User found, but not attached to any companies, please see your administrator'], 400);
         }
 
         return redirect(config('ninja.react_url') . '/oauth-callback?token=' . $company_token->token);

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1079,10 +1079,16 @@ class LoginController extends BaseController
         ]);
 
         // Fall back to a one-time email link for accounts provisioned
-        // outside of OIDC. Only link when the account has no other
-        // OAuth provider attached, to avoid hijacking a google/microsoft
-        // linkage silently.
-        if (!$user && $socialite_user->getEmail()) {
+        // outside of OIDC. Only link when:
+        //  * the IdP asserts email_verified: true — otherwise an attacker
+        //    who can register an unverified account at the IdP under a
+        //    victim's address could take over the matching local account;
+        //  * the local account has no other OAuth provider attached, to
+        //    avoid silently hijacking a google/microsoft linkage.
+        $raw = $socialite_user->getRaw();
+        $email_verified = ($raw['email_verified'] ?? false) === true;
+
+        if (!$user && $email_verified && $socialite_user->getEmail()) {
             $email_user = MultiDB::hasUser(['email' => $socialite_user->getEmail()]);
 
             if ($email_user && (!$email_user->oauth_provider_id || $email_user->oauth_provider_id === 'oidc')) {

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1132,6 +1132,8 @@ class LoginController extends BaseController
             return response()->json(['message' => 'User found, but not attached to any companies, please see your administrator'], 400);
         }
 
+        event(new UserLoggedIn($user, $company_token->company, Ninja::eventVars($user->id)));
+
         // Never place the CompanyToken in the redirect URL — it would land
         // in browser history, Referer headers, and any HTTP access log
         // between the IdP and the SPA. Instead stash the token behind a

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1042,62 +1042,76 @@ class LoginController extends BaseController
     /**
      * Handle the browser callback from a generic OIDC identity provider.
      *
-     * Resolves the Socialite user, then either signs an existing user in
-     * (matching by oauth_user_id/provider or by email), or provisions a
-     * fresh account when no match is found. Finally redirects to the
-     * React SPA `/auth/oauth?token=…` route with a freshly issued
-     * CompanyToken so the SPA can hydrate its Redux auth state and land
-     * the user on the dashboard.
+     * Signs in an existing user matched by (sub, provider) or by a
+     * one-time email link. Never provisions a new account — OIDC on
+     * self-hosted is treated as a sign-in path for accounts that already
+     * exist, not a self-service signup path.
      *
-     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function handleOidcProviderCallback()
     {
+        $error_redirect = fn (string $msg) => redirect(config('ninja.react_url') . '/login?error=' . urlencode($msg));
+
         try {
             /** @var \Laravel\Socialite\Two\User $socialite_user */
-            $socialite_user = Socialite::driver('oidc')->stateless()->user();
+            $socialite_user = Socialite::driver('oidc')->user();
         } catch (\Throwable $e) {
             nlog('OIDC callback failed: ' . $e->getMessage());
-            return redirect(config('ninja.react_url') . '/login?error=' . urlencode('OIDC sign-in failed: ' . $e->getMessage()));
+            return $error_redirect('OIDC sign-in failed: ' . $e->getMessage());
         }
 
         if (!$socialite_user || !$socialite_user->getId()) {
-            return redirect(config('ninja.react_url') . '/login?error=' . urlencode('OIDC sign-in failed: missing subject identifier.'));
+            return $error_redirect('OIDC sign-in failed: missing subject identifier.');
         }
 
-        // Reuse the shared social-login pathway (existing OAuth user,
-        // email-linked user, or fresh signup). It returns a JsonResponse
-        // for the SPA flow, but we only use it here to trigger the
-        // Auth::login()/CompanyToken provisioning as a side effect.
-        $response = $this->loginOrCreateFromSocialite($socialite_user, 'oidc');
-
-        if (!Auth::check()) {
-            // loginOrCreateFromSocialite returned a JSON error – surface it
-            // to the SPA as a query-string error rather than a raw 4xx body.
-            $message = 'OIDC sign-in failed.';
-
-            if ($response instanceof JsonResponse) {
-                $payload = $response->getData(true);
-                $message = $payload['message'] ?? $message;
-            }
-
-            return redirect(config('ninja.react_url') . '/login?error=' . urlencode($message));
-        }
-
-        /** @var \App\Models\User $user */
-        $user = auth()->user();
-
-        // Persist the oauth linkage for future logins.
-        $name = OAuth::splitName($socialite_user->getName() ?? '');
-        $user->update([
-            'first_name' => $user->first_name ?: $name[0],
-            'last_name' => $user->last_name ?: $name[1],
+        $user = MultiDB::hasUser([
             'oauth_user_id' => $socialite_user->getId(),
             'oauth_provider_id' => 'oidc',
         ]);
 
-        // hydrateCompanyUser() already created a system CompanyToken (see
-        // CreateCompanyToken above); grab it so the SPA can pick up its JWT.
+        // Fall back to a one-time email link for accounts provisioned
+        // outside of OIDC. Only link when the account has no other
+        // OAuth provider attached, to avoid hijacking a google/microsoft
+        // linkage silently.
+        if (!$user && $socialite_user->getEmail()) {
+            $email_user = MultiDB::hasUser(['email' => $socialite_user->getEmail()]);
+
+            if ($email_user && (!$email_user->oauth_provider_id || $email_user->oauth_provider_id === 'oidc')) {
+                $email_user->update([
+                    'oauth_user_id' => $socialite_user->getId(),
+                    'oauth_provider_id' => 'oidc',
+                ]);
+                $user = $email_user;
+            }
+        }
+
+        if (!$user) {
+            return $error_redirect('No Invoice Ninja account is linked to this OIDC identity. Ask an administrator to invite you first.');
+        }
+
+        if (!$user->account) {
+            return $error_redirect('User exists but is not attached to any company.');
+        }
+
+        Auth::login($user, false);
+
+        $cu = $this->hydrateCompanyUser($user);
+
+        if ($cu->count() == 0) {
+            return $error_redirect('User found but not attached to any company. Please contact your administrator.');
+        }
+
+        if (Ninja::isHosted() && !$cu->first()->is_owner && !$user->account->isEnterprisePaidClient()) { //@phpstan-ignore-line
+            return $error_redirect('Pro / Free accounts only the owner can log in. Please upgrade.');
+        }
+
+        $name = OAuth::splitName($socialite_user->getName() ?? '');
+        $user->update([
+            'first_name' => $user->first_name ?: $name[0],
+            'last_name' => $user->last_name ?: $name[1],
+        ]);
+
         $company_token = CompanyToken::where('user_id', $user->id)
             ->where('company_id', $user->account->default_company_id)
             ->where('is_system', true)
@@ -1111,9 +1125,7 @@ class LoginController extends BaseController
                 ->first();
         }
 
-        $redirect_url = config('ninja.react_url') . '/oauth-callback?token=' . $company_token->token;
-
-        return redirect($redirect_url);
+        return redirect(config('ninja.react_url') . '/oauth-callback?token=' . $company_token->token);
     }
 
     public function handleMicrosoftProviderCallback($provider = 'microsoft')

--- a/app/Libraries/OAuth/Providers/Oidc/OidcExtendSocialite.php
+++ b/app/Libraries/OAuth/Providers/Oidc/OidcExtendSocialite.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Libraries\OAuth\Providers\Oidc;
+
+use SocialiteProviders\Manager\SocialiteWasCalled;
+
+/**
+ * Listener that registers the generic OIDC driver with Laravel Socialite.
+ *
+ * Wired to the SocialiteWasCalled event in EventServiceProvider.
+ */
+class OidcExtendSocialite
+{
+    public function handle(SocialiteWasCalled $socialiteWasCalled): void
+    {
+        $socialiteWasCalled->extendSocialite('oidc', Provider::class);
+    }
+}

--- a/app/Libraries/OAuth/Providers/Oidc/Provider.php
+++ b/app/Libraries/OAuth/Providers/Oidc/Provider.php
@@ -12,6 +12,8 @@
 
 namespace App\Libraries\OAuth\Providers\Oidc;
 
+use Firebase\JWT\JWK;
+use Firebase\JWT\JWT;
 use GuzzleHttp\RequestOptions;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
@@ -118,6 +120,120 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected function getTokenUrl(): string
     {
         return $this->discovery()['token_endpoint'];
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * Overridden to verify the `id_token` returned alongside the access
+     * token — signature via the IdP's JWKS, plus the OIDC-mandated
+     * `iss` / `aud` / `exp` claims — before we trust anything the
+     * userinfo endpoint tells us. The `sub` from the id_token is also
+     * cross-checked against the userinfo response to defend against
+     * token-substitution attacks.
+     */
+    public function user()
+    {
+        if ($this->hasInvalidState()) {
+            throw new \Laravel\Socialite\Two\InvalidStateException();
+        }
+
+        $response = $this->getAccessTokenResponse($this->getCode());
+
+        $idToken = Arr::get($response, 'id_token');
+
+        if (!$idToken) {
+            throw new \RuntimeException('OIDC token response did not include an id_token.');
+        }
+
+        $claims = $this->verifyIdToken($idToken);
+
+        $accessToken = Arr::get($response, 'access_token');
+        $userinfo = $this->getUserByToken($accessToken);
+
+        // Prefer verified claims from the id_token when the userinfo
+        // response is missing the subject, and refuse the login when the
+        // two disagree.
+        $userinfo['sub'] = $userinfo['sub'] ?? $claims['sub'] ?? null;
+
+        if (!$userinfo['sub'] || $userinfo['sub'] !== ($claims['sub'] ?? null)) {
+            throw new \RuntimeException('OIDC userinfo subject does not match id_token subject.');
+        }
+
+        $user = $this->mapUserToObject($userinfo);
+
+        return $user->setToken($accessToken)
+            ->setRefreshToken(Arr::get($response, 'refresh_token'))
+            ->setExpiresIn(Arr::get($response, 'expires_in'))
+            ->setApprovedScopes(explode($this->scopeSeparator, (string) Arr::get($response, 'scope', '')));
+    }
+
+    /**
+     * Verify the id_token signature and required OIDC claims.
+     *
+     * @return array<string,mixed> the decoded claim set
+     */
+    protected function verifyIdToken(string $idToken): array
+    {
+        $discovery = $this->discovery();
+        $issuer = $discovery['issuer'] ?? null;
+        $jwksUri = $discovery['jwks_uri'] ?? null;
+
+        if (!$issuer || !$jwksUri) {
+            throw new \RuntimeException('OIDC discovery document is missing issuer or jwks_uri.');
+        }
+
+        $keys = JWK::parseKeySet($this->jwks($jwksUri));
+
+        try {
+            $claims = (array) JWT::decode($idToken, $keys);
+        } catch (\Throwable $e) {
+            throw new \RuntimeException('OIDC id_token signature verification failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        if (($claims['iss'] ?? null) !== $issuer) {
+            throw new \RuntimeException('OIDC id_token issuer mismatch.');
+        }
+
+        $aud = $claims['aud'] ?? null;
+        $audiences = is_array($aud) ? $aud : [$aud];
+
+        if (!in_array((string) config('services.oidc.client_id'), $audiences, true)) {
+            throw new \RuntimeException('OIDC id_token audience does not include this client.');
+        }
+
+        if (isset($claims['azp']) && $claims['azp'] !== (string) config('services.oidc.client_id')) {
+            throw new \RuntimeException('OIDC id_token authorized-party (azp) mismatch.');
+        }
+
+        return $claims;
+    }
+
+    /**
+     * Fetch and cache the IdP's JWKS document.
+     *
+     * @return array<string,mixed>
+     */
+    protected function jwks(string $jwksUri): array
+    {
+        return Cache::remember(
+            'oidc.jwks.' . sha1($jwksUri),
+            now()->addHour(),
+            function () use ($jwksUri): array {
+                $response = $this->getHttpClient()->get($jwksUri, [
+                    RequestOptions::HEADERS => ['Accept' => 'application/json'],
+                    RequestOptions::TIMEOUT => 10,
+                ]);
+
+                $payload = json_decode((string) $response->getBody(), true);
+
+                if (!is_array($payload) || !isset($payload['keys'])) {
+                    throw new \RuntimeException('OIDC JWKS document is malformed at ' . $jwksUri);
+                }
+
+                return $payload;
+            }
+        );
     }
 
     /**

--- a/app/Libraries/OAuth/Providers/Oidc/Provider.php
+++ b/app/Libraries/OAuth/Providers/Oidc/Provider.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace App\Libraries\OAuth\Providers\Oidc;
+
+use GuzzleHttp\RequestOptions;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
+use Laravel\Socialite\Two\ProviderInterface;
+use Laravel\Socialite\Two\User;
+use SocialiteProviders\Manager\OAuth2\AbstractProvider;
+
+/**
+ * Generic OpenID Connect (OIDC) Socialite provider.
+ *
+ * Endpoints are discovered from the `.well-known/openid-configuration`
+ * document exposed by any OIDC-compliant identity provider (Authentik,
+ * Keycloak, Zitadel, Okta, Auth0, ...). The discovered metadata is
+ * cached for one hour to avoid a network round-trip on every login.
+ *
+ * Configuration lives under `config/services.php` -> `oidc`:
+ *   - well_known   (required) full URL to the discovery document
+ *   - client_id    (required)
+ *   - client_secret (required)
+ *   - redirect     (required) callback URL, e.g. https://app.example.com/auth/oidc
+ *   - scopes       (optional) space-separated list, default "openid profile email"
+ */
+class Provider extends AbstractProvider implements ProviderInterface
+{
+    public const IDENTIFIER = 'OIDC';
+
+    /**
+     * Extra config keys the SocialiteProviders/Manager should hydrate onto
+     * the driver instance. Required by the manager convention even when we
+     * pull everything else from the .well-known discovery document.
+     */
+    public static function additionalConfigKeys(): array
+    {
+        return ['well_known', 'scopes'];
+    }
+
+    /**
+     * Cached OIDC discovery document.
+     *
+     * @var array<string,mixed>|null
+     */
+    protected ?array $discovery = null;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopes = ['openid', 'profile', 'email'];
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
+     * Return the discovered OIDC metadata, fetching + caching on first use.
+     *
+     * @return array<string,mixed>
+     */
+    protected function discovery(): array
+    {
+        if ($this->discovery !== null) {
+            return $this->discovery;
+        }
+
+        $wellKnown = (string) config('services.oidc.well_known');
+
+        if ($wellKnown === '') {
+            throw new \RuntimeException('OIDC discovery URL (OIDC_WELL_KNOWN) is not configured.');
+        }
+
+        $this->discovery = Cache::remember(
+            'oidc.discovery.' . sha1($wellKnown),
+            now()->addHour(),
+            function () use ($wellKnown): array {
+                $response = $this->getHttpClient()->get($wellKnown, [
+                    RequestOptions::HEADERS => ['Accept' => 'application/json'],
+                    RequestOptions::TIMEOUT => 10,
+                ]);
+
+                $payload = json_decode((string) $response->getBody(), true);
+
+                if (!is_array($payload) || !isset($payload['authorization_endpoint'], $payload['token_endpoint'])) {
+                    throw new \RuntimeException('OIDC discovery document is malformed at ' . $wellKnown);
+                }
+
+                return $payload;
+            }
+        );
+
+        return $this->discovery;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getAuthUrl($state): string
+    {
+        return $this->buildAuthUrlFromBase($this->discovery()['authorization_endpoint'], $state);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getTokenUrl(): string
+    {
+        return $this->discovery()['token_endpoint'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getUserByToken($token): array
+    {
+        $userinfoEndpoint = $this->discovery()['userinfo_endpoint'] ?? null;
+
+        if (!$userinfoEndpoint) {
+            throw new \RuntimeException('OIDC provider does not advertise a userinfo_endpoint.');
+        }
+
+        $response = $this->getHttpClient()->get($userinfoEndpoint, [
+            RequestOptions::HEADERS => [
+                'Authorization' => 'Bearer ' . $token,
+                'Accept' => 'application/json',
+            ],
+            RequestOptions::TIMEOUT => 10,
+        ]);
+
+        return (array) json_decode((string) $response->getBody(), true);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function mapUserToObject(array $user): User
+    {
+        $given = Arr::get($user, 'given_name', '');
+        $family = Arr::get($user, 'family_name', '');
+
+        $displayName = Arr::get($user, 'name')
+            ?: trim($given . ' ' . $family)
+            ?: (string) Arr::get($user, 'preferred_username', '');
+
+        return (new User())->setRaw($user)->map([
+            'id'         => Arr::get($user, 'sub'),
+            'nickname'   => Arr::get($user, 'preferred_username'),
+            'name'       => $displayName,
+            'first_name' => $given,
+            'last_name'  => $family,
+            'email'      => Arr::get($user, 'email'),
+            'avatar'     => Arr::get($user, 'picture'),
+        ]);
+    }
+}

--- a/app/Libraries/OAuth/Providers/Oidc/Provider.php
+++ b/app/Libraries/OAuth/Providers/Oidc/Provider.php
@@ -68,6 +68,21 @@ class Provider extends AbstractProvider implements ProviderInterface
     protected $scopeSeparator = ' ';
 
     /**
+     * {@inheritdoc}
+     *
+     * Enable PKCE on the authorization-code exchange. Any OIDC-conformant
+     * IdP either requires or tolerates PKCE, and enabling it hardens the
+     * browser flow against authorization-code interception even when the
+     * client secret is present.
+     */
+    public function __construct($request, $clientId, $clientSecret, $redirectUrl, $guzzle = [])
+    {
+        parent::__construct($request, $clientId, $clientSecret, $redirectUrl, $guzzle);
+
+        $this->enablePKCE();
+    }
+
+    /**
      * Return the discovered OIDC metadata, fetching + caching on first use.
      *
      * @return array<string,mixed>
@@ -183,7 +198,12 @@ class Provider extends AbstractProvider implements ProviderInterface
             throw new \RuntimeException('OIDC discovery document is missing issuer or jwks_uri.');
         }
 
-        $keys = JWK::parseKeySet($this->jwks($jwksUri));
+        // Some IdPs publish JWKS entries without an `alg` field; without a
+        // default the parser rejects the whole key set. Read the alg from
+        // the id_token header and use it as the default so the parse
+        // succeeds for both alg-tagged and untagged keys.
+        $tokenAlg = $this->idTokenAlg($idToken);
+        $keys = JWK::parseKeySet($this->jwks($jwksUri), $tokenAlg);
 
         try {
             $claims = (array) JWT::decode($idToken, $keys);
@@ -207,6 +227,30 @@ class Provider extends AbstractProvider implements ProviderInterface
         }
 
         return $claims;
+    }
+
+    /**
+     * Read the `alg` header of a JWS-compact serialised id_token.
+     *
+     * Falls back to RS256 (the OIDC-registered default) when the header is
+     * missing an alg, so callers always get a usable value to hand to the
+     * JWKS parser.
+     */
+    protected function idTokenAlg(string $idToken): string
+    {
+        $segments = explode('.', $idToken);
+        if (count($segments) < 2) {
+            return 'RS256';
+        }
+
+        $header = json_decode(
+            (string) base64_decode(strtr($segments[0], '-_', '+/'), true),
+            true
+        );
+
+        $alg = is_array($header) ? ($header['alg'] ?? null) : null;
+
+        return is_string($alg) && $alg !== '' ? $alg : 'RS256';
     }
 
     /**

--- a/app/Libraries/OAuth/Providers/Oidc/Provider.php
+++ b/app/Libraries/OAuth/Providers/Oidc/Provider.php
@@ -276,10 +276,16 @@ class Provider extends AbstractProvider implements ProviderInterface
             throw new \RuntimeException('OIDC JWK kty does not match id_token alg family.');
         }
 
-        // Overwrite the JWK's own `alg` (if any) with our validated
-        // value so JWK::parseKey cannot be nudged into a different
-        // algorithm by a hostile JWKS document.
-        $jwk['alg'] = $alg;
+        // Reject when the JWK advertises an alg that does not match the
+        // id_token header alg. When the JWK omits alg, the second
+        // argument to JWK::parseKey supplies our validated alg as the
+        // default — safer than silently reassigning the JWK's own field.
+        if (
+            array_key_exists('alg', $jwk)
+            && (!is_string($jwk['alg']) || $jwk['alg'] !== $alg)
+        ) {
+            throw new \RuntimeException('OIDC JWK alg does not match id_token alg.');
+        }
 
         try {
             $key = JWK::parseKey($jwk, $alg);

--- a/app/Libraries/OAuth/Providers/Oidc/Provider.php
+++ b/app/Libraries/OAuth/Providers/Oidc/Provider.php
@@ -48,12 +48,16 @@ class Provider extends AbstractProvider implements ProviderInterface
      * the HMAC secret). Used only when the IdP's discovery document
      * omits `id_token_signing_alg_values_supported`.
      *
+     * Scoped to what firebase/php-jwt v7.x actually implements: RS*, PS256,
+     * ES256/ES384, and EdDSA. PS384/PS512/ES512 are intentionally excluded
+     * because JWT::decode would throw "Algorithm not supported" at runtime.
+     *
      * @var string[]
      */
     protected const ID_TOKEN_ALG_ALLOWLIST = [
         'RS256', 'RS384', 'RS512',
-        'PS256', 'PS384', 'PS512',
-        'ES256', 'ES384', 'ES512',
+        'PS256',
+        'ES256', 'ES384',
         'EdDSA',
     ];
 
@@ -61,14 +65,15 @@ class Provider extends AbstractProvider implements ProviderInterface
      * Map from a signing alg to the JWK `kty` value we require on the
      * matching public key. Enforced so a JWK of the wrong shape cannot
      * be reinterpreted as material for a different algorithm family
-     * (again: alg-confusion defence).
+     * (again: alg-confusion defence). Kept in lock-step with the
+     * allowlist above.
      *
      * @var array<string,string>
      */
     protected const ALG_KTY_MAP = [
         'RS256' => 'RSA', 'RS384' => 'RSA', 'RS512' => 'RSA',
-        'PS256' => 'RSA', 'PS384' => 'RSA', 'PS512' => 'RSA',
-        'ES256' => 'EC',  'ES384' => 'EC',  'ES512' => 'EC',
+        'PS256' => 'RSA',
+        'ES256' => 'EC',  'ES384' => 'EC',
         'EdDSA' => 'OKP',
     ];
 
@@ -281,6 +286,18 @@ class Provider extends AbstractProvider implements ProviderInterface
             $claims = (array) JWT::decode($idToken, $key);
         } catch (\Throwable $e) {
             throw new \RuntimeException('OIDC id_token signature verification failed: ' . $e->getMessage(), 0, $e);
+        }
+
+        // OIDC Core §2 requires both iat and exp. JWT::decode enforces exp
+        // when present, but treats an absent claim as "no expiry" — which
+        // would let a token with no lifetime be replayed forever. Reject
+        // outright.
+        if (!isset($claims['exp']) || !is_numeric($claims['exp'])) {
+            throw new \RuntimeException('OIDC id_token is missing required exp claim.');
+        }
+
+        if (!isset($claims['iat']) || !is_numeric($claims['iat'])) {
+            throw new \RuntimeException('OIDC id_token is missing required iat claim.');
         }
 
         if (($claims['iss'] ?? null) !== $issuer) {

--- a/app/Libraries/OAuth/Providers/Oidc/Provider.php
+++ b/app/Libraries/OAuth/Providers/Oidc/Provider.php
@@ -41,6 +41,38 @@ class Provider extends AbstractProvider implements ProviderInterface
     public const IDENTIFIER = 'OIDC';
 
     /**
+     * Asymmetric-signature algorithms we are willing to verify an
+     * id_token with. HMAC (`HS*`) and `none` are deliberately absent —
+     * JWKS is public-key material, so any `HS*` alg against a JWKS key
+     * would be an alg-confusion attack (the public key bytes become
+     * the HMAC secret). Used only when the IdP's discovery document
+     * omits `id_token_signing_alg_values_supported`.
+     *
+     * @var string[]
+     */
+    protected const ID_TOKEN_ALG_ALLOWLIST = [
+        'RS256', 'RS384', 'RS512',
+        'PS256', 'PS384', 'PS512',
+        'ES256', 'ES384', 'ES512',
+        'EdDSA',
+    ];
+
+    /**
+     * Map from a signing alg to the JWK `kty` value we require on the
+     * matching public key. Enforced so a JWK of the wrong shape cannot
+     * be reinterpreted as material for a different algorithm family
+     * (again: alg-confusion defence).
+     *
+     * @var array<string,string>
+     */
+    protected const ALG_KTY_MAP = [
+        'RS256' => 'RSA', 'RS384' => 'RSA', 'RS512' => 'RSA',
+        'PS256' => 'RSA', 'PS384' => 'RSA', 'PS512' => 'RSA',
+        'ES256' => 'EC',  'ES384' => 'EC',  'ES512' => 'EC',
+        'EdDSA' => 'OKP',
+    ];
+
+    /**
      * Extra config keys the SocialiteProviders/Manager should hydrate onto
      * the driver instance. Required by the manager convention even when we
      * pull everything else from the .well-known discovery document.
@@ -198,15 +230,55 @@ class Provider extends AbstractProvider implements ProviderInterface
             throw new \RuntimeException('OIDC discovery document is missing issuer or jwks_uri.');
         }
 
-        // Some IdPs publish JWKS entries without an `alg` field; without a
-        // default the parser rejects the whole key set. Read the alg from
-        // the id_token header and use it as the default so the parse
-        // succeeds for both alg-tagged and untagged keys.
-        $tokenAlg = $this->idTokenAlg($idToken);
-        $keys = JWK::parseKeySet($this->jwks($jwksUri), $tokenAlg);
+        // The header is read *only* to choose which JWKS entry to try
+        // and which alg the caller claims — every field it reports has
+        // to be re-validated against server-trusted metadata before we
+        // decode, otherwise an attacker who controls the token can
+        // steer us into an alg-confusion attack (e.g. HS256 against an
+        // EC public key). See:
+        // https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+        $header = $this->idTokenHeader($idToken);
+        $alg = $header['alg'] ?? null;
+        $kid = $header['kid'] ?? null;
+
+        if (!is_string($alg) || $alg === '') {
+            throw new \RuntimeException('OIDC id_token header is missing alg.');
+        }
+
+        // Hard allowlist. Rejects `HS*`, `none`, and anything else the
+        // IdP has no business signing an id_token with.
+        if (!array_key_exists($alg, self::ALG_KTY_MAP)) {
+            throw new \RuntimeException('OIDC id_token uses an unsupported or unsafe alg: ' . $alg);
+        }
+
+        // OIDC Discovery §3 requires id_token_signing_alg_values_supported.
+        // When the IdP publishes it we honour it exactly; otherwise fall
+        // back to our own asymmetric-only allowlist rather than trusting
+        // the token header.
+        $supportedAlgs = $discovery['id_token_signing_alg_values_supported'] ?? self::ID_TOKEN_ALG_ALLOWLIST;
+
+        if (!is_array($supportedAlgs) || !in_array($alg, $supportedAlgs, true)) {
+            throw new \RuntimeException('OIDC id_token alg ' . $alg . ' is not in the IdP advertised signing algorithms.');
+        }
+
+        $jwks = $this->jwks($jwksUri);
+        $jwk = $this->pickJwk(is_array($jwks['keys'] ?? null) ? $jwks['keys'] : [], is_string($kid) ? $kid : null, $alg);
+
+        // The JWK's kty must match the alg family (RSA/EC/OKP). Without
+        // this check a JWK of the wrong type could be coerced into
+        // material for an alg it was never issued for.
+        if (($jwk['kty'] ?? null) !== self::ALG_KTY_MAP[$alg]) {
+            throw new \RuntimeException('OIDC JWK kty does not match id_token alg family.');
+        }
+
+        // Overwrite the JWK's own `alg` (if any) with our validated
+        // value so JWK::parseKey cannot be nudged into a different
+        // algorithm by a hostile JWKS document.
+        $jwk['alg'] = $alg;
 
         try {
-            $claims = (array) JWT::decode($idToken, $keys);
+            $key = JWK::parseKey($jwk, $alg);
+            $claims = (array) JWT::decode($idToken, $key);
         } catch (\Throwable $e) {
             throw new \RuntimeException('OIDC id_token signature verification failed: ' . $e->getMessage(), 0, $e);
         }
@@ -230,17 +302,21 @@ class Provider extends AbstractProvider implements ProviderInterface
     }
 
     /**
-     * Read the `alg` header of a JWS-compact serialised id_token.
+     * Decode the JOSE header of a JWS-compact serialised id_token.
      *
-     * Falls back to RS256 (the OIDC-registered default) when the header is
-     * missing an alg, so callers always get a usable value to hand to the
-     * JWKS parser.
+     * Callers must treat every field returned here as attacker-controlled
+     * until it is cross-checked against server-trusted metadata (JWKS,
+     * discovery). This helper deliberately performs no validation of its
+     * own — it just parses base64url + JSON.
+     *
+     * @return array<string,mixed>
      */
-    protected function idTokenAlg(string $idToken): string
+    protected function idTokenHeader(string $idToken): array
     {
         $segments = explode('.', $idToken);
+
         if (count($segments) < 2) {
-            return 'RS256';
+            throw new \RuntimeException('OIDC id_token is not a JWS compact serialization.');
         }
 
         $header = json_decode(
@@ -248,9 +324,51 @@ class Provider extends AbstractProvider implements ProviderInterface
             true
         );
 
-        $alg = is_array($header) ? ($header['alg'] ?? null) : null;
+        if (!is_array($header)) {
+            throw new \RuntimeException('OIDC id_token header is not valid JSON.');
+        }
 
-        return is_string($alg) && $alg !== '' ? $alg : 'RS256';
+        return $header;
+    }
+
+    /**
+     * Pick the JWKS entry to verify against, preferring an exact `kid`
+     * match and otherwise the single key whose `kty` fits the alg.
+     *
+     * We fail loudly instead of returning "some key that might work" —
+     * ambiguity in key selection is another vector for alg-confusion.
+     *
+     * @param array<int,array<string,mixed>> $jwks
+     * @return array<string,mixed>
+     */
+    protected function pickJwk(array $jwks, ?string $kid, string $alg): array
+    {
+        $expectedKty = self::ALG_KTY_MAP[$alg] ?? null;
+
+        if ($kid !== null && $kid !== '') {
+            foreach ($jwks as $jwk) {
+                if (is_array($jwk) && ($jwk['kid'] ?? null) === $kid) {
+                    return $jwk;
+                }
+            }
+
+            throw new \RuntimeException('OIDC id_token kid does not match any JWKS entry.');
+        }
+
+        $candidates = array_values(array_filter(
+            $jwks,
+            fn ($jwk) => is_array($jwk) && ($jwk['kty'] ?? null) === $expectedKty
+        ));
+
+        if (count($candidates) === 0) {
+            throw new \RuntimeException('OIDC JWKS has no key compatible with id_token alg.');
+        }
+
+        if (count($candidates) > 1) {
+            throw new \RuntimeException('OIDC id_token has no kid and JWKS is ambiguous.');
+        }
+
+        return $candidates[0];
     }
 
     /**

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -710,6 +710,7 @@ class EventServiceProvider extends ServiceProvider
             // ... Manager won't register drivers that are not added to this listener.
             \SocialiteProviders\Apple\AppleExtendSocialite::class . '@handle',
             \SocialiteProviders\Microsoft\MicrosoftExtendSocialite::class . '@handle',
+            \App\Libraries\OAuth\Providers\Oidc\OidcExtendSocialite::class . '@handle',
         ],
 
     ];

--- a/config/services.php
+++ b/config/services.php
@@ -72,6 +72,20 @@ return [
         'redirect' => env('APPLE_REDIRECT_URI'),
     ],
 
+    'oidc' => [
+        // Full URL to the identity provider's discovery document, e.g.
+        // https://sso.example.com/application/o/invoiceninja/.well-known/openid-configuration
+        'well_known'     => env('OIDC_WELL_KNOWN', ''),
+        'client_id'      => env('OIDC_CLIENT_ID', ''),
+        'client_secret'  => env('OIDC_CLIENT_SECRET', ''),
+        // Fixed callback URL. Must be registered at the IdP.
+        'redirect'       => rtrim((string) env('APP_URL', ''), '/') . '/auth/oidc',
+        // Space-separated scopes.
+        'scopes'         => env('OIDC_SCOPES', 'openid profile email'),
+        // Human-readable label used on the Blade login page button.
+        'provider_label' => env('OIDC_PROVIDER_LABEL', 'OIDC'),
+    ],
+
     'ses' => [
         'key' => env('SES_AWS_ACCESS_KEY_ID'),
         'secret' => env('SES_AWS_SECRET_ACCESS_KEY'),

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -84,17 +84,6 @@
                                         </button>
                                     </div>
                                 </div>
-
-                                @if(config('services.oidc.well_known'))
-                                    <div class="row mt-3">
-                                        <div class="col-12 text-center">
-                                            <a class="btn btn-lg btn-secondary btn-block" href="/auth/oidc">
-                                                <i class="icon-login"></i>
-                                                Sign in with {{ config('services.oidc.provider_label', 'OIDC') }}
-                                            </a>
-                                        </div>
-                                    </div>
-                                @endif
                             </form>
                         </div>
                     </div>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -84,6 +84,17 @@
                                         </button>
                                     </div>
                                 </div>
+
+                                @if(config('services.oidc.well_known'))
+                                    <div class="row mt-3">
+                                        <div class="col-12 text-center">
+                                            <a class="btn btn-lg btn-secondary btn-block" href="/auth/oidc">
+                                                <i class="icon-login"></i>
+                                                Sign in with {{ config('services.oidc.provider_label', 'OIDC') }}
+                                            </a>
+                                        </div>
+                                    </div>
+                                @endif
                             </form>
                         </div>
                     </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -141,6 +141,7 @@ use Illuminate\Support\Facades\Route;
 Route::group(['middleware' => ['throttle:api', 'api_secret_check']], function () {
     Route::post('api/v1/signup', [AccountController::class, 'store'])->name('signup.submit')->middleware('throttle:1,1');
     Route::post('api/v1/oauth_login', [LoginController::class, 'oauthApiLogin']);
+    Route::get('api/v1/oidc/config', [LoginController::class, 'oidcConfig'])->name('oidc.config');
 });
 
 Route::group(['middleware' => ['throttle:precheck']], function () {

--- a/routes/api.php
+++ b/routes/api.php
@@ -142,6 +142,7 @@ Route::group(['middleware' => ['throttle:api', 'api_secret_check']], function ()
     Route::post('api/v1/signup', [AccountController::class, 'store'])->name('signup.submit')->middleware('throttle:1,1');
     Route::post('api/v1/oauth_login', [LoginController::class, 'oauthApiLogin']);
     Route::get('api/v1/oidc/config', [LoginController::class, 'oidcConfig'])->name('oidc.config');
+    Route::post('api/v1/oidc/exchange', [LoginController::class, 'oidcExchange'])->name('oidc.exchange')->middleware('throttle:30,1');
 });
 
 Route::group(['middleware' => ['throttle:precheck']], function () {


### PR DESCRIPTION
## Summary

Adds a generic OpenID Connect provider so any OIDC-conformant IdP
(Authentik, Keycloak, Zitadel, Authelia, Okta, Auth0, plain Google)
can log users in. Discovery is read from `.well-known/openid-configuration`
so nothing needs to change per-IdP beyond three env vars.

Closes #10839 — feature request from March 2025 that
[@turbo124 offered to accept a PR for](https://github.com/invoiceninja/invoiceninja/issues/10839#issuecomment-2707018793).

## Why

Self-hosted operators keep asking for OIDC (@cyberb, @NDCallahan, @jcrmxyz
and others in #10839). The current Microsoft/Apple flows are hardcoded to
each provider's SDK, so a previous attempt (referenced in the issue by
@cyberb) couldn't be generalised. Building on Socialite as an event-driven
provider keeps that footprint small — the driver is ~160 lines and never
touches the Google/Microsoft/Apple code paths.

## What changed

**New driver — `App\Libraries\OAuth\Providers\Oidc\Provider`**
- Extends `SocialiteProviders\Manager\OAuth2\AbstractProvider` (matches the
  existing Microsoft/Apple pattern).
- Fetches `.well-known/openid-configuration` on first use, caches it for
  1 hour (`ninja-oidc-discovery-<sha1(url)>`).
- Pulls the user via `userinfo_endpoint` — email + given_name + family_name
  are mapped to the Socialite `User` model; `sub` is the identifier.

**`LoginController::redirectToProvider`** — accepts `'oidc'` alongside the
existing `'google'`/`'microsoft'` whitelist.

**`LoginController::handleOidcProviderCallback`** — reuses the existing
`loginOrCreateFromSocialite()` path, then reads back the system
`CompanyToken` that `hydrateCompanyUser()` already provisions and redirects
to `\${REACT_URL}/oauth-callback?token=...`. The SPA already knows how to
turn that CompanyToken into a full CompanyUser via `refresh_react`
(companion PR: to be added below).

**`GET /api/v1/oidc/config`** — small unauthenticated endpoint returning
`{oidc_enabled, oidc_provider_label}` so the SPA can decide whether to
render the sign-in button.

**`resources/views/auth/login.blade.php`** — shows a "Sign in with
{OIDC_PROVIDER_LABEL}" button on the Blade fallback login page too (same
env-gated visibility).

## Env vars

\`\`\`
OIDC_WELL_KNOWN=https://sso.example.com/.well-known/openid-configuration
OIDC_CLIENT_ID=...
OIDC_CLIENT_SECRET=...
OIDC_PROVIDER_LABEL=SSO         # optional; button text ("Sign in with SSO")
OIDC_SCOPES="openid profile email"   # optional; sane default
\`\`\`

The redirect URL to register at the IdP is \`\${APP_URL}/auth/oidc\`
(same shape as \`/auth/google\` etc.).

## Backward compatibility

- \`OIDC_*\` all default to empty. When \`OIDC_CLIENT_ID\` is unset:
  - \`redirectToProvider('oidc')\` still 400s (unchanged whitelist behaviour),
  - \`/api/v1/oidc/config\` returns \`{oidc_enabled: false}\` and the SPA hides
    the button,
  - the Blade login shows no OIDC button.
- No changes to Google/Microsoft/Apple flows, no changes to \`OAuth::handleAuth\`,
  no DB migration. \`oauth_user_id\` and \`oauth_provider_id\` columns exist
  already; new rows land with \`oauth_provider_id = 'oidc'\`.

## Tests

I don't have automated coverage here — happy to add tests before merge if
you'd like to guide the mocking pattern for the Socialite driver (all the
existing OAuth flows appear to be exercised only via feature tests that
short-circuit the redirect). Manually validated end-to-end against a
self-hosted Authentik: fresh login, existing-user email link, existing-user
sub relink.

## Companion frontend PR

Companion UI PR: invoiceninja/ui#3249 — it adds the
"Sign in with X" button, the \`/oauth-callback\` route consumer, and hides
the button when \`oidc_enabled: false\`. Both PRs are required to ship the
feature; backend can merge independently and remain a no-op for anyone who
hasn't set the env vars.