### PR TITLE
fix(client-portal): assign null instead of unset() on invoice backup redirect (post-payment 500)

### DIFF
--- a/app/Http/Controllers/ClientPortal/PaymentController.php
+++ b/app/Http/Controllers/ClientPortal/PaymentController.php
@@ -75,7 +75,7 @@ class PaymentController extends Controller
         if ($invoice) {
             $backup = $invoice->backup;
             $url = $backup->redirect;
-            unset($backup->redirect);
+            $backup->redirect = null;
             $invoice->saveQuietly();
             return redirect($url);
         }


### PR DESCRIPTION
Fixes #12109

## Summary

`ClientPortal\PaymentController::show()` returns **HTTP 500** when consuming a per-invoice
post-payment redirect, so a payer who used `?redirect=` is shown an error page instead of being
sent to the redirect URL.

## Steps to reproduce

1. Create an invoice with a `?redirect=` query parameter (a triggered action that persists the URL to
   `invoice->backup->redirect`).
2. Pay the invoice through the client portal.
3. After payment the portal hits `PaymentController::show()`, which 500s.

## Root cause

```php
$backup = $invoice->backup;
$url = $backup->redirect;
unset($backup->redirect);   // leaves the typed property uninitialized (not null)
$invoice->saveQuietly();    // re-reads it through the cast -> fatal Error
return redirect($url);
```

`InvoiceBackup::$redirect` is a **typed** property. `unset()` on a typed property returns it to the
*uninitialized* state rather than `null`; the immediately following `saveQuietly()` re-serialises the
`backup` cast, which reads `$redirect` and throws
`Error: Typed property InvoiceBackup::$redirect must not be accessed before initialization`.

## Fix

`InvoiceBackup::$redirect` is declared `public ?string $redirect = null`, so assigning `null` is
type-safe and clears the one-shot redirect just as `unset()` intended — without leaving the property
uninitialised:

```php
-            unset($backup->redirect);
+            $backup->redirect = null;
```

One line, no behaviour change on the happy path: the redirect is still consumed exactly once and the
payer is still forwarded to `$url`.

Verified against `v5.13.26`.