### PR TITLE
Fix endless reminder template resolution key matching

### DIFF
--- a/app/Jobs/Invoice/BulkInvoiceJob.php
+++ b/app/Jobs/Invoice/BulkInvoiceJob.php
@@ -126,7 +126,7 @@ class BulkInvoiceJob implements ShouldQueue
             'reminder1' => 'email_template_reminder1',
             'reminder2' => 'email_template_reminder2',
             'reminder3' => 'email_template_reminder3',
-            'endless_reminder' => 'email_template_reminder_endless',
+            'endless_reminder', 'reminder_endless', 'email_template_reminder_endless' => 'email_template_reminder_endless',
             'custom1' => 'email_template_custom1',
             'custom2' => 'email_template_custom2',
             'custom3' => 'email_template_custom3',

--- a/app/Services/Invoice/SendEmail.php
+++ b/app/Services/Invoice/SendEmail.php
@@ -88,7 +88,7 @@ class SendEmail extends AbstractService
             'reminder1' => 'email_template_reminder1',
             'reminder2' => 'email_template_reminder2',
             'reminder3' => 'email_template_reminder3',
-            'endless_reminder' => 'email_template_reminder_endless',
+            'endless_reminder', 'reminder_endless', 'email_template_reminder_endless' => 'email_template_reminder_endless',
             'custom1' => 'email_template_custom1',
             'custom2' => 'email_template_custom2',
             'custom3' => 'email_template_custom3',

--- a/app/Services/Quote/SendEmail.php
+++ b/app/Services/Quote/SendEmail.php
@@ -69,6 +69,7 @@ class SendEmail
         return match ($template) {
             'quote' => 'email_template_quote',
             'reminder1' => 'email_quote_template_reminder1',
+            'endless_reminder', 'reminder_endless', 'email_template_reminder_endless' => 'email_template_reminder_endless',
             'custom1' => 'email_template_custom1',
             'custom2' => 'email_template_custom2',
             'custom3' => 'email_template_custom3',


### PR DESCRIPTION
Fixes issue where selecting Endless Reminder from the UI sends template key 'reminder_endless', which previously fell through resolveTemplateString() to default => 'email_template_invoice'