### PR TITLE
fix: quickbooks not pushing updates on self host instances

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -1067,10 +1067,13 @@ class Company extends BaseModel
      */
     public function shouldPushToQuickbooks(string $entity): bool
     {
+
+        $self_host = Ninja::isSelfHost() || !Ninja::isNinja();
+        
         // FASTEST CHECK: Raw database column (no object instantiation, no JSON decode)
         // This is the cheapest possible check - just a null comparison
         // For companies without QuickBooks, this returns immediately with ~0.001ms overhead
-        if (is_null($this->getRawOriginal('quickbooks')) || !$this->account->isPaid()) {
+        if (is_null($this->getRawOriginal('quickbooks')) || (!$this->account->isPaid() && !$self_host)) {
             return false;
         }
 


### PR DESCRIPTION
Based on my query on discord, self-host does allow Quickbooks integration - I noticed a flaw in the logic where it has to be a paid instance or white labelled.