### PR TITLE
Seed task rate from project.task_rate at the request layer (#6380)

### DIFF
--- a/app/Http/Requests/Task/StoreTaskRequest.php
+++ b/app/Http/Requests/Task/StoreTaskRequest.php
@@ -179,6 +179,11 @@ class StoreTaskRequest extends Request
 
             if ($project) {
                 $input['client_id'] = $project->client_id;
+
+                /* If no rate was explicitly provided, seed it from the project's task_rate (see #6380) */
+                if (!isset($input['rate']) || $input['rate'] === '') {
+                    $input['rate'] = $project->task_rate ?? 0;
+                }
             } else {
                 unset($input['project_id']);
             }

--- a/tests/Feature/TaskApiTest.php
+++ b/tests/Feature/TaskApiTest.php
@@ -725,6 +725,48 @@ class TaskApiTest extends TestCase
         $this->assertEquals(101, $arr['data']['rate']);
     }
 
+    public function testTaskRateBaseValueFromProject()
+    {
+        // #6380 - the request layer seeds the task rate from project.task_rate ?? 0
+        // when no rate is explicitly provided, and honors an explicit rate otherwise.
+
+        $p = Project::factory()->create([
+            'user_id' => $this->user->id,
+            'company_id' => $this->company->id,
+            'client_id' => $this->client->id,
+            'name' => 'proggy base value',
+            'task_rate' => 77,
+        ]);
+
+        // No rate supplied -> seeded from the project's task_rate.
+        $data = [
+            'project_id' => $p->hashed_id,
+            'client_id' => $this->client->id,
+            'description' => 'Seeded from project',
+            'time_log' => '[[1681165417,1681165432,"sumtin",true],[1681165446,0]]',
+        ];
+
+        $response = $this->withHeaders([
+            'X-API-SECRET' => config('ninja.api_secret'),
+            'X-API-TOKEN' => $this->token,
+        ])->postJson("/api/v1/tasks", $data);
+
+        $response->assertStatus(200);
+        $this->assertEquals(77, $response->json()['data']['rate']);
+
+        // Explicit rate supplied -> honored, not overwritten by the project rate.
+        $data['rate'] = 250;
+        $data['description'] = 'Explicit rate wins';
+
+        $response = $this->withHeaders([
+            'X-API-SECRET' => config('ninja.api_secret'),
+            'X-API-TOKEN' => $this->token,
+        ])->postJson("/api/v1/tasks", $data);
+
+        $response->assertStatus(200);
+        $this->assertEquals(250, $response->json()['data']['rate']);
+    }
+
     public function testStatusSet()
     {
 


### PR DESCRIPTION
Closes #6380.

Per @turbo124's guidance on the issue — "When storing a task with a project_id, you'll need to ensure that the `project.task_rate ?? 0` is passed in as the base value. @ the request layer in `prepareForValidation()`" — this seeds the task rate from the associated project's `task_rate ?? 0` in `StoreTaskRequest::prepareForValidation()` when no rate is explicitly provided. It reuses the `Project` already loaded in that method for client resolution, and an explicitly submitted rate is still honored (absent / empty is treated as unset, an explicit value including `0` is kept).

Adds a feature test alongside the existing task-rate coverage in `tests/Feature/TaskApiTest.php`.

Note for review: for the original explicit-`$0.00` project-rate scenario to be honored all the way through, `TaskRepository::save()` (re-derives when `rate <= 0`) and `Task::getRate()` (`project->task_rate > 0`) would also need to accept `0` — happy to fold those into this PR or do a separate one, whichever you prefer.
