### PR TITLE
docs: add RepoCloud as a self-hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ All Pro and Enterprise features from the hosted app are included in the source-a
 * [Softaculous](https://www.softaculous.com/apps/ecommerce/Invoice_Ninja)
 * [Elestio](https://elest.io/open-source/invoiceninja)
 * [YunoHost](https://apps.yunohost.org/app/invoiceninja5)
+* [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Invoice%20Ninja/)
 
 ### Recommended Providers
 * [Stripe](https://stripe.com/)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ All Pro and Enterprise features from the hosted app are included in the source-a
 * [Softaculous](https://www.softaculous.com/apps/ecommerce/Invoice_Ninja)
 * [Elestio](https://elest.io/open-source/invoiceninja)
 * [YunoHost](https://apps.yunohost.org/app/invoiceninja5)
-* [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Invoice%20Ninja/)
+* [RepoCloud](https://repocloud.io/details/Invoice%20Ninja/)
 
 ### Recommended Providers
 * [Stripe](https://stripe.com/)


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a self-hosted deployment option alongside
Cloudron, Softaculous, Elestio, and YunoHost in the "Self-Hosted Server Installation" section.

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment.

- Adds RepoCloud text link to the `README.md` self-hosted installation list
- Follows the existing bullet-point text link format
- Links to: https://repocloud.io/details/Invoice%20Ninja/