### PR TITLE
fix: use bcmath for refund amount comparisons in ValidRefundableRequest

### DIFF
--- a/app/Http/ValidationRules/Payment/ValidRefundableRequest.php
+++ b/app/Http/ValidationRules/Payment/ValidRefundableRequest.php
@@ -14,6 +14,7 @@ namespace App\Http\ValidationRules\Payment;
 
 use App\Models\Invoice;
 use App\Models\Payment;
+use App\Utils\BcMath;
 use App\Utils\Traits\MakesHash;
 use Illuminate\Contracts\Validation\Rule;
 
@@ -113,9 +114,9 @@ class ValidRefundableRequest implements Rule
                 if ($request_invoice['invoice_id'] == $paymentable->pivot->paymentable_id) {
                     $record_found = true;
 
-                    $refundable_amount = ($paymentable->pivot->amount - $paymentable->pivot->refunded);
+                    $refundable_amount = BcMath::sub($paymentable->pivot->amount, $paymentable->pivot->refunded, 2);
 
-                    if ($request_invoice['amount'] > $refundable_amount) {
+                    if (BcMath::greaterThan($request_invoice['amount'], $refundable_amount, 2)) {
                         $invoice = $paymentable;
 
                         $this->error_msg = ctrans('texts.max_refundable_invoice', ['invoice' => $invoice->hashed_id, 'amount' => $refundable_amount]);
@@ -146,32 +147,32 @@ class ValidRefundableRequest implements Rule
     private function checkTotalRefundableAmount(Payment $payment, array $request_invoices): bool
     {
         // Calculate total refund amount requested
-        $total_refund_requested = 0;
+        $total_refund_requested = '0';
 
         if (count($request_invoices) > 0) {
-            $total_refund_requested = collect($request_invoices)->sum('amount');
+            $total_refund_requested = BcMath::sum(collect($request_invoices)->pluck('amount')->all(), 2);
         } elseif (array_key_exists('amount', $this->input)) {
-            $total_refund_requested = $this->input['amount'];
+            $total_refund_requested = BcMath::round($this->input['amount'], 2);
         }
 
-        if ($total_refund_requested <= 0) {
+        if (BcMath::lessThanOrEqual($total_refund_requested, 0, 2)) {
             return true; // No refund requested
         }
 
         // Calculate maximum refundable from cash portion
-        $max_cash_refund = $payment->amount - $payment->refunded;
+        $max_cash_refund = BcMath::sub($payment->amount, $payment->refunded, 2);
 
         // Calculate maximum refundable from credits
-        $max_credit_refund = 0;
+        $max_credit_refund = '0';
         if ($payment->credits()->exists()) {
             foreach ($payment->credits as $credit) {
-                $max_credit_refund += ($credit->pivot->amount - $credit->pivot->refunded);
+                $max_credit_refund = BcMath::add($max_credit_refund, BcMath::sub($credit->pivot->amount, $credit->pivot->refunded, 2), 2);
             }
         }
 
-        $max_total_refundable = $max_cash_refund + $max_credit_refund;
+        $max_total_refundable = BcMath::add($max_cash_refund, $max_credit_refund, 2);
 
-        if ($total_refund_requested > $max_total_refundable) {
+        if (BcMath::greaterThan($total_refund_requested, $max_total_refundable, 2)) {
             $this->error_msg = ctrans('texts.max_refundable_payment', [
                 'max_refundable' => $max_total_refundable,
             ]);

--- a/tests/Unit/ValidationRules/ValidRefundableRequestTest.php
+++ b/tests/Unit/ValidationRules/ValidRefundableRequestTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace Tests\Unit\ValidationRules;
+
+use App\Http\ValidationRules\Payment\ValidRefundableRequest;
+use App\Models\Invoice;
+use App\Models\Payment;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use Tests\MockAccountData;
+use Tests\TestCase;
+
+/**
+ * Reproduces a real-world refund rejection caused by floating point
+ * arithmetic in ValidRefundableRequest::checkTotalRefundableAmount()
+ * and ::checkInvoice().
+ *
+ * A payment of 30.20 fully applied across two invoices of 18.35 and
+ * 11.85 could not be refunded in full: summing 18.35 + 11.85 as native
+ * PHP floats yields 30.200000000000003, which then fails a strict `>`
+ * comparison against the 30.20 refundable maximum.
+ */
+class ValidRefundableRequestTest extends TestCase
+{
+    use DatabaseTransactions;
+    use MockAccountData;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware(ThrottleRequests::class);
+
+        $this->makeTestData();
+    }
+
+    public function testFullRefundOfPaymentSplitAcrossTwoInvoicesIsNotRejectedByFloatDrift()
+    {
+        $invoice_a = Invoice::factory()->create([
+            'client_id' => $this->client->id,
+            'user_id' => $this->user->id,
+            'company_id' => $this->company->id,
+            'status_id' => Invoice::STATUS_PAID,
+            'amount' => 18.35,
+            'balance' => 0,
+            'paid_to_date' => 18.35,
+            'date' => now(),
+            'due_date' => now(),
+        ]);
+
+        $invoice_b = Invoice::factory()->create([
+            'client_id' => $this->client->id,
+            'user_id' => $this->user->id,
+            'company_id' => $this->company->id,
+            'status_id' => Invoice::STATUS_PAID,
+            'amount' => 11.85,
+            'balance' => 0,
+            'paid_to_date' => 11.85,
+            'date' => now(),
+            'due_date' => now(),
+        ]);
+
+        $payment = Payment::factory()->create([
+            'client_id' => $this->client->id,
+            'user_id' => $this->user->id,
+            'company_id' => $this->company->id,
+            'amount' => 30.20,
+            'applied' => 30.20,
+            'refunded' => 0,
+            'status_id' => Payment::STATUS_COMPLETED,
+            'date' => now(),
+        ]);
+
+        $payment->invoices()->attach($invoice_a->id, ['amount' => 18.35, 'refunded' => 0]);
+        $payment->invoices()->attach($invoice_b->id, ['amount' => 11.85, 'refunded' => 0]);
+
+        $input = [
+            'id' => $payment->id,
+            'amount' => 30.20,
+            'date' => now()->format('Y-m-d'),
+            'invoices' => [
+                ['invoice_id' => $invoice_a->id, 'amount' => 18.35],
+                ['invoice_id' => $invoice_b->id, 'amount' => 11.85],
+            ],
+        ];
+
+        request()->merge($input);
+
+        $rule = new ValidRefundableRequest($input);
+
+        $this->assertTrue($rule->passes('id', $payment->id), $rule->message());
+    }
+
+    public function testPartialRefundThatExceedsRemainingBalanceIsStillRejected()
+    {
+        $invoice = Invoice::factory()->create([
+            'client_id' => $this->client->id,
+            'user_id' => $this->user->id,
+            'company_id' => $this->company->id,
+            'status_id' => Invoice::STATUS_PAID,
+            'amount' => 30.20,
+            'balance' => 0,
+            'paid_to_date' => 30.20,
+            'date' => now(),
+            'due_date' => now(),
+        ]);
+
+        $payment = Payment::factory()->create([
+            'client_id' => $this->client->id,
+            'user_id' => $this->user->id,
+            'company_id' => $this->company->id,
+            'amount' => 30.20,
+            'applied' => 30.20,
+            'refunded' => 0,
+            'status_id' => Payment::STATUS_COMPLETED,
+            'date' => now(),
+        ]);
+
+        $payment->invoices()->attach($invoice->id, ['amount' => 30.20, 'refunded' => 0]);
+
+        $input = [
+            'id' => $payment->id,
+            'amount' => 30.21,
+            'date' => now()->format('Y-m-d'),
+            'invoices' => [
+                ['invoice_id' => $invoice->id, 'amount' => 30.21],
+            ],
+        ];
+
+        request()->merge($input);
+
+        $rule = new ValidRefundableRequest($input);
+
+        $this->assertFalse($rule->passes('id', $payment->id));
+    }
+}


### PR DESCRIPTION
Fixes #12231

## Summary

We hit a real case where a client's refund was rejected with `max_refundable_payment` even though the requested amount exactly matched what was paid.

Payment of `30.20` fully applied across two invoices of `18.35` and `11.85`. Requesting a full refund across both invoices should succeed, but `ValidRefundableRequest::checkTotalRefundableAmount()` compares the sum of the requested amounts against the payment's refundable balance using native float arithmetic and a strict `>`:

```php
$total_refund_requested = collect($request_invoices)->sum('amount'); // 18.35 + 11.85
...
if ($total_refund_requested > $max_total_refundable) { ... }
```

`18.35 + 11.85` as IEEE-754 doubles evaluates to `30.200000000000003`, which is `>` the `30.20` refundable maximum, so the refund is rejected even though it is exactly the amount paid. The same float-subtraction + strict `>` pattern also exists in `checkInvoice()` for the per-invoice check.

## Changes

- `app/Http/ValidationRules/Payment/ValidRefundableRequest.php`: route all refund-amount arithmetic and comparisons in `checkInvoice()` and `checkTotalRefundableAmount()` through the existing `App\Utils\BcMath` helper at currency precision (scale 2), instead of native float `+`/`-`/`>`. No behavior change for genuinely-invalid refund requests — only removes false rejections caused by float drift.
- `tests/Unit/ValidationRules/ValidRefundableRequestTest.php` (new): reproduces the exact reported scenario (payment `30.20` split across invoices `18.35` + `11.85`, full refund requested) and asserts it now passes, plus a guard test asserting a genuinely excessive refund request is still rejected.

## Testing

Verified locally against MySQL/MariaDB (matching this repo's CI, not phpunit.xml's sqlite default, which several older migrations don't support):

```
vendor/bin/phpunit tests/Unit/ValidationRules/ValidRefundableRequestTest.php
OK (2 tests, 2 assertions)
```

Also confirmed the new test reproduces the bug: reverting only the `ValidRefundableRequest.php` change (keeping the test) makes `testFullRefundOfPaymentSplitAcrossTwoInvoicesIsNotRejectedByFloatDrift` fail with `texts.max_refundable_payment`, exactly matching the real-world error.