### PR TITLE
Log skipped PDF attachment merge when downgrade module is missing (#12004)

### DIFF
--- a/app/Services/PdfMaker/PdfMerge.php
+++ b/app/Services/PdfMaker/PdfMerge.php
@@ -12,6 +12,7 @@
 
 namespace App\Services\PdfMaker;
 
+use Illuminate\Support\Facades\Log;
 use setasign\Fpdi\Fpdi;
 use setasign\Fpdi\PdfParser\StreamReader;
 
@@ -44,6 +45,10 @@ class PdfMerge
                     $downgradedPdf = \Modules\Admin\Services\PdfParse::downgrade($file);
 
                     $pageCount = $pdf->setSourceFile(StreamReader::createByString($downgradedPdf));
+                } else {
+                    Log::error('PDF attachment merge skipped, unable to downgrade PDF for embedding', [
+                        'error' => $e->getMessage(),
+                    ]);
                 }
 
             }

--- a/tests/Unit/Services/PdfMaker/PdfMergeSilentDropLogTest.php
+++ b/tests/Unit/Services/PdfMaker/PdfMergeSilentDropLogTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace Tests\Unit\Services\PdfMaker;
+
+use App\Services\PdfMaker\PdfMerge;
+use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+class PdfMergeSilentDropLogTest extends TestCase
+{
+    private Container $container;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = new Container();
+        Facade::setFacadeApplication($this->container);
+    }
+
+    protected function tearDown(): void
+    {
+        Facade::clearResolvedInstances();
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testLogsWhenPdfCannotBeDowngradedDueToMissingPaidModule(): void
+    {
+        $logger = Mockery::mock();
+        $logger->shouldReceive('error')
+            ->once()
+            ->with('PDF attachment merge skipped, unable to downgrade PDF for embedding', Mockery::type('array'));
+
+        $this->container->instance('log', $logger);
+
+        $merge = new PdfMerge([$this->unparsablePdfContents()]);
+
+        $result = $merge->run();
+
+        $this->assertIsString($result);
+    }
+
+    private function unparsablePdfContents(): string
+    {
+        // Not a valid PDF stream, forces FPDI to throw a PdfParserException.
+        return "%PDF-1.7\nnot a real pdf body";
+    }
+}


### PR DESCRIPTION
Fixes #12004

## Problem
`App\Services\PdfMaker\PdfMerge::run()` catches `setasign\Fpdi\PdfParser\PdfParserException` (thrown by FPDI for PDFs it can't parse natively, e.g. modern v1.5+ PDFs) and only recovers by downgrading via `\Modules\Admin\Services\PdfParse`, a paid-module class that does not exist on self-hosted installs. When `class_exists()` fails, the attachment is silently dropped from the merged PDF with nothing written to `laravel.log`.

## Fix
Minimal, non-behavioral change: add an `else` branch that logs `Log::error(...)` with the original exception message when the downgrade path is unavailable, so self-hosted admins can see why an attachment failed to embed instead of it disappearing without a trace. No attempt at a Ghostscript/shell_exec fallback — kept out of scope per the issue's own "at least log an error" fallback expectation.

## Test plan
- Added `tests/Unit/Services/PdfMaker/PdfMergeSilentDropLogTest.php` (plain PHPUnit, no full Laravel boot) that feeds `PdfMerge` an unparsable PDF stream and asserts `Log::error` is called once with the expected message when the paid module class is absent.
- Verified red → green manually: reverted the source fix and confirmed the test fails (0 calls to `Log::error`), then reapplied the fix and confirmed it passes.
- Ran via a disposable `php:8.3-cli` Docker container (no local PHP/Composer in this shell): `php vendor/bin/phpunit --no-configuration tests/Unit/Services/PdfMaker/PdfMergeSilentDropLogTest.php` → `OK (1 test, 1 assertion)`.
