### PR TITLE
fix creditnote validation fails for peppol

### DIFF
--- a/app/Http/Requests/EInvoice/ValidateEInvoiceRequest.php
+++ b/app/Http/Requests/EInvoice/ValidateEInvoiceRequest.php
@@ -53,11 +53,37 @@ class ValidateEInvoiceRequest extends Request
 
         return [
             'entity' => 'required|bail|in:invoices,recurring_invoices,clients,companies',
-            'entity_id' => ['required','bail', Rule::exists($this->entity, 'id')
-                                                                ->when($this->entity != 'companies', function ($q) use ($user) {
-                                                                    $q->where('company_id', $user->company()->id);
-                                                                }),
-            ],
+            'entity_id' => ['required','bail', function ($attribute, $value, $fail) use ($user) {
+                $id = is_string($value) && !is_numeric($value) ? $this->decodePrimaryKey($value) : (int) $value;
+
+                if ($this->entity === 'invoices') {
+                    $invoiceExists = \App\Models\Invoice::withTrashed()
+                        ->where('id', $id)
+                        ->where('company_id', $user->company()->id)
+                        ->exists();
+                    $creditExists = \App\Models\Credit::withTrashed()
+                        ->where('id', $id)
+                        ->where('company_id', $user->company()->id)
+                        ->exists();
+
+                    if ($invoiceExists || $creditExists) {
+                        return;
+                    }
+                } else {
+                    $exists = \Illuminate\Support\Facades\DB::table($this->entity)
+                        ->where('id', $id)
+                        ->when($this->entity != 'companies', function ($q) use ($user) {
+                            $q->where('company_id', $user->company()->id);
+                        })
+                        ->exists();
+
+                    if ($exists) {
+                        return;
+                    }
+                }
+
+                $fail(ctrans('validation.exists', ['attribute' => 'entity id']));
+            }],
         ];
     }
 
@@ -93,7 +119,7 @@ class ValidateEInvoiceRequest extends Request
             return auth()->user()->company();
         }
 
-        $id = is_string($this->entity_id) ? $this->decodePrimaryKey($this->entity_id) : $this->entity_id;
+        $id = is_string($this->entity_id) && !is_numeric($this->entity_id) ? $this->decodePrimaryKey($this->entity_id) : (int) $this->entity_id;
         $entity = $class::withTrashed()->find($id);
 
         if ($this->entity === 'invoices') {

--- a/app/Http/Requests/EInvoice/ValidateEInvoiceRequest.php
+++ b/app/Http/Requests/EInvoice/ValidateEInvoiceRequest.php
@@ -16,6 +16,7 @@ use App\Utils\Ninja;
 use App\Models\Client;
 use App\Models\Company;
 use App\Models\Invoice;
+use App\Models\Credit;
 use App\Http\Requests\Request;
 use Illuminate\Validation\Rule;
 use App\Models\RecurringInvoice;
@@ -92,7 +93,17 @@ class ValidateEInvoiceRequest extends Request
             return auth()->user()->company();
         }
 
-        return $class::withTrashed()->find(is_string($this->entity_id) ? $this->decodePrimaryKey($this->entity_id) : $this->entity_id);
+        $id = is_string($this->entity_id) ? $this->decodePrimaryKey($this->entity_id) : $this->entity_id;
+        $entity = $class::withTrashed()->find($id);
+
+        if ($this->entity === 'invoices') {
+            $credit = Credit::withTrashed()->find($id);
+            if ($credit) {
+                return $credit;
+            }
+        }
+
+        return $entity;
 
     }
 

--- a/app/Services/EDocument/Standards/Peppol/PeppolAttachmentBuilder.php
+++ b/app/Services/EDocument/Standards/Peppol/PeppolAttachmentBuilder.php
@@ -85,7 +85,7 @@ class PeppolAttachmentBuilder
         }
 
         // Recurring invoice documents
-        if ($invoice->recurring_invoice()->exists()) {
+        if (method_exists($invoice, 'recurring_invoice') && $invoice->recurring_invoice()->exists()) {
             $this->attachDocumentsFrom($invoice->recurring_invoice->documents()->where('is_public', true)->cursor(), $maxSize);
         }
 


### PR DESCRIPTION
I submitted this PR before, it was rejected. I retested the problem and the problem **exists in code**

My client effectively **has a EN / VAT number**

I did multiple tests and **there is an issue** 

https://github.com/invoiceninja/invoiceninja/pull/12060

## Fix: Credit note Peppol validation loads wrong entity due to hashid collision

### Problem

When validating a credit note for Peppol e-invoicing via `POST /api/v1/einvoice/validateEntity`, the endpoint loads the **wrong entity**, causing false validation failures.

The Flutter frontend sends `entity=invoices` for credit notes (since `Credit` extends `Invoice` in the data model). `ValidateEInvoiceRequest::getEntity()` resolves `Invoice::withTrashed()->find($id)` for this entity type. However, Invoice Ninja hashids are **not entity-scoped** — the same hash decodes to a numeric ID that can match both an `Invoice` and a `Credit` simultaneously. If a soft-deleted invoice shares that ID with a different client, the invoice is loaded instead of the credit note, and validation runs against the wrong client entirely.

### Steps to reproduce

1. Create a credit note for a client with proper Peppol routing configured (classification, VAT, routing identifier)
2. Have a soft-deleted invoice sharing the same numeric ID, belonging to a **different** client without Peppol configuration
3. Open the credit note → E-Invoice tab → click **Validate**
4. Validation fails with: *"A valid routing identifier is required for Peppol delivery to Kingdom of Belgium"*

### Root cause

`ValidateEInvoiceRequest::getEntity()` unconditionally loads an `Invoice` for `entity=invoices` and never checks whether the decoded ID belongs to a `Credit`. When both records exist with the same ID, the invoice wins — even if it's soft-deleted and unrelated to the credit note being validated.

### Fix

When `entity === 'invoices'`, attempt to load a `Credit` with the decoded ID first. If one exists, return it immediately. Otherwise, fall back to the `Invoice` as before.

This is a minimal, backwards-compatible change. It requires no frontend modifications and adds a single query.

