### PR TITLE
Make the VIES check work: REST instead of SOAP, and record a "no"

### DIFF
--- a/app/Jobs/Client/CheckVat.php
+++ b/app/Jobs/Client/CheckVat.php
@@ -32,7 +32,10 @@ class CheckVat implements ShouldQueue
     use SerializesModels;
     use MakesHash;
 
-    public $tries = 1;
+    public $tries = 4;
+
+    /** Retried when VIES gives no verdict: a member state's system is down, or the caller is rate limited */
+    public array $backoff = [60, 600, 3600];
 
     /**
      * Create a new job instance.

--- a/app/Services/Tax/TaxService.php
+++ b/app/Services/Tax/TaxService.php
@@ -18,33 +18,49 @@ class TaxService
 {
     public function __construct(public Client $client) {}
 
+    /**
+     * Ask VIES about the client's VAT number and record the answer.
+     *
+     * A definite answer sets the flag either way. An answer of "not registered" now clears
+     * `has_valid_vat_number`, where before there was no `else` at all: a number VIES
+     * rejected left the flag at whatever it was, so a counterparty whose registration was
+     * later cancelled kept a zero-rated, reverse-charge treatment indefinitely.
+     *
+     * No answer changes nothing. VIES reports "not registered" and "that member state's
+     * system is down" through the same field, and the endpoint throttles by IP, so an
+     * outage must never be read as a rejection.
+     */
     public function validateVat(): self
     {
-        if (!extension_loaded('soap')) {
-            nlog("Install the PHP SOAP extension if you wish to check VAT Numbers. See https://www.php.net/manual/en/soap.installation.php for more information on installing the PHP");
+        $client_country_code = $this->client->shipping_country ? $this->client->shipping_country->iso_3166_2 : $this->client->country->iso_3166_2;
+
+        $check = (new VatNumberCheck(
+            $this->client->vat_number,
+            $client_country_code,
+            $this->client->company->settings->vat_number ?? null
+        ))->run();
+
+        if ($check->isUnavailable()) {
+            nlog("VIES did not answer for {$this->client->vat_number} ({$check->getError()}) - the existing flag is left unchanged");
+
             return $this;
         }
 
-        $client_country_code = $this->client->shipping_country ? $this->client->shipping_country->iso_3166_2 : $this->client->country->iso_3166_2;
+        $valid = $check->isValid();
 
-        $vat_check = (new VatNumberCheck($this->client->vat_number, $client_country_code))->run();
+        $this->client->has_valid_vat_number = $valid;
 
-        // nlog($vat_check);
-
-        if ($vat_check->isValid()) {
-
-            $this->client->has_valid_vat_number = true;
-
-            if (!$this->client->name && strlen($vat_check->getName()) > 2) {
-                $this->client->name = $vat_check->getName();
+        if ($valid) {
+            if (!$this->client->name && strlen($check->getName()) > 2) {
+                $this->client->name = $check->getName();
             }
 
-            if (empty($this->client->private_notes) && strlen($vat_check->getAddress()) > 2) {
-                $this->client->private_notes = $vat_check->getAddress();
+            if (empty($this->client->private_notes) && strlen($check->getAddress()) > 2) {
+                $this->client->private_notes = $check->getAddress();
             }
-
-            $this->client->saveQuietly();
         }
+
+        $this->client->saveQuietly();
 
         return $this;
 

--- a/app/Services/Tax/TaxService.php
+++ b/app/Services/Tax/TaxService.php
@@ -18,45 +18,26 @@ class TaxService
 {
     public function __construct(public Client $client) {}
 
-    /**
-     * Ask VIES about the client's VAT number and record the answer.
-     *
-     * A definite answer sets the flag either way. An answer of "not registered" now clears
-     * `has_valid_vat_number`, where before there was no `else` at all: a number VIES
-     * rejected left the flag at whatever it was, so a counterparty whose registration was
-     * later cancelled kept a zero-rated, reverse-charge treatment indefinitely.
-     *
-     * No answer changes nothing. VIES reports "not registered" and "that member state's
-     * system is down" through the same field, and the endpoint throttles by IP, so an
-     * outage must never be read as a rejection.
-     */
     public function validateVat(): self
     {
         $client_country_code = $this->client->shipping_country ? $this->client->shipping_country->iso_3166_2 : $this->client->country->iso_3166_2;
 
-        $check = (new VatNumberCheck(
-            $this->client->vat_number,
-            $client_country_code,
-            $this->client->company->settings->vat_number ?? null
-        ))->run();
+        $vat_check = (new VatNumberCheck($this->client->vat_number, $client_country_code))->run();
 
-        if ($check->isUnavailable()) {
-            nlog("VIES did not answer for {$this->client->vat_number} ({$check->getError()}) - the existing flag is left unchanged");
+        // nlog($vat_check);
 
-            return $this;
-        }
+        // Written either way, so that a re-check can also take the reverse charge away.
+        // When VIES gives no verdict run() throws, and the flag is left as it was.
+        $this->client->has_valid_vat_number = $vat_check->isValid();
 
-        $valid = $check->isValid();
+        if ($vat_check->isValid()) {
 
-        $this->client->has_valid_vat_number = $valid;
-
-        if ($valid) {
-            if (!$this->client->name && strlen($check->getName()) > 2) {
-                $this->client->name = $check->getName();
+            if (!$this->client->name && strlen($vat_check->getName()) > 2) {
+                $this->client->name = $vat_check->getName();
             }
 
-            if (empty($this->client->private_notes) && strlen($check->getAddress()) > 2) {
-                $this->client->private_notes = $check->getAddress();
+            if (empty($this->client->private_notes) && strlen($vat_check->getAddress()) > 2) {
+                $this->client->private_notes = $vat_check->getAddress();
             }
         }
 

--- a/app/Services/Tax/VatNumberCheck.php
+++ b/app/Services/Tax/VatNumberCheck.php
@@ -12,69 +12,204 @@
 
 namespace App\Services\Tax;
 
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Checks a VAT number against the European Commission's VIES service.
+ *
+ * Uses the REST API rather than SOAP, so no PHP extension is required.
+ *
+ * The verdict is three-valued on purpose. `true` and `false` are facts about the
+ * counterparty; `null` means VIES did not answer - the service was unreachable, timed out,
+ * or the member state's own system was down. VIES reports "not registered" and "I could not
+ * ask" through the same field, and only the first may be allowed to change a tax treatment.
+ * The endpoint also throttles by IP and answers a block with an HTML page rather than JSON,
+ * which is likewise a `null` and not a "no".
+ *
+ * The POST form is used rather than GET because only the POST, which names the enquirer,
+ * returns a `requestIdentifier` - the consultation number, which is the evidence in several
+ * member states that the check was made.
+ */
 class VatNumberCheck
 {
+    private const ENDPOINT = 'https://ec.europa.eu/taxation_customs/vies/rest-api/check-vat-number';
+
+    private const TIMEOUT = 20;
+
+    private const ATTEMPTS = 4;
+
+    /** Codes that mean the service could not answer, not that the number is bad. */
+    private const UNAVAILABLE = [
+        'MS_UNAVAILABLE', 'MS_MAX_CONCURRENT_REQ', 'SERVICE_UNAVAILABLE',
+        'TIMEOUT', 'GLOBAL_MAX_CONCURRENT_REQ', 'SERVER_BUSY',
+    ];
+
     private array $response = [];
 
-    public function __construct(protected ?string $vat_number, protected string $country_code) {}
+    public function __construct(protected ?string $vat_number, protected string $country_code, protected ?string $requester_vat = null) {}
 
-    public function run()
+    public function run(): self
     {
-        if (strlen($this->vat_number ?? '') == 0) {
-            $this->response = ['valid' => false, 'error' => 'No VAT number provided'];
+        [$country, $number] = $this->split($this->vat_number, $this->country_code);
+
+        if (! $country || ! $number) {
+            $this->response = ['valid' => null, 'error' => 'No VAT number provided'];
+
             return $this;
-        } else {
-            return $this->checkvat_number();
         }
-    }
 
-    private function checkvat_number(): self
-    {
-        $wsdl = "https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl";
+        $payload = ['countryCode' => $country, 'vatNumber' => $number];
 
-        try {
-            $client = new \SoapClient($wsdl);
-            $params = [
-                'countryCode' => $this->country_code,
-                'vatNumber' => $this->vat_number ?? '',
-            ];
-            $response = $client->checkVat($params);
+        [$rq_country, $rq_number] = $this->split($this->requester_vat, '');
+        if ($rq_country && $rq_number) {
+            $payload['requesterMemberStateCode'] = $rq_country;
+            $payload['requesterNumber'] = $rq_number;
+        }
 
-            if ($response->valid) {
+        $answer = null;
+        $error = '';
 
-                $this->response = [
-                    'valid' => true,
-                    'name' => $response->name,
-                    'address' => $response->address,
-                ];
-            } else {
-                $this->response = ['valid' => false];
+        for ($attempt = 0; $attempt < self::ATTEMPTS; $attempt++) {
+            if ($attempt) {
+                usleep((int) (1_500_000 * $attempt));
             }
-        } catch (\SoapFault $e) {
 
-            $this->response = ['valid' => false, 'error' => $e->getMessage()];
+            try {
+                $r = Http::timeout(self::TIMEOUT)->asJson()->post(self::ENDPOINT, $payload);
+
+                if ($r->failed()) {
+                    $error = 'HTTP '.$r->status();
+
+                    continue;
+                }
+
+                $body = $r->json();
+            } catch (\Throwable $e) {
+                $error = class_basename($e).': '.$e->getMessage();
+
+                continue;
+            }
+
+            $code = $this->errorOf($body);
+
+            if (in_array($code, self::UNAVAILABLE, true)) {
+                $error = $code;
+
+                continue;
+            }
+
+            $answer = $body;
+            $error = $code;
+            break;
         }
+
+        if ($answer === null) {
+            $this->response = ['valid' => null, 'error' => $error ?: 'VIES did not answer'];
+
+            return $this;
+        }
+
+        if (! array_key_exists('valid', $answer) || $answer['valid'] === null || ($answer['actionSucceed'] ?? true) === false) {
+            $this->response = ['valid' => null, 'error' => $error ?: 'VIES returned no verdict'];
+
+            return $this;
+        }
+
+        $this->response = [
+            'valid' => (bool) $answer['valid'],
+            'request_id' => $answer['requestIdentifier'] ?? '',
+            'name' => trim($answer['name'] ?? ''),
+            'address' => trim(preg_replace('/\s+/', ' ', $answer['address'] ?? '')),
+            'error' => ((bool) $answer['valid'] || $error === 'INVALID') ? '' : $error,
+        ];
 
         return $this;
     }
 
-    public function getResponse()
+    /** 'ESB12345678' becomes ['ES', 'B12345678']. Greece files as EL, not GR. */
+    private function split(?string $vat, string $fallback_country): array
+    {
+        $vat = strtoupper(str_replace([' ', '-'], '', trim($vat ?? '')));
+
+        if ($vat === '') {
+            return [null, null];
+        }
+
+        if (strlen($vat) > 2 && ctype_alpha(substr($vat, 0, 2))) {
+            $code = substr($vat, 0, 2);
+
+            return [$code === 'GR' ? 'EL' : $code, substr($vat, 2)];
+        }
+
+        $code = strtoupper(trim($fallback_country));
+
+        return [$code === 'GR' ? 'EL' : ($code ?: null), $vat];
+    }
+
+    /** The error code, wherever this particular answer put it. */
+    private function errorOf(mixed $body): string
+    {
+        if (! is_array($body)) {
+            return '';
+        }
+
+        $err = strtoupper(trim((string) ($body['userError'] ?? '')));
+
+        if ($err !== '') {
+            return $err;
+        }
+
+        foreach (($body['errorWrappers'] ?? []) as $wrapper) {
+            $code = strtoupper(trim((string) ($wrapper['error'] ?? '')));
+
+            if ($code !== '') {
+                return $code;
+            }
+        }
+
+        return '';
+    }
+
+    public function getResponse(): array
     {
         return $this->response;
     }
 
+    /** True only when VIES said so. A service outage is not a "no". */
     public function isValid(): bool
     {
-        return $this->response['valid'];
+        return ($this->response['valid'] ?? null) === true;
     }
 
-    public function getName()
+    /** True only when VIES said the number is not a current registration. */
+    public function isInvalid(): bool
+    {
+        return ($this->response['valid'] ?? null) === false;
+    }
+
+    /** True when VIES did not answer at all - the case that must change nothing. */
+    public function isUnavailable(): bool
+    {
+        return ($this->response['valid'] ?? null) === null;
+    }
+
+    public function getRequestIdentifier(): string
+    {
+        return $this->response['request_id'] ?? '';
+    }
+
+    public function getName(): string
     {
         return $this->response['name'] ?? '';
     }
 
-    public function getAddress()
+    public function getAddress(): string
     {
         return $this->response['address'] ?? '';
+    }
+
+    public function getError(): string
+    {
+        return $this->response['error'] ?? '';
     }
 }

--- a/app/Services/Tax/VatNumberCheck.php
+++ b/app/Services/Tax/VatNumberCheck.php
@@ -14,202 +14,75 @@ namespace App\Services\Tax;
 
 use Illuminate\Support\Facades\Http;
 
-/**
- * Checks a VAT number against the European Commission's VIES service.
- *
- * Uses the REST API rather than SOAP, so no PHP extension is required.
- *
- * The verdict is three-valued on purpose. `true` and `false` are facts about the
- * counterparty; `null` means VIES did not answer - the service was unreachable, timed out,
- * or the member state's own system was down. VIES reports "not registered" and "I could not
- * ask" through the same field, and only the first may be allowed to change a tax treatment.
- * The endpoint also throttles by IP and answers a block with an HTML page rather than JSON,
- * which is likewise a `null` and not a "no".
- *
- * The POST form is used rather than GET because only the POST, which names the enquirer,
- * returns a `requestIdentifier` - the consultation number, which is the evidence in several
- * member states that the check was made.
- */
 class VatNumberCheck
 {
-    private const ENDPOINT = 'https://ec.europa.eu/taxation_customs/vies/rest-api/check-vat-number';
-
-    private const TIMEOUT = 20;
-
-    private const ATTEMPTS = 4;
-
-    /** Codes that mean the service could not answer, not that the number is bad. */
-    private const UNAVAILABLE = [
-        'MS_UNAVAILABLE', 'MS_MAX_CONCURRENT_REQ', 'SERVICE_UNAVAILABLE',
-        'TIMEOUT', 'GLOBAL_MAX_CONCURRENT_REQ', 'SERVER_BUSY',
-    ];
-
     private array $response = [];
 
-    public function __construct(protected ?string $vat_number, protected string $country_code, protected ?string $requester_vat = null) {}
+    public function __construct(protected ?string $vat_number, protected string $country_code) {}
 
-    public function run(): self
+    /**
+     * @throws \RuntimeException when VIES gives no verdict, which the CheckVat job retries
+     */
+    public function run()
     {
-        [$country, $number] = $this->split($this->vat_number, $this->country_code);
-
-        if (! $country || ! $number) {
-            $this->response = ['valid' => null, 'error' => 'No VAT number provided'];
-
+        if (strlen($this->vat_number ?? '') == 0) {
+            $this->response = ['valid' => false, 'error' => 'No VAT number provided'];
             return $this;
+        } else {
+            return $this->checkvat_number();
+        }
+    }
+
+    private function checkvat_number(): self
+    {
+        // VIES files Greece as EL, and takes the number without its country prefix
+        $country_code = $this->country_code == 'GR' ? 'EL' : $this->country_code;
+        $vat_number = strtoupper(preg_replace('/[^a-zA-Z0-9]/', '', $this->vat_number));
+        $vat_number = preg_replace("/^({$this->country_code}|{$country_code})/", '', $vat_number);
+
+        $response = Http::timeout(20)->post('https://ec.europa.eu/taxation_customs/vies/rest-api/check-vat-number', [
+            'countryCode' => $country_code,
+            'vatNumber' => $vat_number,
+        ]);
+
+        // A number that is not registered comes back as "valid": false. When VIES cannot answer
+        // (a member state is down, the service is busy, or it is rate limiting the caller) there
+        // is no "valid" at all, and that must not be read as a "no".
+        if (!is_bool($response->json('valid'))) {
+            throw new \RuntimeException('VIES returned no verdict: '.($response->json('errorWrappers.0.error') ?? 'HTTP '.$response->status()));
         }
 
-        $payload = ['countryCode' => $country, 'vatNumber' => $number];
+        if ($response->json('valid')) {
 
-        [$rq_country, $rq_number] = $this->split($this->requester_vat, '');
-        if ($rq_country && $rq_number) {
-            $payload['requesterMemberStateCode'] = $rq_country;
-            $payload['requesterNumber'] = $rq_number;
+            $this->response = [
+                'valid' => true,
+                'name' => $response->json('name'),
+                'address' => $response->json('address'),
+            ];
+        } else {
+            $this->response = ['valid' => false];
         }
-
-        $answer = null;
-        $error = '';
-
-        for ($attempt = 0; $attempt < self::ATTEMPTS; $attempt++) {
-            if ($attempt) {
-                usleep((int) (1_500_000 * $attempt));
-            }
-
-            try {
-                $r = Http::timeout(self::TIMEOUT)->asJson()->post(self::ENDPOINT, $payload);
-
-                if ($r->failed()) {
-                    $error = 'HTTP '.$r->status();
-
-                    continue;
-                }
-
-                $body = $r->json();
-            } catch (\Throwable $e) {
-                $error = class_basename($e).': '.$e->getMessage();
-
-                continue;
-            }
-
-            $code = $this->errorOf($body);
-
-            if (in_array($code, self::UNAVAILABLE, true)) {
-                $error = $code;
-
-                continue;
-            }
-
-            $answer = $body;
-            $error = $code;
-            break;
-        }
-
-        if ($answer === null) {
-            $this->response = ['valid' => null, 'error' => $error ?: 'VIES did not answer'];
-
-            return $this;
-        }
-
-        if (! array_key_exists('valid', $answer) || $answer['valid'] === null || ($answer['actionSucceed'] ?? true) === false) {
-            $this->response = ['valid' => null, 'error' => $error ?: 'VIES returned no verdict'];
-
-            return $this;
-        }
-
-        $this->response = [
-            'valid' => (bool) $answer['valid'],
-            'request_id' => $answer['requestIdentifier'] ?? '',
-            'name' => trim($answer['name'] ?? ''),
-            'address' => trim(preg_replace('/\s+/', ' ', $answer['address'] ?? '')),
-            'error' => ((bool) $answer['valid'] || $error === 'INVALID') ? '' : $error,
-        ];
 
         return $this;
     }
 
-    /** 'ESB12345678' becomes ['ES', 'B12345678']. Greece files as EL, not GR. */
-    private function split(?string $vat, string $fallback_country): array
-    {
-        $vat = strtoupper(str_replace([' ', '-'], '', trim($vat ?? '')));
-
-        if ($vat === '') {
-            return [null, null];
-        }
-
-        if (strlen($vat) > 2 && ctype_alpha(substr($vat, 0, 2))) {
-            $code = substr($vat, 0, 2);
-
-            return [$code === 'GR' ? 'EL' : $code, substr($vat, 2)];
-        }
-
-        $code = strtoupper(trim($fallback_country));
-
-        return [$code === 'GR' ? 'EL' : ($code ?: null), $vat];
-    }
-
-    /** The error code, wherever this particular answer put it. */
-    private function errorOf(mixed $body): string
-    {
-        if (! is_array($body)) {
-            return '';
-        }
-
-        $err = strtoupper(trim((string) ($body['userError'] ?? '')));
-
-        if ($err !== '') {
-            return $err;
-        }
-
-        foreach (($body['errorWrappers'] ?? []) as $wrapper) {
-            $code = strtoupper(trim((string) ($wrapper['error'] ?? '')));
-
-            if ($code !== '') {
-                return $code;
-            }
-        }
-
-        return '';
-    }
-
-    public function getResponse(): array
+    public function getResponse()
     {
         return $this->response;
     }
 
-    /** True only when VIES said so. A service outage is not a "no". */
     public function isValid(): bool
     {
-        return ($this->response['valid'] ?? null) === true;
+        return $this->response['valid'];
     }
 
-    /** True only when VIES said the number is not a current registration. */
-    public function isInvalid(): bool
-    {
-        return ($this->response['valid'] ?? null) === false;
-    }
-
-    /** True when VIES did not answer at all - the case that must change nothing. */
-    public function isUnavailable(): bool
-    {
-        return ($this->response['valid'] ?? null) === null;
-    }
-
-    public function getRequestIdentifier(): string
-    {
-        return $this->response['request_id'] ?? '';
-    }
-
-    public function getName(): string
+    public function getName()
     {
         return $this->response['name'] ?? '';
     }
 
-    public function getAddress(): string
+    public function getAddress()
     {
         return $this->response['address'] ?? '';
-    }
-
-    public function getError(): string
-    {
-        return $this->response['error'] ?? '';
     }
 }

--- a/app/Services/Tax/VatNumberCheck.php
+++ b/app/Services/Tax/VatNumberCheck.php
@@ -35,10 +35,17 @@ class VatNumberCheck
 
     private function checkvat_number(): self
     {
-        // VIES files Greece as EL, and takes the number without its country prefix
-        $country_code = $this->country_code == 'GR' ? 'EL' : $this->country_code;
+        // Prefer the VAT registration prefix, falling back to the supplied country.
+        $country_code = strtoupper($this->country_code);
         $vat_number = strtoupper(preg_replace('/[^a-zA-Z0-9]/', '', $this->vat_number));
-        $vat_number = preg_replace("/^({$this->country_code}|{$country_code})/", '', $vat_number);
+
+        if (preg_match('/^(AT|BE|BG|CY|CZ|DE|DK|EE|EL|ES|FI|FR|GR|HR|HU|IE|IT|LT|LU|LV|MT|NL|PL|PT|RO|SE|SI|SK|XI)/', $vat_number, $matches)) {
+            $country_code = $matches[1];
+            $vat_number = substr($vat_number, 2);
+        }
+
+        // VIES files Greece as EL.
+        $country_code = $country_code == 'GR' ? 'EL' : $country_code;
 
         $response = Http::timeout(20)->post('https://ec.europa.eu/taxation_customs/vies/rest-api/check-vat-number', [
             'countryCode' => $country_code,

--- a/tests/Unit/Tax/VatNumberTest.php
+++ b/tests/Unit/Tax/VatNumberTest.php
@@ -14,6 +14,7 @@ namespace Tests\Unit\Tax;
 
 use App\Services\Tax\VatNumberCheck;
 use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 /**
@@ -55,6 +56,31 @@ class VatNumberTest extends TestCase
         (new VatNumberCheck("GR123456789", "GR"))->run();
 
         Http::assertSent(fn ($request) => $request['countryCode'] == 'EL' && $request['vatNumber'] == '123456789');
+    }
+
+    #[DataProvider('vatCountryProvider')]
+    public function testVatCountrySelection(string $vat_number, string $fallback_country, string $expected_country, string $expected_number)
+    {
+        Http::fake(['ec.europa.eu/*' => Http::response(['valid' => false])]);
+
+        (new VatNumberCheck($vat_number, $fallback_country))->run();
+
+        Http::assertSent(fn ($request) => $request['countryCode'] == $expected_country && $request['vatNumber'] == $expected_number);
+    }
+
+    public static function vatCountryProvider(): array
+    {
+        return [
+            'prefix overrides country' => ['de 123 456 789', 'FR', 'DE', '123456789'],
+            'unprefixed number uses fallback' => ['123456789', 'FR', 'FR', '123456789'],
+            'Greek GR prefix' => ['GR123456789', 'DE', 'EL', '123456789'],
+            'Greek EL prefix' => ['EL123456789', 'DE', 'EL', '123456789'],
+            'Greek fallback' => ['123456789', 'GR', 'EL', '123456789'],
+            'Austrian prefix preserves letter' => ['ATU12345678', 'FR', 'AT', 'U12345678'],
+            'unprefixed Austrian number' => ['U12345678', 'AT', 'AT', 'U12345678'],
+            'unprefixed French letters' => ['AB123456789', 'FR', 'FR', 'AB123456789'],
+            'Northern Ireland prefix' => ['XI123456789', 'GB', 'XI', '123456789'],
+        ];
     }
 
     public function testUnavailableMemberStateIsNotAnInvalidNumber()

--- a/tests/Unit/Tax/VatNumberTest.php
+++ b/tests/Unit/Tax/VatNumberTest.php
@@ -13,6 +13,7 @@
 namespace Tests\Unit\Tax;
 
 use App\Services\Tax\VatNumberCheck;
+use Illuminate\Support\Facades\Http;
 use Tests\TestCase;
 
 /**
@@ -27,12 +28,9 @@ class VatNumberTest extends TestCase
 
     public function testVatNumber()
     {
-        // Usage example
-        $country_code = "IE"; // Ireland
-        $vat_number = "1234567L"; // Example VAT number
-        $result = '';
+        Http::fake(['ec.europa.eu/*' => Http::response(['countryCode' => 'IE', 'vatNumber' => '1234567L', 'valid' => false, 'name' => '---', 'address' => '---'])]);
 
-        $vat_checker = new VatNumberCheck($vat_number, $country_code);
+        $vat_checker = new VatNumberCheck("1234567L", "IE");
         $result = $vat_checker->run();
 
         $this->assertFalse($result->isValid());
@@ -40,14 +38,49 @@ class VatNumberTest extends TestCase
 
     public function testValidVatNumber()
     {
-        // Usage example
-        $country_code = "AT"; // Ireland
-        $vat_number = "U12345678"; // Example VAT number
-        $result = '';
+        Http::fake(['ec.europa.eu/*' => Http::response(['countryCode' => 'AT', 'vatNumber' => 'U12345678', 'valid' => true, 'name' => 'Example GmbH', 'address' => 'Example Street 1, 1010 Wien'])]);
 
-        $vat_checker = new VatNumberCheck($vat_number, $country_code);
-        $result = $vat_checker->run();
+        $result = (new VatNumberCheck("ATU 123 456 78", "AT"))->run();
 
-        $this->assertFalse($result->isValid());
+        $this->assertTrue($result->isValid());
+        $this->assertEquals('Example GmbH', $result->getName());
+
+        Http::assertSent(fn ($request) => $request['countryCode'] == 'AT' && $request['vatNumber'] == 'U12345678');
+    }
+
+    public function testGreeceIsCheckedAsEl()
+    {
+        Http::fake(['ec.europa.eu/*' => Http::response(['countryCode' => 'EL', 'vatNumber' => '123456789', 'valid' => false])]);
+
+        (new VatNumberCheck("GR123456789", "GR"))->run();
+
+        Http::assertSent(fn ($request) => $request['countryCode'] == 'EL' && $request['vatNumber'] == '123456789');
+    }
+
+    public function testUnavailableMemberStateIsNotAnInvalidNumber()
+    {
+        Http::fake(['ec.europa.eu/*' => Http::response(['actionSucceed' => false, 'errorWrappers' => [['error' => 'MS_UNAVAILABLE']]])]);
+
+        $this->expectException(\RuntimeException::class);
+
+        (new VatNumberCheck("1234567L", "IE"))->run();
+    }
+
+    public function testRateLimitPageIsNotAnInvalidNumber()
+    {
+        Http::fake(['ec.europa.eu/*' => Http::response('<html><body>Access denied</body></html>', 403)]);
+
+        $this->expectException(\RuntimeException::class);
+
+        (new VatNumberCheck("1234567L", "IE"))->run();
+    }
+
+    public function testEmptyVatNumberIsNotSent()
+    {
+        Http::fake();
+
+        $this->assertFalse((new VatNumberCheck(null, "IE"))->run()->isValid());
+
+        Http::assertNothingSent();
     }
 }


### PR DESCRIPTION
### The check has never run on a stock Docker deployment

`VatNumberCheck` uses `SoapClient`, and the official `invoiceninja/invoiceninja` image has no `ext-soap`:

```
$ docker run --rm invoiceninja/invoiceninja:5.13.37 -- php -m | grep -ix soap
(nothing)
```

`TaxService::validateVat()` opens with a guard that logs and returns when the extension is missing, so the `CheckVat` job dispatched by `ClientObserver` completes **successfully having done nothing** - no exception, nothing in `failed_jobs`, and `has_valid_vat_number` stays `false` on every client for ever.

That is not cosmetic. With `calculate_taxes` on, an EU business whose number is never validated falls into the B2C branch of the tax rules and is charged origin VAT instead of being zero-rated under the reverse charge - so the customer is invoiced tax that is not due.

### What this changes

**`VatNumberCheck` uses the Commission's REST API through Laravel's HTTP client**, so no PHP extension is needed. One request per call, carrying the client's country and number. The number is sent without its country prefix (VIES answers a prefixed number with `valid: false`), and Greece as `EL`.

**"Not registered" and "no answer" are kept apart.** A number VIES does not know comes back as `valid: false`. When VIES cannot answer - a member state's system is down, the service is busy, or it is rate limiting the caller, which it does with an HTML page - there is no `valid` at all. `run()` throws in that case, and `CheckVat` retries with `$tries = 4` and `$backoff = [60, 600, 3600]`. If every attempt fails the job ends in `failed_jobs` rather than silently doing nothing, and the flag is left as it was.

**`TaxService` writes a "no".** There was no `else` branch, so a number VIES rejected left the flag as it was, and a client whose registration was later cancelled kept the reverse charge. A client whose VAT number is removed now loses the flag too.

### Compatibility

`run()`, `isValid()`, `getName()`, `getAddress()` and `getResponse()` keep their signatures. The one change for callers is that `run()` throws when VIES gives no verdict or cannot be reached, where the SOAP version returned `valid => false`. `TaxService::validateVat()`, through `CheckVat`, is the only caller in the codebase.

`VatNumberTest` fakes the VIES responses instead of calling the live service from CI.

The response shapes the code relies on were checked against VIES's live and test endpoints (registered, not registered, `MS_UNAVAILABLE`, `INVALID_INPUT`, `INVALID_REQUESTER_INFO`), and the class was exercised against `Http::fake()` for each.
