### PR TITLE
Bulgarian VAT is ДДС, not НДС

### DIFF
--- a/app/DataMapper/Tax/BG/Rule.php
+++ b/app/DataMapper/Tax/BG/Rule.php
@@ -40,6 +40,6 @@ class Rule extends DERule
     /** @var float $reduced_tax_rate */
     public float $reduced_tax_rate = 0;
 
-    public string $tax_name1 = 'НДС';
+    public string $tax_name1 = 'ДДС';
 
 }


### PR DESCRIPTION
`BG\Rule` declares `$tax_name1 = 'НДС'`, which is Russian. Bulgarian VAT is **ДДС** (данък върху добавената стойност).

It is not only a label. `Rule::init()` copies `$tax_name1` into `$tax_name`, `taxByType()` writes it onto every line item, and it is then printed in the line table and the totals block of the invoice - so a Bulgarian seller's invoices name the tax in the wrong language. `calculateRates()` overrides `$tax_name` only in the over-threshold B2C branch, which a seller below the 10 000 EUR OSS threshold never reaches, so nothing corrects it downstream.

`TaxModel` already has it right (`regions.EU.subregions.BG.tax_name` is `'ДДС'`), so this also removes a disagreement inside the codebase.

One line, no behaviour change beyond the name.