### PR TITLE
Fix plain-text alternative of entity emails to reflect the actual body

### DIFF
--- a/app/Mail/Engine/BaseEmailEngine.php
+++ b/app/Mail/Engine/BaseEmailEngine.php
@@ -122,6 +122,20 @@ class BaseEmailEngine implements EngineInterface
         return $this;
     }
 
+    /**
+     * Converts an HTML email body into a plain-text equivalent by turning
+     * block-level tags into line breaks before stripping the remaining markup,
+     * so paragraphs typed via a rich-text editor (which uses <p>/<div>, not
+     * always <br>) don't run together with no separation.
+     */
+    protected function htmlToPlainText(string $html): string
+    {
+        $text = preg_replace('/<\/(p|div|li|h[1-6]|tr)>/i', "\r\n", $html);
+        $text = str_ireplace(['<br />', '<br>', '<br/>'], "\r\n", $text);
+
+        return strip_tags($text);
+    }
+
     public function setTextBody($text)
     {
 

--- a/app/Mail/Engine/CreditEmailEngine.php
+++ b/app/Mail/Engine/CreditEmailEngine.php
@@ -95,15 +95,7 @@ class CreditEmailEngine extends BaseEmailEngine
             );
         }
 
-        $text_body = trans(
-            'texts.credit_message',
-            [
-                'credit' => $this->credit->number,
-                'company' => $this->credit->company->present()->name(),
-                'amount' => Number::formatMoney($this->credit->balance, $this->client),
-            ],
-            $this->client->locale()
-        ) . "\n\n" . $this->invitation->getLink();
+        $text_body = $this->htmlToPlainText($body_template);
 
         $this->setTemplate($this->client->getSetting('email_style'))
             ->setContact($this->contact)

--- a/app/Mail/Engine/InvoiceEmailEngine.php
+++ b/app/Mail/Engine/InvoiceEmailEngine.php
@@ -85,15 +85,7 @@ class InvoiceEmailEngine extends BaseEmailEngine
             $body_template .= '<div class="center">$view_button</div>';
         }
 
-        $text_body = trans(
-            'texts.invoice_message',
-            [
-                'invoice' => $this->invoice->number,
-                'company' => $this->invoice->company->present()->name(),
-                'amount' => Number::formatMoney($this->invoice->balance, $this->client),
-            ],
-            $this->client->locale()
-        ) . "\n\n" . $this->invitation->getLink();
+        $text_body = $this->htmlToPlainText($body_template);
 
         if (is_array($this->template_data) && array_key_exists('subject', $this->template_data) && strlen($this->template_data['subject']) > 0) {
             $subject_template = $this->template_data['subject'];

--- a/app/Mail/Engine/PaymentEmailEngine.php
+++ b/app/Mail/Engine/PaymentEmailEngine.php
@@ -90,12 +90,14 @@ class PaymentEmailEngine extends BaseEmailEngine
             $subject_template = EmailTemplateDefaults::getDefaultTemplate($this->payment_template_subject, $this->client->locale());
         }
 
+        $text_body = $this->htmlToPlainText($body_template);
+
         $this->setTemplate($this->client->getSetting('email_style'))
             ->setContact($this->contact)
             ->setVariables($this->makeValues())
             ->setSubject($subject_template)
             ->setBody($body_template)
-            ->setTextBody($body_template)
+            ->setTextBody($text_body)
             ->setFooter('')
             ->setViewLink('')
             ->setViewText('');

--- a/app/Mail/Engine/PurchaseOrderEmailEngine.php
+++ b/app/Mail/Engine/PurchaseOrderEmailEngine.php
@@ -80,15 +80,7 @@ class PurchaseOrderEmailEngine extends BaseEmailEngine
 
             $body_template .= '<div class="center">$view_button</div>';
         }
-        $text_body = trans(
-            'texts.purchase_order_message',
-            [
-                'purchase_order' => $this->purchase_order->number,
-                'company' => $this->purchase_order->company->present()->name(),
-                'amount' => Number::formatMoney($this->purchase_order->balance, $this->vendor),
-            ],
-            $this->vendor->company->locale()
-        ) . "\n\n" . $this->invitation->getLink();
+        $text_body = $this->htmlToPlainText($body_template);
 
         if (is_array($this->template_data) && array_key_exists('subject', $this->template_data) && strlen($this->template_data['subject']) > 0) {
             $subject_template = $this->template_data['subject'];

--- a/app/Mail/Engine/QuoteEmailEngine.php
+++ b/app/Mail/Engine/QuoteEmailEngine.php
@@ -103,15 +103,7 @@ class QuoteEmailEngine extends BaseEmailEngine
             );
         }
 
-        $text_body = trans(
-            'texts.quote_message',
-            [
-                'quote' => $this->quote->number,
-                'company' => $this->quote->company->present()->name(),
-                'amount' => Number::formatMoney($this->quote->amount, $this->client),
-            ],
-            $this->client->locale()
-        ) . "\n\n" . $this->invitation->getLink();
+        $text_body = $this->htmlToPlainText($body_template);
 
         $this->setTemplate($this->client->getSetting('email_style'))
             ->setContact($this->contact)

--- a/tests/Feature/EntityEmailTextBodyTest.php
+++ b/tests/Feature/EntityEmailTextBodyTest.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * Invoice Ninja (https://invoiceninja.com).
+ *
+ * @link https://github.com/invoiceninja/invoiceninja source repository
+ *
+ * @copyright Copyright (c) 2026. Invoice Ninja LLC (https://invoiceninja.com)
+ *
+ * @license https://www.elastic.co/licensing/elastic-license
+ */
+
+namespace Tests\Feature;
+
+use App\Mail\Engine\CreditEmailEngine;
+use App\Mail\Engine\InvoiceEmailEngine;
+use App\Mail\Engine\PaymentEmailEngine;
+use App\Mail\Engine\PurchaseOrderEmailEngine;
+use App\Mail\Engine\QuoteEmailEngine;
+use App\Models\CreditInvitation;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Session;
+use Tests\MockAccountData;
+use Tests\TestCase;
+
+/**
+ * Asserts that the text/plain MIME alternative of entity emails reflects
+ * the actual (custom) email body, instead of either a hardcoded generic
+ * message (Invoice/Quote/Credit/PurchaseOrder) or the raw un-stripped HTML
+ * body (Payment).
+ *
+ * @see \App\Mail\Engine\BaseEmailEngine::setTextBody()
+ */
+class EntityEmailTextBodyTest extends TestCase
+{
+    use MockAccountData;
+    use DatabaseTransactions;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Session::start();
+        Model::reguard();
+
+        $this->makeTestData();
+    }
+
+    private function customBody(string $marker): string
+    {
+        return "<p>Hello,</p><p>{$marker} with a <strong>bold</strong> word.</p><p>\$view_button</p>";
+    }
+
+    /**
+     * A rich-text email template editor saves paragraphs as <p>, not <br> -
+     * assert the <p> boundaries survive as actual line breaks in the
+     * plain-text part, not just that the words are present somewhere.
+     */
+    private function assertParagraphsAreSeparated(string $marker, string $text_body): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/Hello,\s*[\r\n]+\s*' . preg_quote($marker, '/') . '/',
+            $text_body,
+            "Expected 'Hello,' and '{$marker}' to be on separate lines, not run together."
+        );
+    }
+
+    public function testInvoiceEmailEngineTextBodyMatchesCustomBody(): void
+    {
+        $invitation = $this->invoice->invitations->first();
+
+        $engine = new InvoiceEmailEngine($invitation, 'invoice', [
+            'body' => $this->customBody('This is the custom invoice message'),
+            'subject' => 'Invoice subject',
+        ]);
+        $engine->build();
+
+        $text_body = $engine->getTextBody();
+
+        $this->assertStringContainsString('This is the custom invoice message', $text_body);
+        $this->assertStringNotContainsString('<strong>', $text_body);
+        $this->assertStringNotContainsString('<p>', $text_body);
+        $this->assertStringContainsString($invitation->getLink(), $text_body);
+        $this->assertParagraphsAreSeparated('This is the custom invoice message', $text_body);
+    }
+
+    public function testQuoteEmailEngineTextBodyMatchesCustomBody(): void
+    {
+        $invitation = $this->quote->invitations->first();
+
+        $engine = new QuoteEmailEngine($invitation, 'quote', [
+            'body' => $this->customBody('This is the custom quote message'),
+            'subject' => 'Quote subject',
+        ]);
+        $engine->build();
+
+        $text_body = $engine->getTextBody();
+
+        $this->assertStringContainsString('This is the custom quote message', $text_body);
+        $this->assertStringNotContainsString('<strong>', $text_body);
+        $this->assertStringNotContainsString('<p>', $text_body);
+        $this->assertStringContainsString($invitation->getLink(), $text_body);
+        $this->assertParagraphsAreSeparated('This is the custom quote message', $text_body);
+    }
+
+    public function testCreditEmailEngineTextBodyMatchesCustomBody(): void
+    {
+        // MockAccountData doesn't always seed a CreditInvitation explicitly,
+        // but saving the credit can create one via a model observer.
+        $invitation = $this->credit->invitations()->first() ?? CreditInvitation::factory()->create([
+            'user_id' => $this->credit->user_id,
+            'company_id' => $this->company->id,
+            'client_contact_id' => $this->contact->id,
+            'credit_id' => $this->credit->id,
+        ]);
+
+        $engine = new CreditEmailEngine($invitation, 'credit', [
+            'body' => $this->customBody('This is the custom credit message'),
+            'subject' => 'Credit subject',
+        ]);
+        $engine->build();
+
+        $text_body = $engine->getTextBody();
+
+        $this->assertStringContainsString('This is the custom credit message', $text_body);
+        $this->assertStringNotContainsString('<strong>', $text_body);
+        $this->assertStringNotContainsString('<p>', $text_body);
+        $this->assertStringContainsString($invitation->getLink(), $text_body);
+        $this->assertParagraphsAreSeparated('This is the custom credit message', $text_body);
+    }
+
+    public function testPurchaseOrderEmailEngineTextBodyMatchesCustomBody(): void
+    {
+        $invitation = $this->purchase_order->invitations->first();
+
+        $engine = new PurchaseOrderEmailEngine($invitation, 'purchase_order', [
+            'body' => $this->customBody('This is the custom purchase order message'),
+            'subject' => 'Purchase order subject',
+        ]);
+        $engine->build();
+
+        $text_body = $engine->getTextBody();
+
+        $this->assertStringContainsString('This is the custom purchase order message', $text_body);
+        $this->assertStringNotContainsString('<strong>', $text_body);
+        $this->assertStringNotContainsString('<p>', $text_body);
+        $this->assertStringContainsString($invitation->getLink(), $text_body);
+        $this->assertParagraphsAreSeparated('This is the custom purchase order message', $text_body);
+    }
+
+    public function testPaymentEmailEngineTextBodyStripsHtml(): void
+    {
+        $engine = new PaymentEmailEngine($this->payment, $this->contact, [
+            'body' => $this->customBody('This is the custom payment receipt message'),
+            'subject' => 'Payment subject',
+        ]);
+        $engine->build();
+
+        $text_body = $engine->getTextBody();
+
+        $this->assertStringContainsString('This is the custom payment receipt message', $text_body);
+        $this->assertStringNotContainsString('<strong>', $text_body);
+        $this->assertStringNotContainsString('<p>', $text_body);
+        $this->assertParagraphsAreSeparated('This is the custom payment receipt message', $text_body);
+    }
+}


### PR DESCRIPTION
Invoice/Quote/Credit/PurchaseOrder email engines built the text/plain MIME part from a hardcoded, generic trans('texts.xxx_message', ...) string, completely ignoring whatever custom body the user configured via the email template settings. PaymentEmailEngine instead passed the raw HTML body straight into setTextBody(), leaving markup un-stripped in the plain-text part.

Added BaseEmailEngine::htmlToPlainText(), shared by all five engines, which converts closing block tags (</p>, </div>, </li>, </h1>-</h6>, </tr>) and <br> variants to \r\n before strip_tags(). A rich-text email template editor saves paragraphs as <p>, not <br> - converting only <br> (matching what EmailDefaults::setBody() already does elsewhere in the codebase) stripped <p> tags with no separator at all, running every paragraph together with no space or line break.