### PR TITLE
Fix false positive pending_migrations in health check

### DIFF
--- a/app/Utils/SystemHealth.php
+++ b/app/Utils/SystemHealth.php
@@ -185,13 +185,16 @@ class SystemHealth
     {
         $connectionName = config('database.default');
 
-        $run_count = DB::connection($connectionName)->table('migrations')->count();
+        $ran = DB::connection($connectionName)->table('migrations')->pluck('migration');
 
         $directory = base_path('database/migrations');
-        $iterator = new \FilesystemIterator($directory);
-        $total_count = iterator_count($iterator) - 1;
 
-        return $run_count != $total_count;
+        $pending = collect(new \FilesystemIterator($directory))
+            ->filter(fn ($file) => $file->getExtension() === 'php')
+            ->map(fn ($file) => $file->getBasename('.php'))
+            ->diff($ran);
+
+        return $pending->isNotEmpty();
     }
 
     public static function getPdfEngine()


### PR DESCRIPTION
Fixes #12215

`SystemHealth::checkPendingMigrations()` compared the `migrations` table **row count** against the migration **file count**. On any install that upgraded through releases whose migration files were later removed (e.g. `2024_08_27_230111_blockonomics_gateway`), or that recorded vendor package migrations, the counts can never match again — so `pending_migrations` reports `true` forever, even when `artisan migrate:status` shows nothing pending.

This changes the check to compare **names** instead of counts: pending now means "a shipped migration file that has no row in the `migrations` table", matching what `artisan migrate` would actually run. Orphan rows (upgrade history) no longer trip the flag, and the count-collision false negative (N orphan rows masking N genuinely pending files) is gone too. The `- 1` directory-entry assumption disappears as well.

Verified via tinker on a self-hosted v5.13.35 Docker install with 312 migration rows / 309 shipped files (all migrations run, 3 orphan rows): old check returns `true`, new check returns `false`; adding a simulated un-run migration filename to the file list correctly returns `true`.
